### PR TITLE
Remove macOS Intel release support

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,0 @@
-self-hosted-runner:
-  labels:
-    - macos-15-intel

--- a/.github/workflows/nebula3-release-finalize.yml
+++ b/.github/workflows/nebula3-release-finalize.yml
@@ -63,7 +63,7 @@ jobs:
           test "$(jq -r .head_sha <<<"$run")" = "$commit"
           test "$(jq -r .path <<<"$run")" = .github/workflows/nebula3-release.yml
           artifacts="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PREPARATION_RUN_ID/artifacts" --paginate --jq '.artifacts[].name')"
-          for name in nebula3-macos-arm64 nebula3-macos-x64 nebula3-linux-x64; do
+          for name in nebula3-macos-arm64 nebula3-linux-x64; do
             grep -Fx "$name" <<<"$artifacts" >/dev/null
           done
           case "$version" in *-*) prerelease=true ;; *) prerelease=false ;; esac
@@ -90,10 +90,6 @@ jobs:
             runner: macos-15
             target: aarch64-apple-darwin
             artifact_arch: arm64
-          - id: macos-x64
-            runner: macos-15-intel
-            target: x86_64-apple-darwin
-            artifact_arch: x64
     runs-on: ${{ matrix.runner }}
     env:
       NEBULA_VERSION: ${{ needs.validate.outputs.version }}
@@ -259,21 +255,17 @@ jobs:
         run: |
           required="
           Nebula-$VERSION-macOS-arm64-direct.dmg
-          Nebula-$VERSION-macOS-x64-direct.dmg
           Nebula-$VERSION-macOS-arm64-managed.dmg
-          Nebula-$VERSION-macOS-x64-managed.dmg
           Nebula-$VERSION-linux-x86_64.deb
           Nebula-$VERSION-linux-x86_64.AppImage
           Nebula-$VERSION-linux-x86_64.AppImage.sig
           Nebula-$VERSION-macOS-arm64.updater.tar.gz
           Nebula-$VERSION-macOS-arm64.updater.tar.gz.sig
-          Nebula-$VERSION-macOS-x64.updater.tar.gz
-          Nebula-$VERSION-macOS-x64.updater.tar.gz.sig
           "
           for name in $required; do test -s "release-assets/$name"; done
-          test "$(find release-assets -maxdepth 1 -type f -name '*.cyclonedx.json' | wc -l)" -eq 8
-          test "$(find release-assets -maxdepth 1 -type f -name '*.spdx.json' | wc -l)" -eq 8
-          test "$(find release-assets -maxdepth 1 -type f -name 'SHA256SUMS-*' | wc -l)" -eq 3
+          test "$(find release-assets -maxdepth 1 -type f -name '*.cyclonedx.json' | wc -l)" -eq 5
+          test "$(find release-assets -maxdepth 1 -type f -name '*.spdx.json' | wc -l)" -eq 5
+          test "$(find release-assets -maxdepth 1 -type f -name 'SHA256SUMS-*' | wc -l)" -eq 2
           python - <<'PY'
           import json
           from pathlib import Path

--- a/.github/workflows/nebula3-release.yml
+++ b/.github/workflows/nebula3-release.yml
@@ -78,11 +78,6 @@ jobs:
             target: aarch64-apple-darwin
             platform: macOS
             artifact_arch: arm64
-          - id: macos-x64
-            runner: macos-15-intel
-            target: x86_64-apple-darwin
-            platform: macOS
-            artifact_arch: x64
           - id: linux-x64
             runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
@@ -117,6 +112,16 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
+      - name: Pin Apple system xattr
+        if: matrix.platform == 'macOS'
+        run: |
+          test -x /usr/bin/xattr
+          install -d -m 0755 "$RUNNER_TEMP/nebula-release-bin"
+          ln -sf /usr/bin/xattr "$RUNNER_TEMP/nebula-release-bin/xattr"
+          printf '%s\n' "$RUNNER_TEMP/nebula-release-bin" >> "$GITHUB_PATH"
+      - name: Verify Apple system xattr
+        if: matrix.platform == 'macOS'
+        run: test "$(command -v xattr)" = "$RUNNER_TEMP/nebula-release-bin/xattr"
       - name: Install Linux bundler libraries
         if: matrix.platform == 'Linux'
         run: |

--- a/.github/workflows/publish-updater-manifest.yml
+++ b/.github/workflows/publish-updater-manifest.yml
@@ -62,7 +62,6 @@ jobs:
           done
           for artifact in \
             "release-assets/Nebula-$version-macOS-arm64.updater.tar.gz" \
-            "release-assets/Nebula-$version-macOS-x64.updater.tar.gz" \
             "release-assets/Nebula-$version-linux-x86_64.AppImage"; do
             cargo run --locked --quiet --manifest-path ui/src-tauri/Cargo.toml \
               --example verify_update_signature -- \

--- a/NEBULA3-TODO.md
+++ b/NEBULA3-TODO.md
@@ -15,7 +15,7 @@ provenance internals remain enforced and are progressively disclosed.
 The release is blocked until all of these gates pass:
 
 - [ ] A clean install with a cached workstation image reaches a focused prompt
-      within 10 seconds on supported macOS arm64/x64 and Linux x64 systems.
+      within 10 seconds on supported macOS arm64 and Linux x64 systems.
 - [ ] Cold image preparation reports progress immediately and supports cancel,
       retry, and restart; a cached launch performs no registry request.
 - [ ] The workstation image is release-pinned and signed, with verified digest,

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ alpha build as a stable production release. The first release line is
 
 Published releases can contain:
 
-- macOS 13 or newer DMGs for Apple silicon and Intel;
+- macOS 13 or newer DMGs for Apple silicon;
 - a Linux x86_64 AppImage with direct updates; and
 - a Linux x86_64 DEB for managed installations.
 

--- a/docs/NEBULA3.md
+++ b/docs/NEBULA3.md
@@ -90,7 +90,7 @@ GUI bindings and in-process model stacks from this build.
 
 Release tags use `nebula-v<semantic-version>`, for example
 `nebula-v3.0.0-alpha.1`. The protected release workflow builds native macOS
-arm64/x64 DMGs and Linux x64 DEB/AppImage artifacts, audits their contents,
+arm64 DMGs and Linux x64 DEB/AppImage artifacts, audits their contents,
 exercises the installed `--self-test`, creates SBOMs and provenance, and stages
 a draft release with the checked-in notes for that exact version. See
 [the release runbook](../packaging/RELEASING.md).

--- a/docs/releases/3.0.0-alpha.1.md
+++ b/docs/releases/3.0.0-alpha.1.md
@@ -26,7 +26,7 @@ authorized to test. Back up important engagement data before using it.
 
 The release workflow stages the following artifacts for manual review:
 
-- signed and notarized macOS 13+ DMGs for Apple silicon and Intel, in direct and
+- signed and notarized macOS 13+ DMGs for Apple silicon, in direct and
   managed variants;
 - a Linux x86_64 AppImage for direct distribution; and
 - a Linux x86_64 DEB for managed distribution.

--- a/packaging/RELEASING.md
+++ b/packaging/RELEASING.md
@@ -12,7 +12,6 @@ The protected workflow produces these native packages:
 | Platform | Architecture | Direct distribution | Managed distribution |
 | --- | --- | --- | --- |
 | macOS 13+ | Apple silicon | signed and notarized DMG with updater | signed and notarized DMG without updater |
-| macOS 13+ | Intel | signed and notarized DMG with updater | signed and notarized DMG without updater |
 | Linux | x86_64 | AppImage with signed updater metadata | DEB without the direct updater |
 
 Windows, Linux arm64, RPM, Flatpak, Snap, and Homebrew artifacts are not built
@@ -33,10 +32,9 @@ repository policy. Define these environment secrets:
 - `NEBULA_UPDATER_PUBLIC_KEY`, embedded into direct builds and backed up with
   the private key offline.
 
-The release cannot be prepared without this environment. Confirm the
-`macos-15-intel` runner label is available to the repository before tagging.
-Never use placeholder credentials for a release candidate. The preparation run
-and manual finalization must complete before a draft release exists.
+The release cannot be prepared without this environment. Never use placeholder
+credentials for a release candidate. The preparation run and manual
+finalization must complete before a draft release exists.
 
 ## Candidate checklist
 
@@ -74,7 +72,7 @@ and manual finalization must complete before a draft release exists.
    ```
 
 The tag push starts the preparation workflow. It builds direct and managed
-installers on native macOS arm64, macOS x64, and Ubuntu 22.04 x64 runners.
+installers on native macOS arm64 and Ubuntu 22.04 x64 runners.
 macOS builds are signed and submitted to Apple with Tauri's `--skip-stapling`
 mode, so the runners do not wait for Apple to finish. Linux packages complete
 their final audits, SBOMs, checksums, and attestations during preparation.
@@ -91,10 +89,10 @@ gh workflow run nebula3-release-finalize.yml \
 ```
 
 The finalizer verifies that the preparation run succeeded at the exact tagged
-commit and that all three private artifact sets still exist. If Apple is still
-processing either macOS architecture, stapling fails safely and no draft is
-created; rerun the finalizer later with the same inputs. Never resubmit or move
-the tag merely because Apple is still processing it.
+commit and that both private artifact sets still exist. If Apple is still
+processing the macOS submission, stapling fails safely and no draft is created;
+rerun the finalizer later with the same inputs. Never resubmit or move the tag
+merely because Apple is still processing it.
 
 ## Draft review and publication
 
@@ -106,7 +104,7 @@ macOS SBOMs and checksums, attests the final bytes, and combines them with the
 prepared Linux outputs. Before publishing the draft, a
 release manager must verify:
 
-- all three platform jobs and the clean Linux install matrix passed;
+- both native platform jobs and the clean Linux install matrix passed;
 - the artifact names and counts match the workflow's immutable manifest;
 - macOS signing, Gatekeeper assessment, notarization, and stapling passed;
 - updater signatures accept the original artifact and reject the tampered test;

--- a/packaging/homebrew/nebula.rb.in
+++ b/packaging/homebrew/nebula.rb.in
@@ -6,11 +6,6 @@ cask "nebula" do
     url "https://github.com/BerylliumSec/nebula/releases/download/nebula-v#{version}/Nebula-#{version}-macOS-arm64-managed.dmg"
   end
 
-  on_intel do
-    sha256 "@SHA256_X64@"
-    url "https://github.com/BerylliumSec/nebula/releases/download/nebula-v#{version}/Nebula-#{version}-macOS-x64-managed.dmg"
-  end
-
   name "Nebula"
   desc "Local-first security engagement workspace"
   homepage "https://github.com/BerylliumSec/nebula"

--- a/packaging/updater/generate_manifest.py
+++ b/packaging/updater/generate_manifest.py
@@ -101,11 +101,9 @@ def generate_manifest(
         ) from exc
 
     mac_arm = f"Nebula-{version}-macOS-arm64.updater.tar.gz"
-    mac_x64 = f"Nebula-{version}-macOS-x64.updater.tar.gz"
     linux = f"Nebula-{version}-linux-x86_64.AppImage"
     files = {
         "darwin-aarch64": mac_arm,
-        "darwin-x86_64": mac_x64,
         "linux-x86_64": linux,
     }
     base_url = (

--- a/packaging/updater/test_generate_manifest.py
+++ b/packaging/updater/test_generate_manifest.py
@@ -12,7 +12,6 @@ from packaging.updater.generate_manifest import (
 def release_assets(root: Path, version: str) -> None:
     names = [
         f"Nebula-{version}-macOS-arm64.updater.tar.gz",
-        f"Nebula-{version}-macOS-x64.updater.tar.gz",
         f"Nebula-{version}-linux-x86_64.AppImage",
     ]
     for name in names:
@@ -34,14 +33,13 @@ def test_manifest_maps_native_tauri_targets(tmp_path: Path) -> None:
 
     assert set(manifest["platforms"]) == {
         "darwin-aarch64",
-        "darwin-x86_64",
         "linux-x86_64",
     }
 
 
 def test_manifest_refuses_an_incomplete_release(tmp_path: Path) -> None:
     release_assets(tmp_path, "3.1.0")
-    (tmp_path / "Nebula-3.1.0-macOS-x64.updater.tar.gz.sig").unlink()
+    (tmp_path / "Nebula-3.1.0-macOS-arm64.updater.tar.gz.sig").unlink()
 
     with pytest.raises(ManifestError, match="missing updater signature"):
         generate_manifest(

--- a/tests/v3/test_packaging.py
+++ b/tests/v3/test_packaging.py
@@ -43,6 +43,8 @@ def test_native_launcher_and_admin_command_contract():
     cask = (ROOT / "packaging/homebrew/nebula.rb.in").read_text(encoding="utf-8")
     assert 'Contents/MacOS/nebula-ui", target: "nebula"' in cask
     assert 'Contents/MacOS/nebula-core", target: "nebula-core"' in cask
+    assert "on_intel" not in cask
+    assert "macOS-x64" not in cask
 
 
 def test_python_source_tree_contains_only_core_namespace():


### PR DESCRIPTION
## Summary
- remove macOS x86_64 from release preparation, finalization, updater manifests, and Homebrew metadata
- pin macOS release builds to Apple's `/usr/bin/xattr` to avoid the incompatible Homebrew/Python shim
- update release documentation and artifact-count gates for Apple silicon plus Linux

## Verification
- `poetry run pytest -q packaging/updater/test_generate_manifest.py tests/v3/test_packaging.py`
- `poetry run pytest -q tests/v3 --lf` (527 passed, 5 skipped)
- `npm --prefix ui test -- --testTimeout=15000` (216 passed)
- Ruff check and format check
- parsed all GitHub Actions workflow YAML