### PR TITLE
Use an owned executable for notarization smoke tests

### DIFF
--- a/.github/workflows/desktop-release-credential-smoke.yml
+++ b/.github/workflows/desktop-release-credential-smoke.yml
@@ -101,8 +101,15 @@ jobs:
           app="$RUNNER_TEMP/NebulaCredentialSmoke.app"
           executable="$app/Contents/MacOS/nebula-credential-smoke"
           plist="$app/Contents/Info.plist"
+          source="$RUNNER_TEMP/nebula-credential-smoke.c"
           install -d -m 0755 "$app/Contents/MacOS"
-          cp /bin/echo "$executable"
+          printf '%s\n' \
+            '#include <stdio.h>' \
+            'int main(void) {' \
+            '  return puts("Nebula notarization credential smoke test") < 0;' \
+            '}' \
+            > "$source"
+          xcrun clang -Os -Wall -Wextra -Werror "$source" -o "$executable"
           plutil -create xml1 "$plist"
           plutil -insert CFBundleExecutable -string nebula-credential-smoke "$plist"
           plutil -insert CFBundleIdentifier -string com.berylliumsec.nebula.credential-smoke "$plist"
@@ -178,6 +185,7 @@ jobs:
             "$CERTIFICATE_PATH" \
             "$RUNNER_TEMP/NebulaCredentialSmoke.app" \
             "$RUNNER_TEMP/NebulaCredentialSmoke.zip" \
+            "$RUNNER_TEMP/nebula-credential-smoke.c" \
             "$RUNNER_TEMP/notary-response.json" \
             "$RUNNER_TEMP/updater-smoke.bin" \
             "$RUNNER_TEMP/updater-smoke.bin.sig"


### PR DESCRIPTION
Replaces the copied /bin/echo payload with a tiny Nebula-owned C executable compiled on the runner. This removes unnecessary third-party binary provenance from the disposable notarization probe.