### PR TITLE
Fix desktop development startup ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cd nebula
 poetry install --with dev
 poetry run playwright install chromium
 npm --prefix ui ci
-npm --prefix ui run tauri -- dev
+npm --prefix ui run dev:desktop
 ```
 
 The Playwright browser renders JavaScript-driven URL knowledge sources. If Chrome or Chromium is already installed, Nebula can use that system browser instead. The final command builds the local Nebula Core sidecar, starts the UI development server, and opens the native desktop directly from the checkout.

--- a/tests/v3/test_packaging.py
+++ b/tests/v3/test_packaging.py
@@ -316,15 +316,15 @@ def test_core_payload_staging_excludes_caches_and_source_maps(tmp_path):
     assert not (staged_frontend / "assets/app.js.map").exists()
 
 
-def test_tauri_dev_hook_builds_core_and_required_resources_before_vite():
+def test_desktop_dev_prepares_core_before_tauri_and_starts_vite_in_hook():
     tauri = json.loads(
         (ROOT / "ui/src-tauri/tauri.conf.json").read_text(encoding="utf-8")
     )
     package = json.loads((ROOT / "ui/package.json").read_text(encoding="utf-8"))
 
-    assert tauri["build"]["beforeDevCommand"] == "npm run dev:desktop"
+    assert tauri["build"]["beforeDevCommand"] == "npm run dev"
     assert package["scripts"]["dev:desktop"] == (
-        "npm run build && npm run build:core && npm run dev"
+        "npm run build && npm run build:core && tauri dev"
     )
     assert package["scripts"]["build:core"] == (
         "poetry -C .. run python -m scripts.build_nebula_core"

--- a/ui/README.md
+++ b/ui/README.md
@@ -17,13 +17,14 @@ To run the desktop application, install the repository's Poetry development
 dependencies and launch Tauri from the repository root:
 
 ```bash
-npm --prefix ui run tauri -- dev
+npm --prefix ui run dev:desktop
 ```
 
-The Tauri development hook builds the browser workspace, freezes the current
-Nebula Core into the target-triple sidecar path, generates its build metadata
-and third-party notices, and then starts Vite. The first launch therefore takes
-longer than browser-only development with `npm run dev`.
+The desktop launcher first builds the browser workspace, freezes the current
+Nebula Core into the target-triple sidecar path, and generates its build
+metadata and third-party notices. It starts Tauri only after those steps finish;
+Tauri's development hook can then start Vite immediately. The first launch
+therefore takes longer than browser-only development with `npm run dev`.
 
 ## Usage recordings
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:desktop": "npm run build && npm run build:core && npm run dev",
+    "dev:desktop": "npm run build && npm run build:core && tauri dev",
     "build": "tsc -b && vite build",
     "build:core": "poetry -C .. run python -m scripts.build_nebula_core",
     "preview": "vite preview",

--- a/ui/src-tauri/tauri.conf.json
+++ b/ui/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "io.nebula.security",
   "mainBinaryName": "nebula-ui",
   "build": {
-    "beforeDevCommand": "npm run dev:desktop",
+    "beforeDevCommand": "npm run dev",
     "devUrl": "http://127.0.0.1:1420",
     "beforeBuildCommand": "npm run build",
     "frontendDist": "../dist"


### PR DESCRIPTION
## Summary

- build the frontend and frozen Core sidecar before starting Tauri development mode
- keep the Tauri development hook limited to starting Vite immediately
- update source-development instructions and guard the launch contract with a packaging test

## Problem

The previous `beforeDevCommand` performed the full frontend and PyInstaller Core build before starting Vite. Tauri compiled and launched the desktop concurrently, so its webview could open against port 1420 before a server existed. Sidecar output changes could also cause additional development restarts, producing multiple blank windows.

## Validation

- `poetry run pytest -q tests/v3/test_packaging.py` (28 passed)
- `npm --prefix ui run build`
- `git diff --check`