### PR TITLE
Harden release preparation checks

### DIFF
--- a/.github/workflows/nebula3-release.yml
+++ b/.github/workflows/nebula3-release.yml
@@ -166,7 +166,7 @@ jobs:
             poetry run pytest -q tests/v3/test_sandbox.py -k macos
           fi
           poetry run pytest -q packaging/updater/test_generate_manifest.py
-          npm --prefix ui test
+          npm --prefix ui test -- --testTimeout=15000
           npm --prefix ui run build
           install -d -m 0755 ui/src-tauri/binaries
           touch "ui/src-tauri/binaries/nebula-core-${{ matrix.target }}"
@@ -290,7 +290,7 @@ jobs:
           appimage="$RUNNER_TEMP/release-stage/Nebula-$NEBULA_VERSION-linux-x86_64.AppImage"
           dpkg-deb --info "$deb"
           expected_deb_version="$NEBULA_VERSION"
-          case "$expected_deb_version" in *-*) expected_deb_version="${expected_deb_version/-/~}" ;; esac
+          case "$expected_deb_version" in *-*) expected_deb_version="${expected_deb_version/-/\~}" ;; esac
           test "$(dpkg-deb --field "$deb" Version)" = "$expected_deb_version"
           dpkg --compare-versions "$expected_deb_version" le "$NEBULA_VERSION"
           dpkg-deb --extract "$deb" "$RUNNER_TEMP/deb-root"


### PR DESCRIPTION
## Summary
- allow slower UI unit tests on loaded release runners without weakening assertions
- escape the Debian prerelease tilde so Bash does not expand it to the runner home directory

## Failures addressed
- Intel macOS release tests: four 5-second timeouts under runner load
- Linux installer inspection: valid 3.0.0~alpha.1 package rejected because the expected value became 3.0.0/home/runneralpha.1

The Apple-silicon Tauri xattr failure occurred after successful compilation and is left for a clean retry before adding broader retry behavior.

## Verification
- workflow parses as YAML
- exact Debian prerelease comparison passes
- UI: 43 files / 216 tests passed with the release timeout