### PR TITLE
feat: add Codex pricing catalog and project cost rollups

### DIFF
--- a/src/nebula/v3/harnesses.py
+++ b/src/nebula/v3/harnesses.py
@@ -91,6 +91,7 @@ from .domain import (
     ToolCallStatus,
     utc_now,
 )
+from .model_pricing import CATALOG_VERIFIED_ON, codex_model_pricing
 from .redaction import redact_text, sanitize_display_text
 from .storage import NebulaStore, NotFoundError
 from .mcp import (
@@ -1735,7 +1736,7 @@ class CodexAppServerConnection(HarnessConnection):
                     type="usage",
                     vendor=HarnessKind.CODEX_APP_SERVER,
                     usage=usage,
-                    detailed_usage=_codex_detailed_usage(params),
+                    detailed_usage=_codex_detailed_usage(params, model=model),
                     payload={},
                 )
                 continue
@@ -1923,7 +1924,9 @@ def _codex_usage(params: dict[str, Any]) -> ChatTokenUsage:
     )
 
 
-def _codex_detailed_usage(params: dict[str, Any]) -> HarnessDetailedUsage:
+def _codex_detailed_usage(
+    params: dict[str, Any], *, model: str
+) -> HarnessDetailedUsage:
     raw_usage = params.get("tokenUsage") or params.get("usage") or {}
     usage = raw_usage if isinstance(raw_usage, dict) else {}
     raw_last = usage.get("last")
@@ -1941,12 +1944,23 @@ def _codex_detailed_usage(params: dict[str, Any]) -> HarnessDetailedUsage:
     total_tokens = count("totalTokens", "total_tokens") or (
         input_tokens + output_tokens
     )
+    cached_input_tokens = count("cachedInputTokens", "cached_input_tokens")
     context_window = usage.get("modelContextWindow")
+    pricing = codex_model_pricing(model)
+    cost_usd = (
+        pricing.estimate_cost_usd(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_input_tokens=cached_input_tokens,
+        )
+        if pricing is not None
+        else None
+    )
     return HarnessDetailedUsage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=total_tokens,
-        cached_input_tokens=count("cachedInputTokens", "cached_input_tokens"),
+        cached_input_tokens=cached_input_tokens,
         reasoning_output_tokens=count(
             "reasoningOutputTokens", "reasoning_output_tokens"
         ),
@@ -1956,6 +1970,20 @@ def _codex_detailed_usage(params: dict[str, Any]) -> HarnessDetailedUsage:
             else None
         ),
         context_used=input_tokens,
+        cost_usd=cost_usd,
+        model_usage=(
+            {
+                model: {
+                    "cost_usd": cost_usd,
+                    "pricing_basis": "standard_api_equivalent",
+                    "pricing_model": pricing.model,
+                    "pricing_verified_on": CATALOG_VERIFIED_ON,
+                    "pricing_source": pricing.source_url,
+                }
+            }
+            if pricing is not None
+            else {}
+        ),
     )
 
 

--- a/src/nebula/v3/harnesses.py
+++ b/src/nebula/v3/harnesses.py
@@ -7325,6 +7325,17 @@ class HarnessRuntimeService:
         if event.vendor is None:
             profile = self.store.get(HarnessProfile, session.harness_profile_id)
             event = event.model_copy(update={"vendor": profile.kind})
+        if event.type == "usage" and turn.run_id:
+            run_cost_usd = self._record_harness_run_usage(turn, event)
+            if run_cost_usd is not None:
+                event = event.model_copy(
+                    update={
+                        "payload": {
+                            **event.payload,
+                            "run_cost_usd": run_cost_usd,
+                        }
+                    }
+                )
         if event.item_kind == "file_change" and event.payload.get("attribution"):
             concurrent = 0
             for active in self._active.values():
@@ -7452,6 +7463,53 @@ class HarnessRuntimeService:
             }
         )
 
+    def _record_harness_run_usage(
+        self, turn: HarnessTurn, event: HarnessEvent
+    ) -> float | None:
+        detailed = event.detailed_usage
+        if detailed is None or detailed.cost_usd is None or not turn.run_id:
+            return None
+        run = self.store.get(AgentRun, turn.run_id)
+        raw_usage = run.metadata.get("harness_turn_usage")
+        turn_usage = dict(raw_usage) if isinstance(raw_usage, dict) else {}
+        turn_usage[turn.id] = {
+            "input_tokens": detailed.input_tokens,
+            "output_tokens": detailed.output_tokens,
+            "total_tokens": detailed.total_tokens,
+            "cost_usd": detailed.cost_usd,
+        }
+        entries = [item for item in turn_usage.values() if isinstance(item, dict)]
+        spent_usd = sum(
+            float(item.get("cost_usd", 0))
+            for item in entries
+            if isinstance(item.get("cost_usd"), (int, float))
+        )
+        input_tokens = sum(
+            int(item.get("input_tokens", 0))
+            for item in entries
+            if isinstance(item.get("input_tokens"), (int, float))
+        )
+        output_tokens = sum(
+            int(item.get("output_tokens", 0))
+            for item in entries
+            if isinstance(item.get("output_tokens"), (int, float))
+        )
+        self.store.update(
+            AgentRun,
+            run.id,
+            {
+                "metadata": {
+                    **run.metadata,
+                    "harness_turn_usage": turn_usage,
+                    "spent_usd": spent_usd,
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                }
+            },
+            expected_revision=run.revision,
+        )
+        return spent_usd
+
     def activity_events(
         self, turn_id: str, *, after_sequence: int = 0, limit: int = 1_000
     ) -> HarnessActivityEventList:
@@ -7526,6 +7584,9 @@ class HarnessRuntimeService:
                 "harness_turn_id": turn.id,
             }
         )
+        run_cost_usd = event.payload.get("run_cost_usd")
+        if isinstance(run_cost_usd, (int, float)):
+            payload["run_cost_usd"] = run_cost_usd
         return payload
 
     def _start_owner(self, turn: HarnessTurn) -> None:
@@ -7644,6 +7705,9 @@ class HarnessRuntimeService:
                         "summary": final_summary,
                         "harness_turn_id": turn.id,
                         "usage": usage.model_dump(mode="json"),
+                        "input_tokens": run.metadata.get("input_tokens", 0),
+                        "output_tokens": run.metadata.get("output_tokens", 0),
+                        "cost_usd": run.metadata.get("spent_usd", 0.0),
                     },
                     idempotency_key="run:completed",
                 )

--- a/src/nebula/v3/model_pricing.py
+++ b/src/nebula/v3/model_pricing.py
@@ -1,0 +1,170 @@
+"""Standard API text-token prices used for Codex API-equivalent estimates.
+
+Update each official source entry and ``CATALOG_VERIFIED_ON`` together. These
+estimates intentionally exclude ChatGPT subscription billing, service-tier or
+regional adjustments, tool-call fees, and cache-write charges that the Codex
+token-usage event does not identify.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+CATALOG_VERIFIED_ON = "2026-07-22"
+_PER_MILLION = Decimal(1_000_000)
+_SNAPSHOT_SUFFIX = r"-\d{4}-\d{2}-\d{2}"
+
+
+@dataclass(frozen=True, slots=True)
+class ModelTokenPricing:
+    model: str
+    input_per_million_usd: Decimal
+    cached_input_per_million_usd: Decimal
+    output_per_million_usd: Decimal
+    source_url: str
+    aliases: tuple[str, ...] = ()
+    long_context_threshold: int | None = None
+    long_context_input_multiplier: Decimal = Decimal(1)
+    long_context_output_multiplier: Decimal = Decimal(1)
+
+    def matches(self, model: str) -> bool:
+        normalized = model.strip().casefold()
+        identifiers = (self.model, *self.aliases)
+        return normalized in identifiers or any(
+            re.fullmatch(re.escape(identifier) + _SNAPSHOT_SUFFIX, normalized)
+            for identifier in identifiers
+        )
+
+    def estimate_cost_usd(
+        self,
+        *,
+        input_tokens: int,
+        output_tokens: int,
+        cached_input_tokens: int = 0,
+    ) -> float:
+        total_input = max(0, input_tokens)
+        cached_input = min(total_input, max(0, cached_input_tokens))
+        uncached_input = total_input - cached_input
+        output = max(0, output_tokens)
+        input_multiplier = Decimal(1)
+        output_multiplier = Decimal(1)
+        if (
+            self.long_context_threshold is not None
+            and total_input > self.long_context_threshold
+        ):
+            input_multiplier = self.long_context_input_multiplier
+            output_multiplier = self.long_context_output_multiplier
+        cost = (
+            (
+                Decimal(uncached_input) * self.input_per_million_usd
+                + Decimal(cached_input) * self.cached_input_per_million_usd
+            )
+            * input_multiplier
+            + Decimal(output) * self.output_per_million_usd * output_multiplier
+        ) / _PER_MILLION
+        return float(cost)
+
+
+_OPENAI_MODELS = "https://developers.openai.com/api/docs/models"
+CODEX_MODEL_PRICING: tuple[ModelTokenPricing, ...] = (
+    ModelTokenPricing(
+        model="gpt-5.6-sol",
+        aliases=("gpt-5.6",),
+        input_per_million_usd=Decimal("5.00"),
+        cached_input_per_million_usd=Decimal("0.50"),
+        output_per_million_usd=Decimal("30.00"),
+        source_url=f"{_OPENAI_MODELS}/gpt-5.6-sol",
+        long_context_threshold=272_000,
+        long_context_input_multiplier=Decimal("2"),
+        long_context_output_multiplier=Decimal("1.5"),
+    ),
+    ModelTokenPricing(
+        model="gpt-5.6-terra",
+        input_per_million_usd=Decimal("2.50"),
+        cached_input_per_million_usd=Decimal("0.25"),
+        output_per_million_usd=Decimal("15.00"),
+        source_url=f"{_OPENAI_MODELS}/gpt-5.6-terra",
+        long_context_threshold=272_000,
+        long_context_input_multiplier=Decimal("2"),
+        long_context_output_multiplier=Decimal("1.5"),
+    ),
+    ModelTokenPricing(
+        model="gpt-5.6-luna",
+        input_per_million_usd=Decimal("1.00"),
+        cached_input_per_million_usd=Decimal("0.10"),
+        output_per_million_usd=Decimal("6.00"),
+        source_url=f"{_OPENAI_MODELS}/gpt-5.6-luna",
+        long_context_threshold=272_000,
+        long_context_input_multiplier=Decimal("2"),
+        long_context_output_multiplier=Decimal("1.5"),
+    ),
+    ModelTokenPricing(
+        model="gpt-5.4",
+        input_per_million_usd=Decimal("2.50"),
+        cached_input_per_million_usd=Decimal("0.25"),
+        output_per_million_usd=Decimal("15.00"),
+        source_url=f"{_OPENAI_MODELS}/gpt-5.4",
+        long_context_threshold=272_000,
+        long_context_input_multiplier=Decimal("2"),
+        long_context_output_multiplier=Decimal("1.5"),
+    ),
+    ModelTokenPricing(
+        model="gpt-5.4-mini",
+        input_per_million_usd=Decimal("0.75"),
+        cached_input_per_million_usd=Decimal("0.075"),
+        output_per_million_usd=Decimal("4.50"),
+        source_url=f"{_OPENAI_MODELS}/gpt-5.4-mini",
+    ),
+    ModelTokenPricing(
+        model="gpt-5.4-nano",
+        input_per_million_usd=Decimal("0.20"),
+        cached_input_per_million_usd=Decimal("0.02"),
+        output_per_million_usd=Decimal("1.25"),
+        source_url=f"{_OPENAI_MODELS}/gpt-5.4-nano",
+    ),
+    ModelTokenPricing(
+        model="gpt-5.3-codex",
+        input_per_million_usd=Decimal("1.75"),
+        cached_input_per_million_usd=Decimal("0.175"),
+        output_per_million_usd=Decimal("14.00"),
+        source_url=f"{_OPENAI_MODELS}/gpt-5.3-codex",
+    ),
+    ModelTokenPricing(
+        model="gpt-5.2-codex",
+        input_per_million_usd=Decimal("1.75"),
+        cached_input_per_million_usd=Decimal("0.175"),
+        output_per_million_usd=Decimal("14.00"),
+        source_url=f"{_OPENAI_MODELS}/gpt-5.2-codex",
+    ),
+    ModelTokenPricing(
+        model="gpt-5.1-codex",
+        input_per_million_usd=Decimal("1.25"),
+        cached_input_per_million_usd=Decimal("0.125"),
+        output_per_million_usd=Decimal("10.00"),
+        source_url=f"{_OPENAI_MODELS}/gpt-5.1-codex",
+    ),
+    ModelTokenPricing(
+        model="gpt-5.1-codex-max",
+        input_per_million_usd=Decimal("1.25"),
+        cached_input_per_million_usd=Decimal("0.125"),
+        output_per_million_usd=Decimal("10.00"),
+        source_url=f"{_OPENAI_MODELS}/gpt-5.1-codex-max",
+    ),
+)
+
+
+def codex_model_pricing(model: str) -> ModelTokenPricing | None:
+    return next(
+        (pricing for pricing in CODEX_MODEL_PRICING if pricing.matches(model)), None
+    )
+
+
+__all__ = [
+    "CATALOG_VERIFIED_ON",
+    "CODEX_MODEL_PRICING",
+    "ModelTokenPricing",
+    "codex_model_pricing",
+]

--- a/tests/v3/test_harness_adapters.py
+++ b/tests/v3/test_harness_adapters.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from jsonschema import Draft7Validator
 from pydantic import SecretStr
+import pytest
 
 from nebula.v3.credentials import CredentialCreateRequest, CredentialStore
 from nebula.v3.domain import (
@@ -274,7 +275,7 @@ def test_codex_schema_pinned_handshake_streaming_and_approvals(tmp_path):
             )
         )
         events = [
-            event async for event in connection.run_turn("inspect", model="gpt-test")
+            event async for event in connection.run_turn("inspect", model="gpt-5.4")
         ]
 
         assert [method for method, _ in rpc.calls[:3]] == [
@@ -303,6 +304,14 @@ def test_codex_schema_pinned_handshake_streaming_and_approvals(tmp_path):
         assert usage_event.detailed_usage is not None
         assert usage_event.detailed_usage.input_tokens == 3
         assert usage_event.detailed_usage.output_tokens == 2
+        assert usage_event.detailed_usage.cost_usd == pytest.approx(0.0000375)
+        assert usage_event.detailed_usage.model_usage["gpt-5.4"] == {
+            "cost_usd": pytest.approx(0.0000375),
+            "pricing_basis": "standard_api_equivalent",
+            "pricing_model": "gpt-5.4",
+            "pricing_verified_on": "2026-07-22",
+            "pricing_source": "https://developers.openai.com/api/docs/models/gpt-5.4",
+        }
         assert decisions[0].category == "command"
         assert rpc.responses == [(41, {"decision": "accept"})]
         instructions = rpc.calls[1][1]["developerInstructions"]

--- a/tests/v3/test_harnesses.py
+++ b/tests/v3/test_harnesses.py
@@ -28,6 +28,7 @@ from nebula.v3.domain import (
     ChatTurn,
     Engagement,
     HarnessCapabilities,
+    HarnessDetailedUsage,
     HarnessKind,
     HarnessInteraction,
     HarnessInteractionKind,
@@ -102,9 +103,26 @@ class FakeConnection(HarnessConnection):
         answer = f"Harness answer for {prompt}"
         yield HarnessEvent(type="message_delta", delta=answer[:8])
         yield HarnessEvent(type="message_delta", delta=answer[8:])
+        if prompt == "Continue autonomously":
+            yield HarnessEvent(
+                type="usage",
+                usage=ChatTokenUsage(input_tokens=3, output_tokens=4, total_tokens=7),
+                detailed_usage=HarnessDetailedUsage(
+                    input_tokens=3,
+                    output_tokens=4,
+                    total_tokens=7,
+                    cost_usd=0.1,
+                ),
+            )
         yield HarnessEvent(
             type="usage",
             usage=ChatTokenUsage(input_tokens=4, output_tokens=5, total_tokens=9),
+            detailed_usage=HarnessDetailedUsage(
+                input_tokens=4,
+                output_tokens=5,
+                total_tokens=9,
+                cost_usd=0.125,
+            ),
         )
         yield HarnessEvent(type="completed", message=answer)
 
@@ -275,6 +293,18 @@ def test_shared_session_handoff_streaming_and_frozen_mcp_snapshot(tmp_path):
         assert finished.metadata["final_summary"] == (
             "Harness answer for Continue autonomously"
         )
+        assert finished.metadata["spent_usd"] == pytest.approx(0.125)
+        assert finished.metadata["input_tokens"] == 4
+        assert finished.metadata["output_tokens"] == 5
+        usage_events = [
+            event
+            for event in store.replay_events(run.id)
+            if event.event_type == "harness.usage"
+        ]
+        assert [event.payload["run_cost_usd"] for event in usage_events] == [
+            pytest.approx(0.1),
+            pytest.approx(0.125),
+        ]
         completed_event = next(
             event
             for event in store.replay_events(run.id)
@@ -283,6 +313,7 @@ def test_shared_session_handoff_streaming_and_frozen_mcp_snapshot(tmp_path):
         assert completed_event.payload["summary"] == (
             "Harness answer for Continue autonomously"
         )
+        assert completed_event.payload["cost_usd"] == pytest.approx(0.125)
         assert (
             finished.runtime_snapshot["mcp_snapshot"][0]["url"]
             == "https://mcp.invalid/api"

--- a/tests/v3/test_model_pricing.py
+++ b/tests/v3/test_model_pricing.py
@@ -1,0 +1,63 @@
+from decimal import Decimal
+
+import pytest
+
+from nebula.v3.model_pricing import (
+    CATALOG_VERIFIED_ON,
+    CODEX_MODEL_PRICING,
+    ModelTokenPricing,
+    codex_model_pricing,
+)
+
+
+def test_codex_catalog_resolves_aliases_snapshots_and_unknown_models():
+    assert CATALOG_VERIFIED_ON == "2026-07-22"
+    assert len(CODEX_MODEL_PRICING) == 10
+    assert codex_model_pricing(" GPT-5.6 ").model == "gpt-5.6-sol"
+    assert codex_model_pricing("gpt-5.4-mini-2026-03-17").model == "gpt-5.4-mini"
+    assert codex_model_pricing("future-codex-model") is None
+
+
+def test_catalog_prices_cached_and_uncached_tokens():
+    pricing = codex_model_pricing("gpt-5.3-codex")
+    assert pricing is not None
+    assert pricing.estimate_cost_usd(
+        input_tokens=1_000_000,
+        cached_input_tokens=250_000,
+        output_tokens=100_000,
+    ) == pytest.approx(2.75625)
+
+
+def test_catalog_applies_long_context_rates_and_sanitizes_counts():
+    pricing = codex_model_pricing("gpt-5.6-terra")
+    assert pricing is not None
+    assert pricing.estimate_cost_usd(
+        input_tokens=300_000,
+        output_tokens=100_000,
+    ) == pytest.approx(3.75)
+    assert (
+        pricing.estimate_cost_usd(
+            input_tokens=-1,
+            cached_input_tokens=10,
+            output_tokens=-2,
+        )
+        == 0
+    )
+
+
+def test_catalog_entry_without_long_context_surcharge_uses_standard_rates():
+    pricing = ModelTokenPricing(
+        model="fixture",
+        aliases=("alias",),
+        input_per_million_usd=Decimal("1"),
+        cached_input_per_million_usd=Decimal("0.1"),
+        output_per_million_usd=Decimal("2"),
+        source_url="https://example.test/pricing",
+    )
+    assert pricing.matches("alias-2026-07-22")
+    assert not pricing.matches("alias-preview")
+    assert pricing.estimate_cost_usd(
+        input_tokens=1_000_000,
+        cached_input_tokens=2_000_000,
+        output_tokens=1_000_000,
+    ) == pytest.approx(2.1)

--- a/ui/src/pages/OverviewPage.test.tsx
+++ b/ui/src/pages/OverviewPage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { DialogProvider } from "../components/DialogSystem";
-import { OverviewPage } from "./OverviewPage";
+import { formatProjectModelCost, OverviewPage } from "./OverviewPage";
 import "../styles.css";
 import "../refinement.css";
 
@@ -37,6 +37,7 @@ vi.mock("../state/WorkspaceContext", () => ({
       status: "complete",
       completedTasks: 1,
       totalTasks: 1,
+      spentUsd: 0.0000375,
     },
     startMission: vi.fn(),
     stopMission: vi.fn(),
@@ -63,5 +64,13 @@ describe("project overview mission activity", () => {
     expect(getComputedStyle(markdownListItem!).display).toBe("list-item");
     expect(within(activity!).getByText("192.168.1.1").tagName).toBe("CODE");
     expect(screen.queryByText(/\*\*Analyst-Facing Result\*\*/)).toBeNull();
+    expect(screen.getByText("$0.000038")).toBeInTheDocument();
+  });
+
+  it("formats mission costs without hiding small harness totals", () => {
+    expect(formatProjectModelCost(undefined)).toBe("—");
+    expect(formatProjectModelCost(0)).toBe("$0.00");
+    expect(formatProjectModelCost(0.00125)).toBe("$0.0013");
+    expect(formatProjectModelCost(1.25)).toBe("$1.25");
   });
 });

--- a/ui/src/pages/OverviewPage.tsx
+++ b/ui/src/pages/OverviewPage.tsx
@@ -22,6 +22,13 @@ type EventStepState = "complete" | "running" | "waiting" | "failed" | "stopped" 
 
 const noRunnableLanguages = new Set<ExecutionLanguage>();
 
+export function formatProjectModelCost(cost: number | undefined): string {
+  if (cost === undefined) return "—";
+  const precision = cost > 0 && cost < 0.0001 ? 6 : cost > 0 && cost < 0.01 ? 4 : 2;
+  const scale = 10 ** precision;
+  return `$${(Math.round(cost * scale) / scale).toFixed(precision)}`;
+}
+
 function eventStepState(kind: string): EventStepState {
   if (kind.includes("failed") || kind.includes("blocked")) return "failed";
   if (kind.includes("cancelled") || kind === "run.stop_requested") return "stopped";
@@ -79,7 +86,7 @@ export function OverviewPage() {
         </article>
         <article className="metric-card accent-green">
           <span className="metric-icon"><DollarSign size={19} /></span>
-          <div><small>Model cost</small><strong>{run?.spentUsd === undefined ? "—" : `$${run.spentUsd.toFixed(2)}`}</strong><span>Recorded for this mission</span></div>
+          <div><small>Model cost</small><strong>{formatProjectModelCost(run?.spentUsd)}</strong><span>Recorded for this mission</span></div>
         </article>
       </section>
 

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -67,6 +67,7 @@ import { useWorkbenchDrafts } from "../state/WorkbenchDraftContext";
 import { useWorkspace } from "../state/WorkspaceContext";
 import { AgentsPage } from "./AgentsPage";
 import {
+  harnessCostLabel,
   isTimelineActivity,
   isSameHarnessSessionActivity,
   reasoningSummaryState,
@@ -2050,7 +2051,7 @@ export function SessionsPage() {
                             {Object.entries(item.streams).filter(([stream]) => stream !== "reasoning_summary").map(([stream, output]) => <div className="harness-output" key={stream}><small>{stream}</small><pre tabIndex={0}>{output}</pre></div>)}
                             {typeof item.payload.diff === "string" && item.payload.diff && <div className="harness-output diff"><small>Unified diff</small><pre tabIndex={0}>{item.payload.diff}</pre></div>}
                             {item.kind && ["command", "tool", "web_search", "browser", "image", "skill", "hook", "review", "subagent"].includes(item.kind) && Object.keys(item.payload).length > 0 && <details className="harness-structured-details"><summary>Arguments and result details</summary><pre className="harness-structured" tabIndex={0}>{JSON.stringify(item.payload, null, 2)}</pre></details>}
-                            {item.usage && <small>{item.usage.totalTokens.toLocaleString()} tokens{item.usage.reasoningTokens ? ` · ${item.usage.reasoningTokens.toLocaleString()} reasoning` : ""}{item.usage.costUsd ? ` · $${item.usage.costUsd.toFixed(4)}` : ""}{item.usage.durationMs ? ` · ${(item.usage.durationMs / 1000).toFixed(1)}s` : ""}</small>}
+                            {item.usage && <small>{item.usage.totalTokens.toLocaleString()} tokens{item.usage.reasoningTokens ? ` · ${item.usage.reasoningTokens.toLocaleString()} reasoning` : ""}{harnessCostLabel(item) ? ` · ${harnessCostLabel(item)}` : ""}{item.usage.durationMs ? ` · ${(item.usage.durationMs / 1000).toFixed(1)}s` : ""}</small>}
                             {item.artifactIds.length > 0 && <div className="scope-chip-list">{item.artifactIds.map((id) => <span title={id} key={id}>Artifact {id.slice(0, 8)}</span>)}</div>}
                             {item.kind === "subagent" && item.status === "running" && selectedHarness?.capabilities?.subagentControl && <button className="button quiet" type="button" disabled={harnessControlBusy} onClick={() => void stopSubagent(item)}>Stop subagent</button>}
                             {item.type === "checkpoint" && selectedHarness?.capabilities?.checkpointRewind && <button className="button quiet" type="button" disabled={harnessControlBusy || (item.sessionId === harnessSessionId && harnessActivity?.busy)} title={item.sessionId === harnessSessionId && harnessActivity?.busy ? "Checkpoint rewind is available while the session is idle" : undefined} onClick={() => void rewindCheckpoint(item)}>Rewind files here</button>}

--- a/ui/src/pages/harnessActivity.test.ts
+++ b/ui/src/pages/harnessActivity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { HarnessActivityEvent, HarnessSessionActivity } from "../api/types";
 import {
   finalAssistantContent,
+  harnessCostLabel,
   isSameHarnessSessionActivity,
   isTimelineActivity,
   reasoningSummaryState,
@@ -207,5 +208,40 @@ describe("harness activity presentation", () => {
 
     expect(reasoningSummaryState(item)).toBe("available");
     expect(reasoningSummaryText(item)).toBe("Safe stream");
+  });
+
+  it("labels catalog-derived Codex cost as an API-equivalent estimate", () => {
+    const usage = {
+      inputTokens: 3,
+      outputTokens: 2,
+      totalTokens: 5,
+      cachedInputTokens: 0,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+      reasoningTokens: 0,
+      costUsd: 0.0000375,
+      turnCount: 0,
+      modelUsage: {},
+      rateLimit: {},
+    };
+    const base = {
+      assistantId: "assistant-1",
+      key: "turn-1:usage",
+      type: "usage",
+      title: "usage",
+      sequence: 1,
+      streams: {},
+      payload: {},
+      artifactIds: [],
+      usage,
+    };
+
+    expect(harnessCostLabel({ ...base, vendor: "codex_app_server" })).toBe(
+      "≈$0.000038 API equivalent",
+    );
+    expect(harnessCostLabel({ ...base, vendor: "claude_agent_sdk" })).toBe(
+      "$0.000038",
+    );
+    expect(harnessCostLabel({ ...base, usage: { ...usage, costUsd: 0 } })).toBeUndefined();
   });
 });

--- a/ui/src/pages/harnessActivity.ts
+++ b/ui/src/pages/harnessActivity.ts
@@ -178,3 +178,14 @@ export function shouldShowActivityKind(item: HarnessActivityItem): boolean {
   const normalize = (value: string) => value.toLowerCase().replaceAll(/[_\s-]/g, "");
   return normalize(item.kind) !== normalize(item.title);
 }
+
+export function harnessCostLabel(item: HarnessActivityItem): string | undefined {
+  const cost = item.usage?.costUsd;
+  if (!cost) return undefined;
+  const precision = cost < 0.0001 ? 6 : 4;
+  const scale = 10 ** precision;
+  const displayed = (Math.round(cost * scale) / scale).toFixed(precision);
+  return item.vendor === "codex_app_server"
+    ? `≈$${displayed} API equivalent`
+    : `$${displayed}`;
+}

--- a/ui/src/state/WorkspaceContext.test.ts
+++ b/ui/src/state/WorkspaceContext.test.ts
@@ -15,7 +15,9 @@ describe("evolveRunFromEvent", () => {
     expect(run).toMatchObject({ status: "running", totalTasks: 2 });
     run = evolveRunFromEvent(run, event("task.completed", 3, { task_id: "one" }));
     expect(run.completedTasks).toBe(1);
-    run = evolveRunFromEvent(run, event("run.completed", 4, { cost_usd: 1.25 }));
+    run = evolveRunFromEvent(run, event("harness.usage", 4, { run_cost_usd: 0.0000375 }));
+    expect(run.spentUsd).toBe(0.0000375);
+    run = evolveRunFromEvent(run, event("run.completed", 5, { cost_usd: 1.25 }));
     expect(run).toMatchObject({ status: "complete", completedTasks: 2, spentUsd: 1.25 });
   });
 

--- a/ui/src/state/WorkspaceContext.tsx
+++ b/ui/src/state/WorkspaceContext.tsx
@@ -72,6 +72,14 @@ export function evolveRunFromEvent(current: AgentRunSummary, event: RunEvent): A
   }
   if (event.kind === "run.waiting_approval") return { ...base, status: "waiting_approval" };
   if (event.kind === "run.stop_requested") return { ...base, status: "cancelling" };
+  if (event.kind === "harness.usage") {
+    return {
+      ...base,
+      spentUsd: typeof event.payload.run_cost_usd === "number"
+        ? event.payload.run_cost_usd
+        : current.spentUsd,
+    };
+  }
   if (event.kind === "run.completed") {
     return {
       ...base,


### PR DESCRIPTION
## Summary
- add a versioned model-pricing catalog for the Codex harness
- calculate model costs from recorded token usage
- roll execution and chat costs into project totals

## Validation
- backend tests: 533 passed, 5 skipped
- frontend tests: 221 passed
- frontend build, lint, formatting, and mypy passed