### PR TITLE
Fix licensed macOS DMG inspection

### DIFF
--- a/.github/workflows/nebula3-release-finalize.yml
+++ b/.github/workflows/nebula3-release-finalize.yml
@@ -153,7 +153,7 @@ jobs:
             hdiutil convert "$dmg" -format UDRW -o "$writable"
             mount="$RUNNER_TEMP/mount-$flavor"
             install -d -m 0755 "$mount"
-            hdiutil attach "$writable" -mountpoint "$mount" -nobrowse
+            printf 'Y\n' | hdiutil attach "$writable" -mountpoint "$mount" -nobrowse
             app="$mount/Nebula.app"
             test -x "$app/Contents/MacOS/nebula-ui"
             test -x "$app/Contents/MacOS/nebula-core"

--- a/.github/workflows/nebula3-release.yml
+++ b/.github/workflows/nebula3-release.yml
@@ -234,10 +234,6 @@ jobs:
           managed_dmg="$(find "$bundle/dmg" -maxdepth 1 -type f -name '*.dmg' -print -quit)"
           test -n "$managed_dmg"
           install -m 0644 "$managed_dmg" "$stage/Nebula-$NEBULA_VERSION-macOS-${{ matrix.artifact_arch }}-managed.dmg"
-          if strings "$bundle/macos/Nebula.app/Contents/MacOS/nebula-ui" | grep -Fq 'berylliumsec.github.io/nebula/updates'; then
-            printf 'managed build unexpectedly contains the direct update endpoint\n' >&2
-            exit 1
-          fi
       - name: Build signed direct AppImage and managed DEB
         if: matrix.platform == 'Linux'
         env:
@@ -279,12 +275,16 @@ jobs:
             codesign --verify --deep --strict --verbose=2 "$dmg"
             mount="$RUNNER_TEMP/mount-$flavor"
             install -d -m 0755 "$mount"
-            hdiutil attach "$dmg" -mountpoint "$mount" -nobrowse -readonly
+            printf 'Y\n' | hdiutil attach "$dmg" -mountpoint "$mount" -nobrowse -readonly
             app="$mount/Nebula.app"
             test -x "$app/Contents/MacOS/nebula-ui"
             test -x "$app/Contents/MacOS/nebula-core"
             poetry run python scripts/package_audit.py --tree "$app"
             codesign --verify --deep --strict --verbose=2 "$app"
+            if [ "$flavor" = managed ] && strings "$app/Contents/MacOS/nebula-ui" | grep -Fq 'berylliumsec.github.io/nebula/updates'; then
+              printf 'managed build unexpectedly contains the direct update endpoint\n' >&2
+              exit 1
+            fi
             "$app/Contents/MacOS/nebula-ui" --self-test
             hdiutil detach "$mount"
           done

--- a/ui/src/components/imageEditor/ImageEditor.test.ts
+++ b/ui/src/components/imageEditor/ImageEditor.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { calculateImageEditorFitZoom } from "./ImageEditor";
+
+describe("calculateImageEditorFitZoom", () => {
+  it("fits a tall terminal capture below ten percent", () => {
+    const zoom = calculateImageEditorFitZoom(2_387, 16_384, 1_846, 940);
+
+    expect(zoom).toBeCloseTo(940 / 16_384);
+    expect(zoom).toBeLessThan(0.1);
+    expect(16_384 * zoom).toBeLessThanOrEqual(940);
+  });
+
+  it("does not enlarge an image that already fits", () => {
+    expect(calculateImageEditorFitZoom(800, 600, 1_600, 900)).toBe(1);
+  });
+
+  it("honors the available space even below the manual zoom floor", () => {
+    expect(calculateImageEditorFitZoom(16_384, 16_384, 1, 1)).toBe(1 / 16_384);
+  });
+});

--- a/ui/src/components/imageEditor/ImageEditor.tsx
+++ b/ui/src/components/imageEditor/ImageEditor.tsx
@@ -73,6 +73,17 @@ type EditorGesture = DrawGesture | PanGesture;
 const MIN_EDITOR_ZOOM = 0.1;
 const MAX_EDITOR_ZOOM = 4;
 
+export function calculateImageEditorFitZoom(
+  imageWidth: number,
+  imageHeight: number,
+  availableWidth: number,
+  availableHeight: number,
+): number {
+  const widthRatio = Math.max(1, availableWidth) / Math.max(1, imageWidth);
+  const heightRatio = Math.max(1, availableHeight) / Math.max(1, imageHeight);
+  return Math.min(1, widthRatio, heightRatio);
+}
+
 function operationId(): string {
   return globalThis.crypto?.randomUUID?.() ?? `image-edit-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
@@ -291,8 +302,12 @@ export function ImageEditor({
     const verticalBorder = (Number.parseFloat(canvasStyle.borderTopWidth) || 0) + (Number.parseFloat(canvasStyle.borderBottomWidth) || 0);
     const availableWidth = Math.max(1, viewport.clientWidth - horizontalPadding - horizontalBorder);
     const availableHeight = Math.max(1, viewport.clientHeight - verticalPadding - verticalBorder);
-    const nextZoom = Math.min(1, availableWidth / dimensions.width, availableHeight / dimensions.height);
-    setZoom(Math.max(MIN_EDITOR_ZOOM, nextZoom));
+    setZoom(calculateImageEditorFitZoom(
+      dimensions.width,
+      dimensions.height,
+      availableWidth,
+      availableHeight,
+    ));
   }, [dimensions]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- accept Nebula’s embedded license when release automation mounts DMGs during preparation and finalization
- inspect the managed app inside its staged DMG instead of the Tauri bundle path that is removed after packaging
- merge `codex/fix-terminal-screenshot-fit` so tall terminal captures fit within the image editor below the manual zoom floor

## Validation
- reproduced unattended `hdiutil attach` failure with a Tauri-generated licensed DMG on the arm64 research Mac
- verified the patched mount succeeds for both read-only and converted writable licensed DMGs
- `npm --prefix ui run audit:diagnostics`
- `npm --prefix ui test -- --testTimeout=15000` (219 passed)
- `npm --prefix ui run build`
- both release workflow YAML files parse successfully