### PR TITLE
Bundle Chromium for URL source rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,12 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xvfb
       - run: python -m pip install "poetry==2.1.3"
       - run: poetry install --with dev --no-interaction
+      - name: Stage bundled Playwright Chromium
+        run: |
+          target="$(rustc -vV | sed -n 's/^host: //p')"
+          poetry run python -m scripts.stage_playwright_runtime \
+            ui/src-tauri/resources/playwright-browsers \
+            --target "$target"
       - run: python scripts/nebula3_version.py check
       - run: poetry run pytest -q tests/v3
       - run: poetry run pytest -q packaging/updater/test_generate_manifest.py

--- a/.github/workflows/nebula3-release.yml
+++ b/.github/workflows/nebula3-release.yml
@@ -123,6 +123,9 @@ jobs:
           poetry install --with dev --no-interaction
           npm --prefix ui ci
           python scripts/nebula3_version.py check --expected "$NEBULA_VERSION"
+          poetry run python -m scripts.stage_playwright_runtime \
+            ui/src-tauri/resources/playwright-browsers \
+            --target "${{ matrix.target }}"
       - name: Run Linux release tests
         env:
           NEBULA_UPDATER_PUBLIC_KEY: ${{ secrets.NEBULA_UPDATER_PUBLIC_KEY }}
@@ -273,6 +276,9 @@ jobs:
           apt-get update
           DEBIAN_FRONTEND=noninteractive apt-get install -y xauth xvfb "./release-assets/Nebula-$VERSION-linux-x86_64.deb"
           xvfb-run -a /usr/bin/nebula --self-test
+          browser="$(find /usr -path '*/playwright-browsers/*' -type f \( -name headless_shell -o -name chrome-headless-shell \) -perm /111 -print -quit)"
+          test -n "$browser"
+          "$browser" --headless --no-sandbox --disable-gpu --dump-dom about:blank | grep -F '<html'
           /usr/bin/nebula-core doctor --data-dir /tmp/nebula-clean-doctor --json > /tmp/doctor.json
           grep -F '"mode": "analysis-only"' /tmp/doctor.json
           grep -F '"host_fallback": false' /tmp/doctor.json

--- a/README.md
+++ b/README.md
@@ -94,7 +94,12 @@ npm --prefix ui ci
 npm --prefix ui run dev:desktop
 ```
 
-The Playwright browser renders JavaScript-driven URL knowledge sources. If Chrome or Chromium is already installed, Nebula can use that system browser instead. The final command builds the local Nebula Core sidecar, starts the UI development server, and opens the native desktop directly from the checkout.
+The Playwright browser renders JavaScript-driven URL knowledge sources. Signed
+Linux installers include the locked Chromium headless runtime used by the
+packaged desktop. Source checkouts require the explicit installation step above;
+Nebula can also use an existing system Chrome or Chromium browser. The final
+command builds the local Nebula Core sidecar, starts the UI development server,
+and opens the native desktop directly from the checkout.
 
 <details>
 <summary>Browser-only development and pre-merge checks</summary>

--- a/docs/NEBULA3.md
+++ b/docs/NEBULA3.md
@@ -203,7 +203,10 @@ public-IP-pinned network boundary; private addresses, unsafe redirects, download
 service workers, WebSockets, images, media, and fonts are blocked. Core stores a
 passive visible-text HTML snapshot rather than executable page markup. Non-HTML
 document URLs retain their original bounded bytes. Rendering uses Playwright's
-installed Chromium or a system Chrome/Chromium browser.
+installed Chromium or a system Chrome/Chromium browser. Native Linux installers
+carry the Playwright-version-matched Chromium headless shell as an audited
+application resource, so URL ingestion does not require a separate browser
+installation.
 
 Chroma's local `all-MiniLM-L6-v2` ONNX embedding model is used by default. The first
 index or query downloads and caches approximately 80 MiB; subsequent embedding and

--- a/packaging/RELEASING.md
+++ b/packaging/RELEASING.md
@@ -67,9 +67,10 @@ manual draft creation must complete before a GitHub Release exists.
 
 The tag push starts the preparation workflow on Ubuntu 22.04 x86_64. It builds
 the direct AppImage and managed DEB, audits and self-tests both packages,
-verifies the updater signature against a tampered copy, generates SBOMs and
-checksums, creates GitHub provenance attestations, and runs clean DEB install
-tests on Ubuntu 24.04, Debian 12, and Kali rolling containers.
+smoke-tests the bundled Playwright Chromium headless shell, verifies the updater
+signature against a tampered copy, generates SBOMs and checksums, creates GitHub
+provenance attestations, and runs clean DEB install tests on Ubuntu 24.04,
+Debian 12, and Kali rolling containers.
 
 Record the successful preparation workflow run ID. Then manually run **Create
 Nebula 3 Linux release draft** with the immutable tag and preparation run ID:
@@ -94,6 +95,8 @@ Before publishing the draft, a release manager must verify:
 - updater signatures accept the original AppImage and reject the tampered test;
 - the AppImage and DEB layouts pass `nebula --self-test` and
   `nebula-core doctor --json`;
+- the bundled Playwright Chromium headless shell launches in the clean-install
+  matrix;
 - CycloneDX and SPDX SBOMs, SHA-256 sums, and GitHub provenance attestations are
   present for every required deliverable;
 - the version is marked as a prerelease when it contains a semantic-version

--- a/scripts/package_audit.py
+++ b/scripts/package_audit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 from typing import Iterable
 
@@ -123,6 +124,7 @@ FORBIDDEN_INSTALLER_BINARIES = {
 }
 
 FORBIDDEN_RESIDUE_SUFFIXES = (".pyc", ".pyo", ".js.map", ".css.map")
+PLAYWRIGHT_RUNTIME_MANIFEST = "nebula-playwright-runtime.json"
 
 
 def _normalized(member: str) -> str:
@@ -234,15 +236,71 @@ def inspect_installer_tree(root: Path) -> dict[str, object]:
         missing.append("LICENSE")
     if not has_suffix("/THIRD_PARTY_NOTICES.txt"):
         missing.append("THIRD_PARTY_NOTICES.txt")
+    playwright_manifests = [
+        path for path in files if path.name == PLAYWRIGHT_RUNTIME_MANIFEST
+    ]
+    if len(playwright_manifests) != 1:
+        missing.append("bundled Playwright Chromium manifest")
     if missing:
         raise ArtifactAuditError(
             f"required installer content absent: {', '.join(missing)}"
         )
+    manifest_path = playwright_manifests[0]
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ArtifactAuditError(
+            "bundled Playwright Chromium manifest is invalid"
+        ) from exc
+    executables = manifest.get("executables")
+    licenses = manifest.get("licenses")
+    if (
+        manifest.get("schema") != 1
+        or manifest.get("browser") != "chromium-headless-shell"
+        or not isinstance(manifest.get("playwright_version"), str)
+        or not manifest["playwright_version"]
+        or not isinstance(manifest.get("target"), str)
+        or not manifest["target"]
+        or not isinstance(manifest.get("payload_bytes"), int)
+        or manifest["payload_bytes"] <= 0
+        or not isinstance(executables, list)
+        or not executables
+        or not all(isinstance(value, str) and value for value in executables)
+        or not isinstance(licenses, list)
+        or not licenses
+        or not all(isinstance(value, str) and value for value in licenses)
+    ):
+        raise ArtifactAuditError(
+            "bundled Playwright Chromium manifest has an invalid contract"
+        )
+    runtime_root = manifest_path.parent.resolve()
+    for relative in executables:
+        executable = (runtime_root / relative).resolve()
+        if (
+            not executable.is_relative_to(runtime_root)
+            or not executable.is_file()
+            or not os.access(executable, os.X_OK)
+        ):
+            raise ArtifactAuditError(
+                "bundled Playwright Chromium executable is absent or not executable"
+            )
+    for relative in licenses:
+        license_file = (runtime_root / relative).resolve()
+        if (
+            not license_file.is_relative_to(runtime_root)
+            or not license_file.is_file()
+            or license_file.stat().st_size == 0
+        ):
+            raise ArtifactAuditError(
+                "bundled Playwright Chromium license payload is absent"
+            )
     return {
         "status": "ok",
         "tree": str(root),
         "file_count": len(files),
         "forbidden_path_count": 0,
+        "playwright_executable_count": len(executables),
+        "playwright_license_count": len(licenses),
     }
 
 

--- a/scripts/stage_playwright_runtime.py
+++ b/scripts/stage_playwright_runtime.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Stage the locked Playwright Chromium headless shell for native installers."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+
+MANIFEST_NAME = "nebula-playwright-runtime.json"
+BROWSER_EXECUTABLE_NAMES = {
+    "chrome",
+    "chrome.exe",
+    "chrome-headless-shell",
+    "headless_shell",
+    "headless_shell.exe",
+}
+
+
+class PlaywrightRuntimeStageError(RuntimeError):
+    """The browser payload could not be staged safely."""
+
+
+def _clear_generated_payload(destination: Path) -> None:
+    if destination.name != "playwright-browsers":
+        raise PlaywrightRuntimeStageError(
+            "the Playwright runtime destination must be named playwright-browsers"
+        )
+    if destination.is_symlink():
+        raise PlaywrightRuntimeStageError(
+            "the Playwright runtime destination cannot be a symbolic link"
+        )
+    destination.mkdir(parents=True, exist_ok=True)
+    for child in destination.iterdir():
+        if child.name == ".gitignore":
+            continue
+        if child.is_symlink() or child.is_file():
+            child.unlink()
+        else:
+            shutil.rmtree(child)
+
+
+def _browser_executables(destination: Path) -> list[Path]:
+    candidates: list[Path] = []
+    for path in destination.rglob("*"):
+        if not path.is_file() or not os.access(path, os.X_OK):
+            continue
+        relative = path.relative_to(destination)
+        if path.name.casefold() in BROWSER_EXECUTABLE_NAMES:
+            candidates.append(relative)
+    return sorted(candidates)
+
+
+def _browser_licenses(destination: Path) -> list[Path]:
+    return sorted(
+        path.relative_to(destination)
+        for path in destination.rglob("*")
+        if path.is_file() and path.name.casefold().startswith(("license", "notice"))
+    )
+
+
+def stage_playwright_runtime(
+    destination: Path,
+    *,
+    target: str,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> dict[str, object]:
+    """Download and verify the headless-only Chromium payload."""
+
+    destination = destination.absolute()
+    _clear_generated_payload(destination)
+    destination = destination.resolve()
+    environment = os.environ.copy()
+    environment["PLAYWRIGHT_BROWSERS_PATH"] = str(destination)
+    command = [
+        sys.executable,
+        "-m",
+        "playwright",
+        "install",
+        "--only-shell",
+        "chromium",
+    ]
+    try:
+        run(command, env=environment, check=True, text=True)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise PlaywrightRuntimeStageError(
+            "Playwright Chromium could not be downloaded"
+        ) from exc
+
+    executables = _browser_executables(destination)
+    if not executables:
+        raise PlaywrightRuntimeStageError(
+            "Playwright did not install an executable Chromium headless shell"
+        )
+    licenses = _browser_licenses(destination)
+    if not licenses:
+        raise PlaywrightRuntimeStageError(
+            "Playwright Chromium did not include its required license payload"
+        )
+    files = [path for path in destination.rglob("*") if path.is_file()]
+    payload_bytes = sum(path.stat().st_size for path in files)
+    manifest: dict[str, object] = {
+        "schema": 1,
+        "browser": "chromium-headless-shell",
+        "playwright_version": importlib.metadata.version("playwright"),
+        "target": target,
+        "payload_bytes": payload_bytes,
+        "executables": [path.as_posix() for path in executables],
+        "licenses": [path.as_posix() for path in licenses],
+    }
+    (destination / MANIFEST_NAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("destination", type=Path)
+    parser.add_argument("--target", required=True)
+    arguments = parser.parse_args()
+    manifest = stage_playwright_runtime(
+        arguments.destination,
+        target=arguments.target,
+    )
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/v3/test_packaging.py
+++ b/tests/v3/test_packaging.py
@@ -23,6 +23,10 @@ from scripts.package_audit import (
     inspect_installer_tree,
     validate_members,
 )
+from scripts.stage_playwright_runtime import (
+    PlaywrightRuntimeStageError,
+    stage_playwright_runtime,
+)
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -62,6 +66,20 @@ def test_protected_release_distribution_is_linux_x86_64_only():
         "notarytool",
     ):
         assert unsupported not in workflows
+
+
+def test_release_stages_and_smoke_tests_bundled_playwright_chromium():
+    release = (ROOT / ".github/workflows/nebula3-release.yml").read_text(
+        encoding="utf-8"
+    )
+    continuous_integration = (ROOT / ".github/workflows/ci.yml").read_text(
+        encoding="utf-8"
+    )
+    command = "python -m scripts.stage_playwright_runtime"
+    assert command in release
+    assert command in continuous_integration
+    assert "ui/src-tauri/resources/playwright-browsers" in release
+    assert "--dump-dom about:blank" in release
 
 
 def test_updater_manifest_supports_validated_recovery_with_native_libraries():
@@ -316,6 +334,65 @@ def test_core_payload_staging_excludes_caches_and_source_maps(tmp_path):
     assert not (staged_frontend / "assets/app.js.map").exists()
 
 
+def test_playwright_runtime_staging_keeps_only_verified_generated_payload(tmp_path):
+    destination = tmp_path / "playwright-browsers"
+    destination.mkdir()
+    (destination / ".gitignore").write_text("*\n", encoding="utf-8")
+    (destination / "stale-browser").write_text("stale\n", encoding="utf-8")
+    commands: list[tuple[list[str], str]] = []
+
+    def install(command, *, env, check, text):
+        assert check is True
+        assert text is True
+        runtime = Path(env["PLAYWRIGHT_BROWSERS_PATH"])
+        executable = (
+            runtime / "chromium_headless_shell-test" / "chrome-linux" / "headless_shell"
+        )
+        executable.parent.mkdir(parents=True)
+        executable.write_bytes(b"browser")
+        executable.chmod(0o755)
+        (executable.parent / "LICENSE.headless_shell").write_text(
+            "Chromium license\n",
+            encoding="utf-8",
+        )
+        commands.append((command, env["PLAYWRIGHT_BROWSERS_PATH"]))
+        return subprocess.CompletedProcess(command, 0)
+
+    manifest = stage_playwright_runtime(
+        destination,
+        target="x86_64-unknown-linux-gnu",
+        run=install,
+    )
+
+    assert not (destination / "stale-browser").exists()
+    assert (destination / ".gitignore").is_file()
+    assert manifest["browser"] == "chromium-headless-shell"
+    assert manifest["executables"] == [
+        "chromium_headless_shell-test/chrome-linux/headless_shell"
+    ]
+    assert manifest["licenses"] == [
+        "chromium_headless_shell-test/chrome-linux/LICENSE.headless_shell"
+    ]
+    assert commands[0][0][-3:] == ["install", "--only-shell", "chromium"]
+    assert commands[0][1] == str(destination.resolve())
+
+
+def test_playwright_runtime_staging_rejects_a_symlink_destination(tmp_path):
+    target = tmp_path / "outside"
+    target.mkdir()
+    destination = tmp_path / "playwright-browsers"
+    destination.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(
+        PlaywrightRuntimeStageError,
+        match="cannot be a symbolic link",
+    ):
+        stage_playwright_runtime(
+            destination,
+            target="x86_64-unknown-linux-gnu",
+        )
+
+
 def test_desktop_dev_prepares_core_before_tauri_and_starts_vite_in_hook():
     tauri = json.loads(
         (ROOT / "ui/src-tauri/tauri.conf.json").read_text(encoding="utf-8")
@@ -333,6 +410,10 @@ def test_desktop_dev_prepares_core_before_tauri_and_starts_vite_in_hook():
     assert (
         "../../build/nebula-core-metadata/THIRD_PARTY_NOTICES.txt"
         in tauri["bundle"]["resources"]
+    )
+    assert (
+        tauri["bundle"]["resources"]["resources/playwright-browsers"]
+        == "playwright-browsers"
     )
 
 
@@ -413,12 +494,45 @@ def test_artifact_member_audit_rejects_build_residue():
 def test_installer_tree_gate_requires_legal_files_and_rejects_toolchains(tmp_path):
     binary = tmp_path / "usr/bin"
     legal = tmp_path / "usr/share/doc/nebula"
+    playwright = (
+        tmp_path
+        / "usr/lib/nebula/playwright-browsers"
+        / "chromium_headless_shell-test/chrome-linux"
+    )
     binary.mkdir(parents=True)
     legal.mkdir(parents=True)
+    playwright.mkdir(parents=True)
     for name in ("nebula-ui", "nebula-core"):
         (binary / name).write_bytes(b"binary")
     (legal / "LICENSE").write_text("BSD\n", encoding="utf-8")
     (legal / "THIRD_PARTY_NOTICES.txt").write_text("Notices\n", encoding="utf-8")
+    browser = playwright / "headless_shell"
+    browser.write_bytes(b"browser")
+    browser.chmod(0o755)
+    (playwright / "LICENSE.headless_shell").write_text(
+        "Chromium license\n",
+        encoding="utf-8",
+    )
+    (
+        tmp_path / "usr/lib/nebula/playwright-browsers/nebula-playwright-runtime.json"
+    ).write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "browser": "chromium-headless-shell",
+                "playwright_version": "1.61.0",
+                "target": "x86_64-unknown-linux-gnu",
+                "payload_bytes": 7,
+                "executables": [
+                    "chromium_headless_shell-test/chrome-linux/headless_shell"
+                ],
+                "licenses": [
+                    "chromium_headless_shell-test/chrome-linux/LICENSE.headless_shell"
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
     assert inspect_installer_tree(tmp_path)["status"] == "ok"
 
     (binary / "python3").write_bytes(b"toolchain")

--- a/ui/src-tauri/resources/playwright-browsers/.gitignore
+++ b/ui/src-tauri/resources/playwright-browsers/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/ui/src-tauri/src/sidecar.rs
+++ b/ui/src-tauri/src/sidecar.rs
@@ -2,7 +2,7 @@ use std::{
     fs::{self, File, OpenOptions},
     io::{self, BufRead, BufReader, Read, Write},
     net::{Ipv4Addr, SocketAddrV4, TcpStream},
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::{Child, ChildStderr, ChildStdin, Command, Stdio},
     sync::{Mutex, mpsc},
     thread::JoinHandle,
@@ -26,6 +26,8 @@ const MAX_HEALTH_RESPONSE_BYTES: u64 = 64 * 1024;
 const MAX_STARTUP_LOG_BYTES: usize = 256 * 1024;
 const MAX_PENDING_LOG_BYTES: usize = 16 * 1024;
 const STARTUP_LOG_NAME: &str = "nebula-core-startup.log";
+const PLAYWRIGHT_RESOURCE_DIRECTORY: &str = "playwright-browsers";
+const PLAYWRIGHT_RESOURCE_MANIFEST: &str = "nebula-playwright-runtime.json";
 const LOG_TRUNCATED_MARKER: &[u8] = b"\n[nebula] startup log truncated at 256 KiB\n";
 const TRUSTED_SYSTEM_PATH: &str =
     "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/homebrew/bin";
@@ -189,6 +191,26 @@ fn sibling_sidecar_path() -> Result<PathBuf, String> {
         return Err("the configured Nebula Core sidecar is not a file".to_string());
     }
     Ok(resolved)
+}
+
+fn bundled_playwright_browsers_path(resource_dir: &Path) -> Result<Option<PathBuf>, String> {
+    let candidate = resource_dir.join(PLAYWRIGHT_RESOURCE_DIRECTORY);
+    if !candidate.join(PLAYWRIGHT_RESOURCE_MANIFEST).is_file() {
+        return Ok(None);
+    }
+    let resolved_resource_dir = resource_dir
+        .canonicalize()
+        .map_err(|error| format!("cannot resolve the Nebula resource directory: {error}"))?;
+    let resolved = candidate
+        .canonicalize()
+        .map_err(|error| format!("cannot resolve the bundled Playwright runtime: {error}"))?;
+    if !resolved.is_dir() || !resolved.starts_with(&resolved_resource_dir) {
+        return Err(
+            "refusing to use a bundled Playwright runtime outside the application resources"
+                .to_string(),
+        );
+    }
+    Ok(Some(resolved))
 }
 
 fn secure_token() -> Result<String, String> {
@@ -843,6 +865,11 @@ fn launch(app: &AppHandle) -> Result<ManagedBackend, String> {
     let settings_path = app_data_dir.join("diagnostics-settings.json");
     let startup_log_path = log_dir.join(STARTUP_LOG_NAME);
     let mut startup_log_file = open_startup_log(&startup_log_path)?;
+    let resource_dir = app
+        .path()
+        .resource_dir()
+        .map_err(|error| format!("cannot locate the Nebula resource directory: {error}"))?;
+    let playwright_browsers = bundled_playwright_browsers_path(&resource_dir)?;
 
     let mut command = Command::new(sidecar);
     command
@@ -864,6 +891,10 @@ fn launch(app: &AppHandle) -> Result<ManagedBackend, String> {
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+
+    if let Some(path) = playwright_browsers {
+        command.env("PLAYWRIGHT_BROWSERS_PATH", path);
+    }
 
     for name in SIDECAR_ENV_ALLOWLIST {
         if let Some(value) = std::env::var_os(name) {
@@ -1281,6 +1312,35 @@ mod tests {
             "nebula-core"
         };
         assert_eq!(Path::new(name).components().count(), 1);
+    }
+
+    #[test]
+    fn bundled_playwright_runtime_requires_a_manifest_inside_resources() {
+        let directory = std::env::temp_dir().join(format!(
+            "nebula-playwright-resource-test-{}",
+            secure_token().expect("token generation should work")
+        ));
+        let browsers = directory.join(PLAYWRIGHT_RESOURCE_DIRECTORY);
+        fs::create_dir_all(&browsers).expect("browser resource should be created");
+        assert_eq!(
+            bundled_playwright_browsers_path(&directory)
+                .expect("an absent manifest should be accepted"),
+            None
+        );
+        fs::write(
+            browsers.join(PLAYWRIGHT_RESOURCE_MANIFEST),
+            b"{\"schema\":1}\n",
+        )
+        .expect("browser manifest should be written");
+        assert_eq!(
+            bundled_playwright_browsers_path(&directory).expect("a bundled runtime should resolve"),
+            Some(
+                browsers
+                    .canonicalize()
+                    .expect("browser resource should canonicalize")
+            )
+        );
+        fs::remove_dir_all(directory).expect("browser resource should be removed");
     }
 
     #[cfg(unix)]

--- a/ui/src-tauri/tauri.conf.json
+++ b/ui/src-tauri/tauri.conf.json
@@ -49,7 +49,8 @@
     "licenseFile": "../../LICENSE.md",
     "resources": {
       "../../LICENSE.md": "licenses/LICENSE.md",
-      "../../build/nebula-core-metadata/THIRD_PARTY_NOTICES.txt": "licenses/THIRD_PARTY_NOTICES.txt"
+      "../../build/nebula-core-metadata/THIRD_PARTY_NOTICES.txt": "licenses/THIRD_PARTY_NOTICES.txt",
+      "resources/playwright-browsers": "playwright-browsers"
     },
     "shortDescription": "Local-first security engagement workspace",
     "longDescription": "Nebula provides a zero-setup security workbench with policy-controlled automation and evidence.",


### PR DESCRIPTION
## Summary

- bundle a Playwright-matched Chromium headless shell in Linux release packages
- configure the managed Nebula Core sidecar to use the bundled browser runtime
- audit packaged browser executables and licensing, and smoke-test Chromium during release builds
- document the bundled runtime and keep generated browser payloads out of git

The browser toolbar quick-add is already present on `main`; this PR completes its URL-rendering dependency.

## Validation

- Python: 559 passed, 5 skipped
- UI: 224 passed
- Rust: 28 passed
- built and audited the Debian package
- launched the extracted bundled Chromium and rendered a blank page