### PR TITLE
Add desktop release credential smoke test

### DIFF
--- a/.github/workflows/desktop-release-credential-smoke.yml
+++ b/.github/workflows/desktop-release-credential-smoke.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Check out release tooling
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: nebula-3-modernization
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/desktop-release-credential-smoke.yml
+++ b/.github/workflows/desktop-release-credential-smoke.yml
@@ -1,0 +1,161 @@
+name: Desktop release credential smoke test
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: desktop-release-credential-smoke
+  cancel-in-progress: false
+
+jobs:
+  credentials:
+    name: Verify signing and notarization credentials
+    runs-on: macos-15
+    environment: desktop-release
+    timeout-minutes: 30
+    env:
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      NEBULA_UPDATER_PUBLIC_KEY: ${{ secrets.NEBULA_UPDATER_PUBLIC_KEY }}
+    steps:
+      - name: Check out release tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
+        with:
+          toolchain: stable
+
+      - name: Reject missing and placeholder credentials
+        shell: bash
+        run: |
+          for name in \
+            APPLE_CERTIFICATE \
+            APPLE_CERTIFICATE_PASSWORD \
+            APPLE_KEYCHAIN_PASSWORD \
+            APPLE_SIGNING_IDENTITY \
+            APPLE_ID \
+            APPLE_PASSWORD \
+            APPLE_TEAM_ID \
+            TAURI_SIGNING_PRIVATE_KEY \
+            TAURI_SIGNING_PRIVATE_KEY_PASSWORD \
+            NEBULA_UPDATER_PUBLIC_KEY; do
+            value="${!name:-}"
+            test -n "$value" || { printf '%s is missing\n' "$name" >&2; exit 1; }
+            case "$value" in
+              PLACEHOLDER_REPLACE_BEFORE_RELEASE_*)
+                printf '%s still contains a release placeholder\n' "$name" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+      - name: Install locked Tauri tooling
+        run: npm --prefix ui ci
+
+      - name: Import Developer ID certificate
+        shell: bash
+        env:
+          CERTIFICATE_PATH: ${{ runner.temp }}/nebula-developer-id.p12
+          KEYCHAIN_PATH: ${{ runner.temp }}/nebula-release-smoke.keychain-db
+        run: |
+          python3 -c 'import base64, os, pathlib; pathlib.Path(os.environ["CERTIFICATE_PATH"]).write_bytes(base64.b64decode(os.environ["APPLE_CERTIFICATE"], validate=True))'
+          chmod 600 "$CERTIFICATE_PATH"
+          security create-keychain -p "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$APPLE_KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep -F -- "\"$APPLE_SIGNING_IDENTITY\"" >/dev/null
+
+      - name: Sign and verify a disposable macOS executable
+        shell: bash
+        run: |
+          cp /bin/echo "$RUNNER_TEMP/nebula-signing-smoke"
+          codesign \
+            --force \
+            --options runtime \
+            --timestamp \
+            --sign "$APPLE_SIGNING_IDENTITY" \
+            "$RUNNER_TEMP/nebula-signing-smoke"
+          codesign --verify --strict --verbose=2 "$RUNNER_TEMP/nebula-signing-smoke"
+
+      - name: Authenticate with Apple notarization
+        shell: bash
+        run: |
+          xcrun notarytool history \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --output-format json \
+            > "$RUNNER_TEMP/notary-history.json"
+          python3 -c 'import json, os; json.load(open(os.path.join(os.environ["RUNNER_TEMP"], "notary-history.json"), encoding="utf-8"))'
+
+      - name: Sign and verify a disposable updater payload
+        shell: bash
+        run: |
+          printf 'Nebula updater credential smoke test\n' > "$RUNNER_TEMP/updater-smoke.bin"
+          ui/node_modules/.bin/tauri signer sign "$RUNNER_TEMP/updater-smoke.bin"
+          test -s "$RUNNER_TEMP/updater-smoke.bin.sig"
+          cargo run \
+            --locked \
+            --quiet \
+            --manifest-path ui/src-tauri/Cargo.toml \
+            --example verify_update_signature \
+            -- \
+            "$RUNNER_TEMP/updater-smoke.bin" \
+            "$RUNNER_TEMP/updater-smoke.bin.sig" \
+            "$NEBULA_UPDATER_PUBLIC_KEY"
+          printf 'tampered\n' >> "$RUNNER_TEMP/updater-smoke.bin"
+          if cargo run \
+            --locked \
+            --quiet \
+            --manifest-path ui/src-tauri/Cargo.toml \
+            --example verify_update_signature \
+            -- \
+            "$RUNNER_TEMP/updater-smoke.bin" \
+            "$RUNNER_TEMP/updater-smoke.bin.sig" \
+            "$NEBULA_UPDATER_PUBLIC_KEY"; then
+            printf 'tampered updater payload unexpectedly passed verification\n' >&2
+            exit 1
+          fi
+
+      - name: Remove temporary credentials
+        if: always()
+        shell: bash
+        env:
+          CERTIFICATE_PATH: ${{ runner.temp }}/nebula-developer-id.p12
+          KEYCHAIN_PATH: ${{ runner.temp }}/nebula-release-smoke.keychain-db
+        run: |
+          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          rm -f \
+            "$CERTIFICATE_PATH" \
+            "$RUNNER_TEMP/notary-history.json" \
+            "$RUNNER_TEMP/nebula-signing-smoke" \
+            "$RUNNER_TEMP/updater-smoke.bin" \
+            "$RUNNER_TEMP/updater-smoke.bin.sig"


### PR DESCRIPTION
Adds a manual, non-publishing smoke test for the protected desktop-release environment. It validates Apple certificate import, code signing, notarization authentication, and a Tauri updater sign/verify round trip. The workflow checks out the modernization branch only for its pinned release tooling; it does not publish artifacts or releases.