### PR TITLE
Exercise real Apple notarization in credential smoke test

### DIFF
--- a/.github/workflows/desktop-release-credential-smoke.yml
+++ b/.github/workflows/desktop-release-credential-smoke.yml
@@ -95,28 +95,47 @@ jobs:
           security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
             | grep -F -- "\"$APPLE_SIGNING_IDENTITY\"" >/dev/null
 
-      - name: Sign and verify a disposable macOS executable
+      - name: Build, sign, and verify a disposable macOS application
         shell: bash
         run: |
-          cp /bin/echo "$RUNNER_TEMP/nebula-signing-smoke"
+          app="$RUNNER_TEMP/NebulaCredentialSmoke.app"
+          executable="$app/Contents/MacOS/nebula-credential-smoke"
+          plist="$app/Contents/Info.plist"
+          install -d -m 0755 "$app/Contents/MacOS"
+          cp /bin/echo "$executable"
+          plutil -create xml1 "$plist"
+          plutil -insert CFBundleExecutable -string nebula-credential-smoke "$plist"
+          plutil -insert CFBundleIdentifier -string com.berylliumsec.nebula.credential-smoke "$plist"
+          plutil -insert CFBundleName -string NebulaCredentialSmoke "$plist"
+          plutil -insert CFBundlePackageType -string APPL "$plist"
+          plutil -insert CFBundleShortVersionString -string 1.0.0 "$plist"
+          plutil -insert CFBundleVersion -string 1 "$plist"
           codesign \
             --force \
             --options runtime \
             --timestamp \
             --sign "$APPLE_SIGNING_IDENTITY" \
-            "$RUNNER_TEMP/nebula-signing-smoke"
-          codesign --verify --strict --verbose=2 "$RUNNER_TEMP/nebula-signing-smoke"
+            "$app"
+          codesign --verify --deep --strict --verbose=2 "$app"
 
-      - name: Authenticate with Apple notarization
+      - name: Submit, staple, and validate disposable notarization
         shell: bash
         run: |
-          xcrun notarytool history \
+          app="$RUNNER_TEMP/NebulaCredentialSmoke.app"
+          archive="$RUNNER_TEMP/NebulaCredentialSmoke.zip"
+          response="$RUNNER_TEMP/notary-response.json"
+          ditto -c -k --keepParent "$app" "$archive"
+          xcrun notarytool submit "$archive" \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
+            --wait \
+            --timeout 15m \
             --output-format json \
-            > "$RUNNER_TEMP/notary-history.json"
-          python3 -c 'import json, os; json.load(open(os.path.join(os.environ["RUNNER_TEMP"], "notary-history.json"), encoding="utf-8"))'
+            > "$response"
+          NOTARY_RESPONSE="$response" python3 -c 'import json, os; response = json.load(open(os.environ["NOTARY_RESPONSE"], encoding="utf-8")); status = response.get("status"); status == "Accepted" or (_ for _ in ()).throw(SystemExit(f"notarization status was {status!r}"))'
+          xcrun stapler staple "$app"
+          xcrun stapler validate "$app"
 
       - name: Sign and verify a disposable updater payload
         shell: bash
@@ -155,9 +174,10 @@ jobs:
           KEYCHAIN_PATH: ${{ runner.temp }}/nebula-release-smoke.keychain-db
         run: |
           security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
-          rm -f \
+          rm -rf \
             "$CERTIFICATE_PATH" \
-            "$RUNNER_TEMP/notary-history.json" \
-            "$RUNNER_TEMP/nebula-signing-smoke" \
+            "$RUNNER_TEMP/NebulaCredentialSmoke.app" \
+            "$RUNNER_TEMP/NebulaCredentialSmoke.zip" \
+            "$RUNNER_TEMP/notary-response.json" \
             "$RUNNER_TEMP/updater-smoke.bin" \
             "$RUNNER_TEMP/updater-smoke.bin.sig"


### PR DESCRIPTION
Replaces the submission-history lookup with a real disposable notarization cycle. The smoke test now signs a minimal app, submits it with notarytool, requires Accepted, then staples and validates the ticket. It publishes no repository artifacts or releases.