### PR TITLE
Wait for Apple notarization before stapling

### DIFF
--- a/.github/workflows/nebula3-release-finalize.yml
+++ b/.github/workflows/nebula3-release-finalize.yml
@@ -172,6 +172,9 @@ jobs:
       - name: Staple accepted apps and rebuild signed installers
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
@@ -210,6 +213,40 @@ jobs:
             app="$mount/Nebula.app"
             test -x "$app/Contents/MacOS/nebula-ui"
             test -x "$app/Contents/MacOS/nebula-core"
+            codesign --verify --deep --strict --verbose=2 "$app"
+            notarization="$RUNNER_TEMP/Nebula-$flavor-notarization.zip"
+            notarization_result="$RUNNER_TEMP/Nebula-$flavor-notarization.json"
+            ditto -c -k --keepParent "$app" "$notarization"
+            if ! xcrun notarytool submit "$notarization" \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" \
+              --wait \
+              --output-format json > "$notarization_result"; then
+              cat "$notarization_result" >&2
+              submission_id="$(jq -r '.id // empty' "$notarization_result")"
+              if [ -n "$submission_id" ]; then
+                xcrun notarytool log "$submission_id" \
+                  --apple-id "$APPLE_ID" \
+                  --password "$APPLE_PASSWORD" \
+                  --team-id "$APPLE_TEAM_ID" >&2 || true
+              fi
+              exit 1
+            fi
+            cat "$notarization_result"
+            submission_id="$(jq -r '.id // empty' "$notarization_result")"
+            status="$(jq -r '.status // empty' "$notarization_result")"
+            if [ "$status" != Accepted ]; then
+              printf 'notarization %s completed with status %s\n' \
+                "$submission_id" "$status" >&2
+              if [ -n "$submission_id" ]; then
+                xcrun notarytool log "$submission_id" \
+                  --apple-id "$APPLE_ID" \
+                  --password "$APPLE_PASSWORD" \
+                  --team-id "$APPLE_TEAM_ID" >&2 || true
+              fi
+              exit 1
+            fi
             xcrun stapler staple "$app"
             xcrun stapler validate "$app"
             poetry run python scripts/package_audit.py --tree "$app"

--- a/.github/workflows/nebula3-release.yml
+++ b/.github/workflows/nebula3-release.yml
@@ -196,13 +196,10 @@ jobs:
           security import "$certificate" -k nebula-build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple: -s -k "$APPLE_KEYCHAIN_PASSWORD" nebula-build.keychain
           security list-keychains -d user -s nebula-build.keychain login.keychain-db
-      - name: Build signed macOS apps, submit notarization, and prepare DMGs
+      - name: Build signed macOS apps and prepare DMGs
         if: matrix.platform == 'macOS'
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |


### PR DESCRIPTION
## Summary
- stop fire-and-forget notarization during release preparation
- submit each exact prepared app during finalization and wait for Apple acceptance
- staple only after an explicit Accepted response
- print Apple notarization logs automatically on rejection

## Root cause
Preparation submitted both apps with status Pending and did not wait. Finalization later assumed acceptance and Apple stapler returned Record not found (error 65).

## Validation
- research Mac: notarization archive round-trip preserved nested and app signatures
- research Mac notarytool supports all invoked authentication/wait/JSON flags
- workflow YAML and diff checks passed