### PR TITLE
Retry transient macOS DMG detach failures

### DIFF
--- a/.github/workflows/nebula3-release-finalize.yml
+++ b/.github/workflows/nebula3-release-finalize.yml
@@ -145,6 +145,28 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           stage="$RUNNER_TEMP/release-stage"
+          detach_volume() {
+            local mountpoint="$1"
+            local attempt output status=1
+            for attempt in {1..15}; do
+              if output="$(hdiutil detach "$mountpoint" 2>&1)"; then
+                printf '%s\n' "$output"
+                return 0
+              else
+                status=$?
+              fi
+              printf 'DMG detach attempt %d/15 failed for %s: %s\n' \
+                "$attempt" "$mountpoint" "$output" >&2
+              if [ "$attempt" -lt 15 ]; then
+                sync
+                sleep 1
+              fi
+            done
+            printf 'mounted image state after detach retries:\n' >&2
+            hdiutil info >&2 || true
+            return "$status"
+          }
+
           for flavor in direct managed; do
             dmg="$stage/Nebula-$NEBULA_VERSION-macOS-${{ matrix.artifact_arch }}-$flavor.dmg"
             test -s "$dmg"
@@ -168,7 +190,7 @@ jobs:
               COPYFILE_DISABLE=1 tar -czf "$updater" -C "$mount" Nebula.app
               npm --prefix ui run tauri -- signer sign "$updater"
             fi
-            hdiutil detach "$mount"
+            detach_volume "$mount"
             hdiutil convert "$writable" -format UDZO -o "$rebuilt"
             codesign --force --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$rebuilt"
             mv "$rebuilt" "$dmg"

--- a/.github/workflows/nebula3-release.yml
+++ b/.github/workflows/nebula3-release.yml
@@ -270,6 +270,28 @@ jobs:
       - name: Inspect prepared macOS installers
         if: matrix.platform == 'macOS'
         run: |
+          detach_volume() {
+            local mountpoint="$1"
+            local attempt output status=1
+            for attempt in {1..15}; do
+              if output="$(hdiutil detach "$mountpoint" 2>&1)"; then
+                printf '%s\n' "$output"
+                return 0
+              else
+                status=$?
+              fi
+              printf 'DMG detach attempt %d/15 failed for %s: %s\n' \
+                "$attempt" "$mountpoint" "$output" >&2
+              if [ "$attempt" -lt 15 ]; then
+                sync
+                sleep 1
+              fi
+            done
+            printf 'mounted image state after detach retries:\n' >&2
+            hdiutil info >&2 || true
+            return "$status"
+          }
+
           for flavor in direct managed; do
             dmg="$RUNNER_TEMP/release-stage/Nebula-$NEBULA_VERSION-macOS-${{ matrix.artifact_arch }}-$flavor.dmg"
             codesign --verify --deep --strict --verbose=2 "$dmg"
@@ -286,7 +308,7 @@ jobs:
               exit 1
             fi
             "$app/Contents/MacOS/nebula-ui" --self-test
-            hdiutil detach "$mount"
+            detach_volume "$mount"
           done
       - name: Inspect and self-test Linux installers
         if: matrix.platform == 'Linux'


### PR DESCRIPTION
## Summary
- retry macOS DMG detach for up to 15 seconds after mounted app self-tests
- apply the same retry and diagnostics to release finalization
- keep the fix inline so immutable alpha.4 can be rerun from the updated workflow

## Validation
- research Mac: real alpha.4 release-profile managed licensed DMG mount/audit/signature/self-test/detach passed 10/10
- research Mac: direct-updater licensed DMG mount/audit/signature/self-test/detach passed
- research Mac: forced Resource busy failed four attempts then detached successfully on attempt five
- research Mac: UDRW finalization mount/self-test/detach/UDZO rebuild passed
- workflow YAML parse and git diff checks passed