### PR TITLE
Raise URL render resource limit to 50 MiB

### DIFF
--- a/src/nebula/v3/knowledge.py
+++ b/src/nebula/v3/knowledge.py
@@ -46,8 +46,8 @@ CHUNK_OVERLAP_CHARACTERS = 180
 INGESTION_VERSION = "nebula.knowledge.v1"
 MAX_SOURCE_URL_LENGTH = 2_048
 MAX_SOURCE_REDIRECTS = 5
-MAX_RENDER_RESOURCE_BYTES = 8 * 1024 * 1024
-MAX_RENDER_TOTAL_BYTES = 40 * 1024 * 1024
+MAX_RENDER_RESOURCE_BYTES = 50 * 1024 * 1024
+MAX_RENDER_TOTAL_BYTES = 50 * 1024 * 1024
 RENDER_SETTLE_MILLISECONDS = 1_500
 GLOBAL_LIBRARY_ARTIFACT_OWNER = "global-library"
 
@@ -575,7 +575,8 @@ def _render_html_snapshot(document: bytes, *, base_url: str) -> bytes:
             transferred_bytes += len(resource.data)
             if transferred_bytes > MAX_RENDER_TOTAL_BYTES:
                 raise DocumentTooLargeError(
-                    "rendered page resources exceed the 40 MiB limit"
+                    "rendered page resources exceed the "
+                    f"{MAX_RENDER_TOTAL_BYTES // (1024 * 1024)} MiB limit"
                 )
             route.fulfill(
                 status=200,

--- a/tests/v3/test_knowledge.py
+++ b/tests/v3/test_knowledge.py
@@ -458,6 +458,13 @@ def test_playwright_snapshot_captures_dynamic_text_through_pinned_routes(
     assert b"<script" not in snapshot
 
 
+def test_playwright_remote_resource_budget_is_50_mib():
+    expected = 50 * 1024 * 1024
+
+    assert knowledge_module.MAX_RENDER_RESOURCE_BYTES == expected
+    assert knowledge_module.MAX_RENDER_TOTAL_BYTES == expected
+
+
 def test_missing_playwright_disables_url_rendering_without_breaking_core(monkeypatch):
     def missing_import(name: str):
         assert name == "playwright.sync_api"


### PR DESCRIPTION
## Summary

- raise the per-resource limit for JavaScript-rendered URL sources from 8 MiB to 50 MiB
- raise the aggregate rendered-resource budget from 40 MiB to 50 MiB so a maximum-sized resource is usable
- derive the operator-facing aggregate limit message from the configured constant
- add regression coverage for both limits

The separate 20 MiB persisted-document limit is unchanged.

## Validation

- `poetry run pytest -q tests/v3`: 561 passed, 5 skipped
- `poetry run pytest -q tests/v3/test_knowledge.py`: 23 passed
- Ruff lint and format checks passed