### PR TITLE
fix: guarantee Playwright in frozen Core

### DIFF
--- a/scripts/build_nebula_core.py
+++ b/scripts/build_nebula_core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import importlib
 import os
 import shutil
 import subprocess
@@ -21,6 +22,28 @@ if __package__ in {None, ""}:
 from scripts.generate_third_party_notices import generate_notices
 from scripts.nebula3_version import check_versions
 from scripts.package_audit import FORBIDDEN_MODULES, inspect_pyinstaller_binary
+
+
+REQUIRED_RUNTIME_IMPORTS = ("playwright.sync_api",)
+
+
+def require_runtime_imports() -> None:
+    """Fail before freezing when the Poetry environment is out of date."""
+
+    missing: list[str] = []
+    for module in REQUIRED_RUNTIME_IMPORTS:
+        try:
+            importlib.import_module(module)
+        except ModuleNotFoundError as exc:
+            if exc.name and (exc.name == module or module.startswith(f"{exc.name}.")):
+                missing.append(module)
+                continue
+            raise
+    if missing:
+        raise RuntimeError(
+            "required Core dependencies are not installed: "
+            f"{', '.join(missing)}; run `poetry install --with dev` and rebuild"
+        )
 
 
 def macos_codesign_arguments(
@@ -112,6 +135,7 @@ def stage_runtime_payload(root: Path) -> tuple[Path, Path]:
 
 def main() -> None:
     root = Path(__file__).resolve().parents[1]
+    require_runtime_imports()
     version = check_versions(root)
     migrations, frontend = stage_runtime_payload(root)
     license_file = root / "LICENSE.md"

--- a/scripts/package_audit.py
+++ b/scripts/package_audit.py
@@ -81,6 +81,10 @@ REQUIRED_MEMBERS = (
     ("regex",),
     ("reportlab",),
     ("PIL",),
+    # URL knowledge rendering must be importable from the frozen Core and its
+    # bundled Node driver must remain executable after extraction.
+    ("playwright.sync_api",),
+    ("playwright/driver/node",),
     ("nebula/v3/BUILD_INFO.json", "nebula.v3.BUILD_INFO.json"),
     ("nebula/v3/migrations/script.py.mako",),
     ("nebula/v3/kali_tool_inventory.py",),

--- a/src/nebula/v3/knowledge.py
+++ b/src/nebula/v3/knowledge.py
@@ -11,6 +11,7 @@ from .diagnostics import record_caught_exception
 
 import hashlib
 import html
+import importlib
 import ipaddress
 import json
 import os
@@ -30,13 +31,6 @@ from urllib.parse import SplitResult, unquote, urljoin, urlsplit, urlunsplit
 from xml.etree import ElementTree
 
 import httpx
-from playwright.sync_api import (
-    Browser,
-    Error as PlaywrightError,
-    Playwright,
-    Route,
-    sync_playwright,
-)
 from pypdf import PdfReader
 
 from .artifacts import ArtifactIntegrityError, ArtifactStore
@@ -503,6 +497,7 @@ def _is_html_media_type(media_type: str | None, filename: str) -> bool:
 def _render_html_snapshot(document: bytes, *, base_url: str) -> bytes:
     """Run page scripts, then persist only a passive visible-text HTML snapshot."""
 
+    sync_playwright, playwright_error = _load_playwright_runtime()
     try:
         markup = document.decode("utf-8")
     except UnicodeDecodeError:  # diagnostic-expected: bounded replacement
@@ -518,7 +513,7 @@ def _render_html_snapshot(document: bytes, *, base_url: str) -> bytes:
     blocked_error: list[KnowledgeIngestionError] = []
     transferred_bytes = 0
 
-    def route_request(route: Route) -> None:
+    def route_request(route: Any) -> None:
         nonlocal transferred_bytes
         request = route.request
         if request.method != "GET":
@@ -555,7 +550,7 @@ def _render_html_snapshot(document: bytes, *, base_url: str) -> bytes:
 
     try:
         with sync_playwright() as playwright:
-            browser = _launch_chromium(playwright)
+            browser = _launch_chromium(playwright, playwright_error)
             try:
                 context = browser.new_context(
                     accept_downloads=False,
@@ -609,7 +604,7 @@ def _render_html_snapshot(document: bytes, *, base_url: str) -> bytes:
                 browser.close()
     except KnowledgeIngestionError:
         raise
-    except PlaywrightError as exc:
+    except playwright_error as exc:
         raise SourceFetchError("source page could not be rendered") from exc
 
     if not visible_text:
@@ -626,7 +621,24 @@ def _render_html_snapshot(document: bytes, *, base_url: str) -> bytes:
     return snapshot
 
 
-def _launch_chromium(playwright: Playwright) -> Browser:
+def _load_playwright_runtime() -> tuple[Any, type[Exception]]:
+    """Load the optional renderer without making all of Core depend on its import."""
+
+    try:
+        runtime = importlib.import_module("playwright.sync_api")
+    except ModuleNotFoundError as exc:
+        if exc.name and exc.name.split(".", 1)[0] == "playwright":
+            raise BrowserRuntimeUnavailableError(
+                "URL page rendering is unavailable because Playwright is not installed"
+            ) from exc
+        raise
+    return runtime.sync_playwright, runtime.Error
+
+
+def _launch_chromium(
+    playwright: Any,
+    playwright_error: type[Exception],
+) -> Any:
     """Launch managed Playwright Chromium or an explicitly supported system build."""
 
     configured = os.getenv("NEBULA_PLAYWRIGHT_EXECUTABLE", "").strip()
@@ -640,7 +652,7 @@ def _launch_chromium(playwright: Playwright) -> Browser:
         candidates.append(str(candidate))
     try:
         return playwright.chromium.launch(headless=True)
-    except PlaywrightError as default_error:
+    except playwright_error as default_error:
         for command in ("google-chrome", "chromium", "chromium-browser"):
             executable = shutil.which(command)
             if executable and executable not in candidates:
@@ -651,7 +663,7 @@ def _launch_chromium(playwright: Playwright) -> Browser:
                     headless=True,
                     executable_path=executable,
                 )
-            except PlaywrightError:  # diagnostic-expected: try another Chromium
+            except playwright_error:  # diagnostic-expected: try another Chromium
                 continue
         raise BrowserRuntimeUnavailableError(
             "URL page rendering requires Chromium; install Playwright Chromium "

--- a/tests/v3/test_knowledge.py
+++ b/tests/v3/test_knowledge.py
@@ -458,6 +458,20 @@ def test_playwright_snapshot_captures_dynamic_text_through_pinned_routes(
     assert b"<script" not in snapshot
 
 
+def test_missing_playwright_disables_url_rendering_without_breaking_core(monkeypatch):
+    def missing_import(name: str):
+        assert name == "playwright.sync_api"
+        raise ModuleNotFoundError("missing", name="playwright")
+
+    monkeypatch.setattr(knowledge_module.importlib, "import_module", missing_import)
+
+    with pytest.raises(
+        BrowserRuntimeUnavailableError,
+        match="Playwright is not installed",
+    ):
+        knowledge_module._load_playwright_runtime()
+
+
 @pytest.mark.parametrize(
     "url",
     [

--- a/tests/v3/test_packaging.py
+++ b/tests/v3/test_packaging.py
@@ -14,10 +14,12 @@ from scripts.nebula3_version import (
     set_version,
 )
 from scripts.build_nebula_core import macos_codesign_arguments
+from scripts.build_nebula_core import require_runtime_imports
 from scripts.build_nebula_core import stage_runtime_payload
 from scripts.package_audit import (
     ArtifactAuditError,
     FORBIDDEN_MODULES,
+    REQUIRED_MEMBERS,
     inspect_installer_tree,
     validate_members,
 )
@@ -226,6 +228,18 @@ def test_core_build_bundles_dynamic_chroma_runtime_modules():
         assert module in build_script
 
 
+def test_core_build_fails_before_freezing_when_playwright_is_absent(monkeypatch):
+    def missing_import(name: str):
+        raise ModuleNotFoundError("missing", name=name)
+
+    monkeypatch.setattr(
+        "scripts.build_nebula_core.importlib.import_module", missing_import
+    )
+
+    with pytest.raises(RuntimeError, match=r"poetry install --with dev"):
+        require_runtime_imports()
+
+
 def test_core_archive_rejects_nltk_and_its_pyinstaller_runtime_hook():
     for member in ("nltk", "nltk/tokenize/casual.py", "pyi_rth_nltk.py"):
         with pytest.raises(ArtifactAuditError, match="forbidden members"):
@@ -235,6 +249,15 @@ def test_core_archive_rejects_nltk_and_its_pyinstaller_runtime_hook():
 def test_core_archive_requires_timeout_capable_regex_runtime():
     with pytest.raises(ArtifactAuditError, match="required members absent: regex"):
         validate_members(["nebula.v3.cli", "nebula.v3.mcp_gateway"])
+
+
+def test_core_archive_requires_playwright_module_and_driver():
+    complete = {
+        candidate for alternatives in REQUIRED_MEMBERS for candidate in alternatives[:1]
+    }
+    for missing in ("playwright.sync_api", "playwright/driver/node"):
+        with pytest.raises(ArtifactAuditError, match="required members absent"):
+            validate_members(complete - {missing})
 
 
 def test_nebula3_runtime_has_no_conditional_import_fallbacks():
@@ -321,6 +344,8 @@ def test_artifact_member_audit_accepts_only_complete_v3_payload():
             "regex",
             "reportlab",
             "PIL",
+            "playwright.sync_api",
+            "playwright/driver/node",
             "nebula/v3/BUILD_INFO.json",
             "nebula/v3/migrations/script.py.mako",
             "nebula/v3/kali_tool_inventory.py",


### PR DESCRIPTION
## Summary

- avoid crashing all of Core when the optional URL renderer cannot import
- fail the Core build when the Poetry environment is missing Playwright
- require both the Playwright Python API and bundled driver in package audits
- cover missing-runtime behavior and package preflight with regression tests

## Validation

- 50 focused knowledge and packaging tests passed
- Ruff, MyPy, and diagnostics audit passed
- newly frozen Core passed doctor and package audit