### PR TITLE
adding vulscan

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,9 +135,9 @@ jobs:
           prerelease: false
           body: |
             Release Notes:
-              - Added validation to ensure that selected LPORT(s) for metasploit are not in use.
-              - Fixed LHOST auto-selection, will fall back to loop-back if it fails.
-              - Updated the docs
+              - Added option to bring your own nmap command in autonomous mode.
+              - Changed the LPORT range for metasploit to 1024-65535.
+              - Added vulscan to the default scripts that are ran for nmap vulnerability scans.
 
       - name: Upload Release Assets
         if: github.event.pull_request.merged == true

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ sudo apt install -y wget
 - [Crackmapexec](https://github.com/byt3bl33d3r/CrackMapExec/wiki/Installation)
 - [Nuclei](https://docs.nuclei.sh/getting-started/install)
 - [Metasploit](https://docs.rapid7.com/metasploit/installing-the-metasploit-framework)
+- [Vulnscan-Nmap-Scripts](https://github.com/scipag/vulscan)
 
 
 ## Installation
@@ -277,7 +278,7 @@ nebula -h
 
 ```bash
 usage: nebula.py [-h] [--results_dir RESULTS_DIR] [--model_dir MODEL_DIR] [--testing_mode TESTING_MODE] [--targets_list TARGETS_LIST]
-                 [--autonomous_mode AUTONOMOUS_MODE] [--attack_mode ATTACK_MODE]
+                 [--autonomous_mode AUTONOMOUS_MODE] [--attack_mode ATTACK_MODE] [--nmap_vuln_scan_command NMAP_VULN_SCAN_COMMAND]
 
 Interactive Command Generator
 
@@ -295,6 +296,8 @@ options:
                         Flag to indicate autonomous mode
   --attack_mode ATTACK_MODE
                         Attack approach
+  --nmap_vuln_scan_command NMAP_VULN_SCAN_COMMAND
+                        Nmap vulnerability scan command to run
 ```
 
 ### Modes.
@@ -310,6 +313,14 @@ To activate the autonomous mode, run:
 ```bash
 nebula --autonomous_mode True
 ```
+
+By default it will run the `vuln`, `exploit`, `vulnscan`, service detection `-sV`,  and treat the host as online `-Pn`. You can override this by passing in your own nmap command and scripts:
+
+```bash
+nebula --autonomous_mode True --nmap_vuln_scan_command 'nmap -Pn -sV --script=your_script'
+```
+
+There is no need to add output flags such as `-oX` and `-oN` as those will be automatically added.
 
 Nebula will run an initial vulnerability scan, parse the results, attempt to discover more vulnerabilities. Your targets should be placed in a plain text file
 titled `targets.txt`. This is also customizable by using the `--targets_list` arg:

--- a/src/nebula/nebula.py
+++ b/src/nebula/nebula.py
@@ -173,6 +173,13 @@ class InteractiveGenerator:
             default="stealth",
             help="Attack approach",
         )
+        parser.add_argument(
+            "--nmap_vuln_scan_command",
+            type=str,
+            default="nmap -Pn -sV --script=vuln,exploit,vulscan/vulscan.nse",
+            help="Nmap vulnerability scan command to run",
+        )
+
         return parser.parse_args()
 
     def split(self, data):
@@ -284,8 +291,9 @@ class InteractiveGenerator:
                         f"nmap -Pn --script=vuln {ip} -oX {output_xml} -oN {output_txt}"
                     )
                 else:
+                    print(self.args.nmap_vuln_scan_command)
                     result = self.run_command_and_alert(
-                        f"nmap -Pn --script=vuln,exploit {ip} -oX {output_xml} -oN {output_txt}"
+                        f"{self.args.nmap_vuln_scan_command}  {ip} -oX {output_xml} -oN {output_txt}"
                     )
                 results.append(result)
 
@@ -676,7 +684,7 @@ class InteractiveGenerator:
             except Exception:
                 return "127.0.0.1"  # default to loopback, if unable to determine IP
 
-        def get_random_port(above: int = 1000, max_retries: int = 100) -> int:
+        def get_random_port(above: int = 1024, max_retries: int = 100) -> int:
             """Get random port above the specified number that's not in use."""
             for _ in range(max_retries):
                 port = random.randint(above, 65535)


### PR DESCRIPTION
This PR:

  - Added the option to bring your own nmap command in autonomous mode.
  - Changed the LPORT range for metasploit to 1024-65535.
  - Added vulscan to the default scripts that are ran for nmap vulnerability scans.