### PR TITLE
Add signed APT repository release flow

### DIFF
--- a/.agents/skills/release-nebula-apt/SKILL.md
+++ b/.agents/skills/release-nebula-apt/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: release-nebula-apt
+description: Validate, promote, build, sign, test, or publish Nebula Linux DEB releases through the public signed APT repository. Use for BerylliumSec/nebula-apt, stable or prerelease APT channels, archive signing keys, GitHub Pages deployment, package install or upgrade testing, and changes to packaging/repositories/nebula-apt.
+---
+
+# Release Nebula APT
+
+Use `packaging/RELEASING.md` as the release contract and
+`packaging/repositories/nebula-apt` as the external repository scaffold. Treat
+release tags, published assets, attestations, and promoted channel entries as
+immutable.
+
+## Guardrails
+
+- Accept only a published `nebula-v3.*` release and its
+  `Nebula-VERSION-linux-x86_64.deb`.
+- Map semantic versions with a prerelease suffix only to `prerelease`; map
+  versions without one only to `stable`.
+- Verify the release-provided SHA-256 and GitHub provenance attestation before
+  changing `channels.json`. Match the checksum filename exactly; similarly
+  prefixed SBOM filenames are separate assets.
+- Validate `Package`, `Version`, and `Architecture` from DEB metadata. Do not
+  pass `--arch` to `dpkg-scanpackages`: Nebula's managed asset ends in
+  `linux-x86_64.deb`, while that option filters Debian-style filenames ending
+  in `_amd64.deb`.
+- Retain the current and previous package in each channel so CI tests a real
+  upgrade.
+- Require every promotion to advance semantic-version precedence. Reject
+  downgrades, duplicate versions, and any change to an already-recorded tag.
+- Keep the OpenPGP primary key and revocation certificate offline. Put only an
+  exported dedicated signing subkey and its passphrase in the protected
+  `apt-release` environment.
+- Never commit or upload a private key, passphrase, token, `.env` file, decrypted
+  credential, or signing home directory.
+- Commit the public archive key only after its fingerprint is verified through
+  an independent channel.
+- Do not push a promotion branch, open or merge a pull request, publish Pages,
+  replace an asset, or repoint a tag unless the user explicitly authorizes that
+  external change.
+
+## Change the repository source
+
+When editing the scaffold, run:
+
+```console
+python -m unittest discover -s packaging/repositories/nebula-apt/tests -v
+sh -n packaging/repositories/nebula-apt/scripts/build-repository.sh
+sh -n packaging/repositories/nebula-apt/scripts/smoke-test.sh
+```
+
+Review every workflow for least-privilege permissions and pinned action commit
+SHAs. Validate `channels.json` before any job can access `apt-release`. Confirm
+that signing material is created under the runner temporary directory and that
+the job never uploads it as an artifact.
+
+## Promote a release
+
+1. Confirm the source GitHub release is published, immutable, and has the
+   expected stable or prerelease flag.
+2. Confirm the managed DEB digest matches `SHA256SUMS-linux-x64.txt`.
+3. Verify its GitHub attestation against `BerylliumSec/nebula`.
+4. Dispatch `promote.yml` in `BerylliumSec/nebula-apt` with the exact tag and
+   channel.
+5. Review the generated `channels.json` pull request. It must contain only the
+   new current package and, when present, the prior package for that channel.
+6. Merge only after repository CI passes and explicit publication approval is
+   granted.
+
+## Verify publication
+
+Require `publish.yml` to:
+
+1. Re-download and verify every retained DEB.
+2. Generate `Packages`, `Packages.gz`, `Release`, `Release.gpg`, and `InRelease`
+   for both channels, and make the entire public tree world-readable.
+3. Verify the metadata with the exported public archive key.
+4. Run clean install, upgrade, `nebula --self-test`,
+   `nebula-core doctor --json`, and uninstall checks on Ubuntu, Debian, and
+   Kali.
+5. Deploy the tested directory to GitHub Pages.
+
+After deployment, fetch `InRelease` and `Packages.gz` from Pages, verify the
+signature using a clean keyring, and confirm the promoted version is indexed.

--- a/.agents/skills/release-nebula-apt/agents/openai.yaml
+++ b/.agents/skills/release-nebula-apt/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Nebula APT Releases"
+  short_description: "Promote and publish signed Nebula APT releases"
+  default_prompt: "Use $release-nebula-apt to validate and promote a signed Nebula APT release."

--- a/packaging/RELEASING.md
+++ b/packaging/RELEASING.md
@@ -16,6 +16,9 @@ The protected workflow currently produces Linux x86_64 packages only:
 macOS, Windows, Linux arm64, RPM, Flatpak, Snap, and Homebrew artifacts are not
 built by this workflow and must not be promised in release copy.
 
+Use `.agents/skills/release-nebula-apt/SKILL.md` when promoting a published DEB
+into the signed APT repository.
+
 ## One-time repository setup
 
 Create a protected GitHub environment named `desktop-release`. Require release
@@ -122,3 +125,24 @@ from GitHub, and revalidates checksums, attestations, and the updater signature.
 If a content or release gate fails, leave the draft unpublished, fix the problem
 on a new commit, advance the version, and create a new tag. Do not replace
 artifacts on an existing published release or repoint its tag.
+
+## APT promotion
+
+The public `BerylliumSec/nebula-apt` repository is created from the secret-free
+scaffold in `packaging/repositories/nebula-apt`. Its protected `apt-release`
+environment holds only a dedicated signing subkey and passphrase; keep the
+primary key and revocation certificate offline. Commit only the exported public
+archive key and verify its fingerprint through an independent channel.
+
+After publishing an immutable Nebula release, dispatch `promote.yml` in the APT
+repository with the tag and matching `stable` or `prerelease` channel. The
+workflow verifies the release checksum and GitHub attestation and opens a
+reviewable pull request. Promotions must advance the channel and cannot change
+an already-recorded tag. Merging that pull request validates repository input
+before signing access, builds and signs both APT distributions, retains the
+current and previous package for upgrade testing, runs clean install, upgrade,
+self-test, doctor, and uninstall checks on Ubuntu, Debian, and Kali, and deploys
+the repository through GitHub Pages.
+
+Never upload a private key, passphrase, token, `.env` file, or decrypted
+credential to either public repository or a workflow artifact.

--- a/packaging/apt/README.md
+++ b/packaging/apt/README.md
@@ -1,11 +1,11 @@
-# Signed APT promotion
+# Signed APT support
 
-This directory prepares a static, signed APT repository; it does not create or push `berylliumsec/nebula-apt`.
+`publish-deb.sh` is the low-level single-distribution helper retained for local
+packaging tests. The production public repository source, channel promotion,
+protected signing, upgrade tests, and Pages deployment are maintained in the
+ready-to-copy scaffold at `packaging/repositories/nebula-apt`.
 
-The promotion pipeline must download the immutable managed DEB and its checksum from a published GitHub Release, verify the checksum, and then run:
-
-```console
-./publish-deb.sh Nebula-VERSION-linux-x86_64.deb PUBLIC_REPOSITORY_ROOT GPG_KEY_ID
-```
-
-Publish `PUBLIC_REPOSITORY_ROOT` at `https://berylliumsec.github.io/nebula-apt`. Keep the signing key in a protected release environment and publish only its exported `nebula-archive-keyring.asc`. The DEB owns `/usr/bin/nebula`, which launches the bundled desktop, and `/usr/bin/nebula-core`, which provides administration and diagnostics. The managed desktop build never invokes the Tauri updater.
+The production workflow downloads only managed DEBs from immutable published
+Nebula releases, verifies release checksums and GitHub provenance attestations,
+and signs metadata with a dedicated subkey from the external repository’s
+protected `apt-release` environment. No private signing material belongs here.

--- a/packaging/repositories/nebula-apt/.github/workflows/ci.yml
+++ b/packaging/repositories/nebula-apt/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Validate APT repository source
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Validate promotion policy
+        run: |
+          python scripts/channel_policy.py channels.json
+          python -m unittest discover -s tests -v
+      - name: Validate shell entry points
+        run: |
+          sh -n scripts/build-repository.sh
+          sh -n scripts/smoke-test.sh
+      - name: Reject private credential material
+        run: |
+          test -z "$(find . -type f \( -name '*.key' -o -name '*.p8' -o -name '*.p12' -o -name '.env' \) -print)"
+          if git grep -E -- 'BEGIN (PGP )?PRIVATE KEY'; then
+            printf 'private key material is forbidden\n' >&2
+            exit 1
+          fi

--- a/packaging/repositories/nebula-apt/.github/workflows/promote.yml
+++ b/packaging/repositories/nebula-apt/.github/workflows/promote.yml
@@ -1,0 +1,92 @@
+name: Propose APT channel promotion
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Published immutable nebula-v3.* tag
+        required: true
+        type: string
+      channel:
+        description: APT distribution to update
+        required: true
+        type: choice
+        options:
+          - stable
+          - prerelease
+
+permissions:
+  contents: write
+  pull-requests: write
+  attestations: read
+
+concurrency:
+  group: apt-promote-${{ inputs.channel }}
+  cancel-in-progress: false
+
+jobs:
+  propose:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Validate the existing channel manifest
+        run: python scripts/channel_policy.py channels.json
+      - name: Validate the published release and managed DEB
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.release_tag }}
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          case "$TAG" in nebula-v3.*) ;; *) exit 1 ;; esac
+          version="${TAG#nebula-v}"
+          case "$CHANNEL" in
+            stable)
+              case "$version" in
+                *-*) printf 'prerelease version cannot enter stable\n' >&2; exit 1 ;;
+              esac
+              ;;
+            prerelease)
+              case "$version" in
+                *-*) ;;
+                *) printf 'stable version cannot enter prerelease\n' >&2; exit 1 ;;
+              esac
+              ;;
+          esac
+          release="$(gh api "repos/BerylliumSec/nebula/releases/tags/$TAG")"
+          test "$(jq -r .draft <<<"$release")" = false
+          test "$(jq -r .prerelease <<<"$release")" = "$([ "$CHANNEL" = prerelease ] && echo true || echo false)"
+          asset="Nebula-$version-linux-x86_64.deb"
+          digest="$(jq -r --arg asset "$asset" '.assets[] | select(.name == $asset) | .digest' <<<"$release")"
+          sha256="${digest#sha256:}"
+          test "${#sha256}" -eq 64
+          install -d -m 0755 release
+          gh release download "$TAG" --repo BerylliumSec/nebula --dir release \
+            --pattern "$asset" --pattern SHA256SUMS-linux-x64.txt
+          python scripts/verify_release_checksum.py \
+            --checksums release/SHA256SUMS-linux-x64.txt \
+            --asset "release/$asset" \
+            --sha256 "$sha256"
+          gh attestation verify "release/$asset" --repo BerylliumSec/nebula
+          python scripts/promote.py --channel "$CHANNEL" --tag "$TAG" --sha256 "$sha256"
+      - name: Push a reviewable promotion branch and open a pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.release_tag }}
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          branch="promote/$CHANNEL/$TAG"
+          git config user.name github-actions
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git checkout -b "$branch"
+          git add channels.json
+          git commit -m "Promote $TAG to $CHANNEL"
+          git push origin "$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "Promote $TAG to APT $CHANNEL" \
+            --body "Verified release checksum and GitHub build attestation. Merging publishes and smoke-tests the signed APT repository."

--- a/packaging/repositories/nebula-apt/.github/workflows/publish.yml
+++ b/packaging/repositories/nebula-apt/.github/workflows/publish.yml
@@ -1,0 +1,132 @@
+name: Publish signed APT repository
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - channels.json
+      - nebula-archive-keyring.asc
+      - scripts/**
+      - .github/workflows/publish.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  attestations: read
+
+concurrency:
+  group: apt-pages
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Validate source before granting signing access
+        run: |
+          python scripts/channel_policy.py channels.json
+          python -m unittest discover -s tests -v
+          sh -n scripts/build-repository.sh
+          sh -n scripts/smoke-test.sh
+          test -s nebula-archive-keyring.asc
+          test "$(gpg --show-keys --with-colons nebula-archive-keyring.asc | awk -F: '$1 == "pub" { count++ } END { print count+0 }')" -eq 1
+
+  build-and-test:
+    needs: validate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    environment: apt-release
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install repository tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y apt-utils dpkg-dev gnupg jq
+      - name: Import the protected signing subkey
+        env:
+          APT_SIGNING_SUBKEY: ${{ secrets.APT_SIGNING_SUBKEY }}
+          APT_SIGNING_PASSPHRASE: ${{ secrets.APT_SIGNING_PASSPHRASE }}
+        run: |
+          test -n "$APT_SIGNING_SUBKEY"
+          test -n "$APT_SIGNING_PASSPHRASE"
+          export GNUPGHOME="$RUNNER_TEMP/gnupg"
+          install -d -m 0700 "$GNUPGHOME"
+          printf '%s' "$APT_SIGNING_SUBKEY" | gpg --batch --import
+          printf '%s' "$APT_SIGNING_PASSPHRASE" >"$RUNNER_TEMP/gpg-passphrase"
+          chmod 0600 "$RUNNER_TEMP/gpg-passphrase"
+          test -s nebula-archive-keyring.asc
+          secret_keys="$(gpg --batch --with-colons --list-secret-keys)"
+          test "$(awk -F: '$1 == "sec" { count++ } END { print count+0 }' <<<"$secret_keys")" -eq 1
+          test "$(awk -F: '$1 == "sec" && $15 == "#" { count++ } END { print count+0 }' <<<"$secret_keys")" -eq 1
+          test "$(awk -F: '$1 ~ /^s(ec|sb)$/ && $15 == "+" { count++ } END { print count+0 }' <<<"$secret_keys")" -eq 1
+          test "$(awk -F: '$1 == "ssb" && $12 ~ /s/ && $15 == "+" { count++ } END { print count+0 }' <<<"$secret_keys")" -eq 1
+          test "$(gpg --show-keys --with-colons nebula-archive-keyring.asc | awk -F: '$1 == "pub" { count++ } END { print count+0 }')" -eq 1
+          secret_fingerprint="$(awk -F: '$1 == "fpr" { print $10; exit }' <<<"$secret_keys")"
+          public_fingerprint="$(gpg --show-keys --with-colons nebula-archive-keyring.asc | awk -F: '$1 == "fpr" { print $10; exit }')"
+          test -n "$secret_fingerprint"
+          test "$secret_fingerprint" = "$public_fingerprint"
+          key="$(awk -F: '$1 == "sec" { print $5; exit }' <<<"$secret_keys")"
+          test -n "$key"
+          {
+            printf 'GNUPGHOME=%s\n' "$GNUPGHOME"
+            printf 'APT_SIGNING_KEY=%s\n' "$key"
+            printf 'APT_SIGNING_PASSPHRASE_FILE=%s\n' "$RUNNER_TEMP/gpg-passphrase"
+          } >>"$GITHUB_ENV"
+      - name: Download and verify every retained release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          install -d -m 0755 downloads
+          jq -c '.channels[][]' channels.json | while IFS= read -r entry; do
+            tag="$(jq -r .tag <<<"$entry")"
+            asset="$(jq -r .asset <<<"$entry")"
+            expected="$(jq -r .sha256 <<<"$entry")"
+            gh release download "$tag" --repo BerylliumSec/nebula \
+              --dir downloads --pattern "$asset" --skip-existing
+            test "$(sha256sum "downloads/$asset" | cut -d " " -f 1)" = "$expected"
+            gh attestation verify "downloads/$asset" --repo BerylliumSec/nebula
+          done
+      - name: Build and verify signed repository metadata
+        run: |
+          scripts/build-repository.sh channels.json downloads public "$APT_SIGNING_KEY"
+          gpg --dearmor <public/nebula-archive-keyring.asc >archive.gpg
+          for channel in stable prerelease; do
+            gpgv --keyring ./archive.gpg \
+              "public/dists/$channel/Release.gpg" \
+              "public/dists/$channel/Release"
+          done
+          test "$(gpg --show-keys --with-colons nebula-archive-keyring.asc | awk -F: '$1 == "fpr" { print $10; exit }')" = \
+               "$(gpg --show-keys --with-colons public/nebula-archive-keyring.asc | awk -F: '$1 == "fpr" { print $10; exit }')"
+      - name: Smoke-test clean install, upgrade, doctor, and uninstall
+        run: scripts/smoke-test.sh public channels.json
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: public
+      - name: Remove signing material
+        if: always()
+        run: |
+          rm -f "$RUNNER_TEMP/gpg-passphrase"
+          rm -rf "$RUNNER_TEMP/gnupg"
+
+  deploy:
+    needs: build-and-test
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - name: Deploy the verified signed repository
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/packaging/repositories/nebula-apt/.gitignore
+++ b/packaging/repositories/nebula-apt/.gitignore
@@ -1,0 +1,8 @@
+downloads/
+public/
+archive.gpg
+*.key
+*.p8
+*.p12
+.env
+.env.*

--- a/packaging/repositories/nebula-apt/LICENSE.md
+++ b/packaging/repositories/nebula-apt/LICENSE.md
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2025, berylliumsec
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packaging/repositories/nebula-apt/README.md
+++ b/packaging/repositories/nebula-apt/README.md
@@ -1,0 +1,58 @@
+# Nebula APT repository
+
+This directory is the complete, secret-free source scaffold for the public
+`BerylliumSec/nebula-apt` repository. Copy its contents to that repository; do
+not publish it as a subdirectory of the Nebula website.
+
+The repository has two Debian distributions:
+
+- `stable` accepts semantic versions without a prerelease suffix.
+- `prerelease` accepts semantic versions with a prerelease suffix.
+
+`channels.json` retains the current and previous release in each distribution
+so CI can prove a real package upgrade. Promotions must move a channel forward;
+downgrades and changes to an already-recorded tag are rejected. `promote.yml`
+validates a published, immutable GitHub release and opens a reviewable
+channel-change pull request. Merging that pull request makes `publish.yml`
+validate all repository-controlled input before granting signing access,
+download the DEBs, verify their release checksums and GitHub attestations,
+create signed APT metadata, test fresh install/upgrade/doctor/uninstall on
+Ubuntu, Debian, and Kali, and deploy Pages.
+
+## One-time setup
+
+1. Create the public repository with an initial `main` branch, then protect it.
+2. Copy this scaffold onto a setup branch; do not push directly to `main`.
+3. Generate the archive primary key offline and a dedicated signing subkey.
+   Export the public archive key as `nebula-archive-keyring.asc`, add it to the
+   setup branch, and verify its fingerprint through an independently controlled
+   channel.
+4. Create an `apt-release` environment with required reviewer approval and
+   tag/branch protection. Add:
+   - `APT_SIGNING_SUBKEY`: an ASCII-armored export of a dedicated signing
+     subkey, never the offline primary key.
+   - `APT_SIGNING_PASSPHRASE`: the signing subkey passphrase.
+5. Configure GitHub Pages to use GitHub Actions.
+6. Permit Actions to create pull requests, or have a release manager push the
+   generated promotion branch and open the pull request manually.
+7. Open and review the setup pull request. After merging, approve the initial
+   `apt-release` deployment only after confirming the workflow is the reviewed
+   version and the public-key fingerprint is correct.
+
+Never put a private key, passphrase, token, `.env` file, or decrypted credential
+in this repository or an artifact.
+
+## Consumer setup
+
+After the archive key fingerprint has been independently verified:
+
+```console
+curl -fsSL https://berylliumsec.github.io/nebula-apt/nebula-archive-keyring.asc |
+  sudo gpg --dearmor -o /usr/share/keyrings/nebula-archive-keyring.gpg
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/nebula-archive-keyring.gpg] https://berylliumsec.github.io/nebula-apt stable main" |
+  sudo tee /etc/apt/sources.list.d/nebula.list
+sudo apt update
+sudo apt install nebula
+```
+
+Use `prerelease` in place of `stable` only when prerelease upgrades are wanted.

--- a/packaging/repositories/nebula-apt/channels.json
+++ b/packaging/repositories/nebula-apt/channels.json
@@ -1,0 +1,7 @@
+{
+  "schema": 1,
+  "channels": {
+    "stable": [],
+    "prerelease": []
+  }
+}

--- a/packaging/repositories/nebula-apt/scripts/build-repository.sh
+++ b/packaging/repositories/nebula-apt/scripts/build-repository.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 4 ]; then
+  printf 'usage: %s CHANNELS DOWNLOADS PUBLIC_ROOT GPG_KEY_ID\n' "$0" >&2
+  exit 2
+fi
+
+channels=$1
+downloads=$2
+public=$3
+gpg_key=$4
+
+for command in apt-ftparchive dpkg-deb dpkg-scanpackages gpg jq python3; do
+  command -v "$command" >/dev/null
+done
+test -f "$channels"
+test -d "$downloads"
+test -n "${APT_SIGNING_PASSPHRASE_FILE:-}"
+test -f "$APT_SIGNING_PASSPHRASE_FILE"
+script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+python3 "$script_dir/channel_policy.py" "$channels"
+
+install -d -m 0755 "$public/pool" "$public/dists"
+
+for channel in stable prerelease; do
+  pool="$public/pool/$channel/main/n/nebula"
+  binary="$public/dists/$channel/main/binary-amd64"
+  install -d -m 0755 "$pool" "$binary"
+
+  tab=$(printf '\t')
+  jq -r --arg channel "$channel" \
+    '.channels[$channel][] | [.asset, .version] | @tsv' "$channels" |
+  while IFS="$tab" read -r asset version; do
+    test -n "$asset"
+    test -n "$version"
+    deb="$downloads/$asset"
+    test "$(dpkg-deb -f "$deb" Package)" = nebula
+    test "$(dpkg-deb -f "$deb" Architecture)" = amd64
+    case "$version" in
+      *-*) expected_deb_version="${version%%-*}~${version#*-}" ;;
+      *) expected_deb_version=$version ;;
+    esac
+    test "$(dpkg-deb -f "$deb" Version)" = "$expected_deb_version"
+    install -m 0644 "$deb" "$pool/$asset"
+  done
+
+  (
+    cd "$public"
+    # Upstream release assets use `linux-x86_64.deb`, not Debian's
+    # `_amd64.deb` filename convention. The --arch filter selects by filename
+    # and would silently omit them; package metadata is validated above.
+    dpkg-scanpackages "pool/$channel" /dev/null
+  ) >"$binary/Packages"
+  expected_count=$(jq -r --arg channel "$channel" \
+    '.channels[$channel] | length' "$channels")
+  actual_count=$(awk '/^Package: / { count++ } END { print count+0 }' \
+    "$binary/Packages")
+  if [ "$actual_count" -ne "$expected_count" ]; then
+    printf '%s package index contains %s entries; expected %s\n' \
+      "$channel" "$actual_count" "$expected_count" >&2
+    exit 1
+  fi
+  gzip -n -9 -c "$binary/Packages" >"$binary/Packages.gz"
+
+  release="$public/dists/$channel/Release"
+  apt-ftparchive \
+    -o APT::FTPArchive::Release::Origin=Nebula \
+    -o APT::FTPArchive::Release::Label=Nebula \
+    -o APT::FTPArchive::Release::Suite="$channel" \
+    -o APT::FTPArchive::Release::Codename="$channel" \
+    -o APT::FTPArchive::Release::Architectures=amd64 \
+    -o APT::FTPArchive::Release::Components=main \
+    release "$public/dists/$channel" >"$release"
+
+  gpg --batch --yes --pinentry-mode loopback \
+    --passphrase-file "$APT_SIGNING_PASSPHRASE_FILE" \
+    --local-user "$gpg_key" --armor --detach-sign \
+    --output "$public/dists/$channel/Release.gpg" "$release"
+  gpg --batch --yes --pinentry-mode loopback \
+    --passphrase-file "$APT_SIGNING_PASSPHRASE_FILE" \
+    --local-user "$gpg_key" --armor --clearsign \
+    --output "$public/dists/$channel/InRelease" "$release"
+done
+
+gpg --batch --yes --local-user "$gpg_key" --armor --export \
+  --output "$public/nebula-archive-keyring.asc"
+
+# Repository metadata and packages are public artifacts. Set deterministic
+# modes so APT's unprivileged downloader can read them even if the runner has
+# inherited a restrictive umask from signing-key setup.
+chmod -R u=rwX,go=rX "$public"

--- a/packaging/repositories/nebula-apt/scripts/channel_policy.py
+++ b/packaging/repositories/nebula-apt/scripts/channel_policy.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Validate the immutable Nebula APT channel manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+VERSION = re.compile(
+    r"^(?P<major>0|[1-9][0-9]*)\."
+    r"(?P<minor>0|[1-9][0-9]*)\."
+    r"(?P<patch>0|[1-9][0-9]*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+TAG = re.compile(r"^nebula-v(?P<version>3\..+)$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+CHANNELS = ("stable", "prerelease")
+ENTRY_KEYS = {"tag", "version", "asset", "sha256"}
+
+
+class ChannelPolicyError(ValueError):
+    """Raised when channels.json violates the release policy."""
+
+
+def parse_version(version: str) -> tuple[tuple[int, int, int], tuple[str, ...] | None]:
+    match = VERSION.fullmatch(version)
+    if match is None:
+        raise ChannelPolicyError(f"invalid semantic version: {version!r}")
+    prerelease = match.group("prerelease")
+    identifiers = None if prerelease is None else tuple(prerelease.split("."))
+    if identifiers is not None:
+        for identifier in identifiers:
+            if identifier.isdigit() and len(identifier) > 1 and identifier.startswith("0"):
+                raise ChannelPolicyError(
+                    f"numeric prerelease identifier has a leading zero: {version!r}"
+                )
+    return (
+        (
+            int(match.group("major")),
+            int(match.group("minor")),
+            int(match.group("patch")),
+        ),
+        identifiers,
+    )
+
+
+def compare_versions(left: str, right: str) -> int:
+    left_core, left_prerelease = parse_version(left)
+    right_core, right_prerelease = parse_version(right)
+    if left_core != right_core:
+        return 1 if left_core > right_core else -1
+    if left_prerelease is None or right_prerelease is None:
+        if left_prerelease is right_prerelease:
+            return 0
+        return 1 if left_prerelease is None else -1
+    for left_identifier, right_identifier in zip(
+        left_prerelease, right_prerelease, strict=False
+    ):
+        if left_identifier == right_identifier:
+            continue
+        left_numeric = left_identifier.isdigit()
+        right_numeric = right_identifier.isdigit()
+        if left_numeric and right_numeric:
+            return 1 if int(left_identifier) > int(right_identifier) else -1
+        if left_numeric != right_numeric:
+            return -1 if left_numeric else 1
+        return 1 if left_identifier > right_identifier else -1
+    if len(left_prerelease) == len(right_prerelease):
+        return 0
+    return 1 if len(left_prerelease) > len(right_prerelease) else -1
+
+
+def validate_entry(channel: str, entry: Any) -> dict[str, str]:
+    if not isinstance(entry, dict) or set(entry) != ENTRY_KEYS:
+        raise ChannelPolicyError(f"{channel} entry has unsupported fields")
+    if not all(isinstance(entry[key], str) for key in ENTRY_KEYS):
+        raise ChannelPolicyError(f"{channel} entry fields must be strings")
+
+    tag_match = TAG.fullmatch(entry["tag"])
+    if tag_match is None:
+        raise ChannelPolicyError(f"invalid Nebula 3 tag: {entry['tag']!r}")
+    version = entry["version"]
+    parse_version(version)
+    if tag_match.group("version") != version:
+        raise ChannelPolicyError(f"tag and version disagree: {entry['tag']!r}")
+    if ("-" in version) != (channel == "prerelease"):
+        raise ChannelPolicyError(f"{version!r} does not belong in {channel}")
+    expected_asset = f"Nebula-{version}-linux-x86_64.deb"
+    if entry["asset"] != expected_asset:
+        raise ChannelPolicyError(f"unexpected asset for {version!r}")
+    if SHA256.fullmatch(entry["sha256"]) is None:
+        raise ChannelPolicyError(f"invalid SHA-256 for {version!r}")
+    return entry
+
+
+def validate_payload(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict) or set(payload) != {"schema", "channels"}:
+        raise ChannelPolicyError("channels.json has unsupported top-level fields")
+    if payload["schema"] != 1:
+        raise ChannelPolicyError("unsupported channels.json schema")
+    channels = payload["channels"]
+    if not isinstance(channels, dict) or set(channels) != set(CHANNELS):
+        raise ChannelPolicyError("channels.json must contain stable and prerelease")
+
+    seen_tags: set[str] = set()
+    seen_versions: set[str] = set()
+    for channel in CHANNELS:
+        entries = channels[channel]
+        if not isinstance(entries, list) or len(entries) > 2:
+            raise ChannelPolicyError(f"{channel} must retain at most two releases")
+        previous_version: str | None = None
+        for raw_entry in entries:
+            entry = validate_entry(channel, raw_entry)
+            if entry["tag"] in seen_tags or entry["version"] in seen_versions:
+                raise ChannelPolicyError("release entries must be unique")
+            seen_tags.add(entry["tag"])
+            seen_versions.add(entry["version"])
+            if (
+                previous_version is not None
+                and compare_versions(previous_version, entry["version"]) <= 0
+            ):
+                raise ChannelPolicyError(
+                    f"{channel} releases must be strictly newest-first"
+                )
+            previous_version = entry["version"]
+    return payload
+
+
+def load_channels(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ChannelPolicyError(f"could not read {path}: {error}") from error
+    return validate_payload(payload)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("channels", type=Path, nargs="?", default=Path("channels.json"))
+    arguments = parser.parse_args()
+    try:
+        load_channels(arguments.channels)
+    except ChannelPolicyError as error:
+        parser.error(str(error))
+    print(f"{arguments.channels}: channel policy valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/repositories/nebula-apt/scripts/promote.py
+++ b/packaging/repositories/nebula-apt/scripts/promote.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Record a validated Nebula release in one APT channel."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from channel_policy import (
+    ChannelPolicyError,
+    compare_versions,
+    load_channels,
+    validate_payload,
+)
+
+
+def main() -> int:  # noqa: PLR0915
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--channels", type=Path, default=Path("channels.json"))
+    parser.add_argument("--channel", choices=("stable", "prerelease"), required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--sha256", required=True)
+    arguments = parser.parse_args()
+
+    version = arguments.tag.removeprefix("nebula-v")
+    entry = {
+        "tag": arguments.tag,
+        "version": version,
+        "asset": f"Nebula-{version}-linux-x86_64.deb",
+        "sha256": arguments.sha256,
+    }
+    try:
+        payload = load_channels(arguments.channels)
+        validate_payload(
+            {
+                "schema": 1,
+                "channels": {
+                    arguments.channel: [entry],
+                    "prerelease" if arguments.channel == "stable" else "stable": [],
+                },
+            }
+        )
+    except ChannelPolicyError as error:
+        parser.error(str(error))
+
+    entries = payload["channels"][arguments.channel]
+    for existing in entries:
+        if existing["tag"] == arguments.tag or existing["version"] == version:
+            if existing == entry:
+                parser.error(f"{arguments.tag} is already recorded")
+            parser.error(f"{arguments.tag} conflicts with an immutable channel entry")
+    if entries and compare_versions(version, entries[0]["version"]) <= 0:
+        parser.error(
+            f"promotion must advance {arguments.channel} beyond "
+            f"{entries[0]['version']}"
+        )
+
+    payload["channels"][arguments.channel] = [
+        entry,
+        *entries,
+    ][:2]
+    try:
+        validate_payload(payload)
+    except ChannelPolicyError as error:
+        parser.error(str(error))
+    arguments.channels.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/repositories/nebula-apt/scripts/smoke-test.sh
+++ b/packaging/repositories/nebula-apt/scripts/smoke-test.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 2 ]; then
+  printf 'usage: %s PUBLIC_ROOT CHANNELS\n' "$0" >&2
+  exit 2
+fi
+
+public=$(cd "$1" && pwd)
+channels=$(cd "$(dirname "$2")" && pwd)/$(basename "$2")
+
+for channel in stable prerelease; do
+  count=$(jq -r --arg channel "$channel" '.channels[$channel] | length' "$channels")
+  if [ "$count" -eq 0 ]; then
+    continue
+  fi
+  current_version=$(jq -r --arg channel "$channel" '.channels[$channel][0].version' "$channels")
+  previous=
+  if [ "$count" -gt 1 ]; then
+    previous=$(jq -r --arg channel "$channel" '.channels[$channel][1].asset' "$channels")
+  fi
+  for image in ubuntu:24.04 debian:12-slim kalilinux/kali-rolling:latest; do
+    docker run --rm \
+      -e CHANNEL="$channel" \
+      -e CURRENT_VERSION="$current_version" \
+      -e PREVIOUS="$previous" \
+      -v "$public:/repo:ro" \
+      "$image" sh -euxc '
+        apt-get update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates gnupg xauth xvfb
+        gpg --dearmor </repo/nebula-archive-keyring.asc >/usr/share/keyrings/nebula.gpg
+        printf "deb [arch=amd64 signed-by=/usr/share/keyrings/nebula.gpg] file:/repo %s main\n" "$CHANNEL" \
+          >/etc/apt/sources.list.d/nebula.list
+        apt-get update
+        if [ -n "$PREVIOUS" ]; then
+          DEBIAN_FRONTEND=noninteractive apt-get install -y "/repo/pool/$CHANNEL/main/n/nebula/$PREVIOUS"
+        fi
+        DEBIAN_FRONTEND=noninteractive apt-get install -y nebula
+        expected_version="$CURRENT_VERSION"
+        case "$expected_version" in
+          *-*) expected_version="${expected_version%%-*}~${expected_version#*-}" ;;
+        esac
+        test "$(dpkg-query -W -f="\${Version}" nebula)" = "$expected_version"
+        xvfb-run -a nebula --self-test
+        nebula-core doctor --data-dir /tmp/nebula-doctor --json
+        DEBIAN_FRONTEND=noninteractive apt-get remove -y nebula
+        test ! -e /usr/bin/nebula
+        test ! -e /usr/bin/nebula-ui
+        test ! -e /usr/bin/nebula-core
+      '
+  done
+done

--- a/packaging/repositories/nebula-apt/scripts/verify_release_checksum.py
+++ b/packaging/repositories/nebula-apt/scripts/verify_release_checksum.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Require the release checksum, GitHub digest, and asset bytes to agree."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+from pathlib import Path
+
+
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def checksum_entries(path: Path) -> list[tuple[str, str]]:
+    entries: list[tuple[str, str]] = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if len(line) < 67 or line[64:66] not in {"  ", " *"}:
+            raise ValueError(f"{path}:{line_number}: invalid SHA-256 line")
+        digest = line[:64]
+        filename = line[66:]
+        if SHA256.fullmatch(digest) is None or not filename:
+            raise ValueError(f"{path}:{line_number}: invalid SHA-256 entry")
+        entries.append((filename, digest))
+    return entries
+
+
+def verify(checksums: Path, asset: Path, expected: str) -> None:
+    if SHA256.fullmatch(expected) is None:
+        raise ValueError("expected digest must be 64 lowercase hexadecimal characters")
+    matches = [
+        digest
+        for filename, digest in checksum_entries(checksums)
+        if filename == asset.name
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"{checksums} must contain exactly one entry for {asset.name}"
+        )
+    actual = hashlib.sha256(asset.read_bytes()).hexdigest()
+    if matches[0] != expected or actual != expected:
+        raise ValueError(
+            f"digest disagreement for {asset.name}: "
+            f"release={matches[0]} github={expected} actual={actual}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checksums", type=Path, required=True)
+    parser.add_argument("--asset", type=Path, required=True)
+    parser.add_argument("--sha256", required=True)
+    arguments = parser.parse_args()
+    try:
+        verify(arguments.checksums, arguments.asset, arguments.sha256)
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+    print(f"{arguments.asset}: release checksum and GitHub digest verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/repositories/nebula-apt/tests/test_promote.py
+++ b/packaging/repositories/nebula-apt/tests/test_promote.py
@@ -1,0 +1,228 @@
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class PromotionTests(unittest.TestCase):
+    def run_promotion(
+        self,
+        channels: Path,
+        *,
+        channel: str,
+        tag: str,
+        digest: str = "a" * 64,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                ROOT / "scripts" / "promote.py",
+                "--channels",
+                channels,
+                "--channel",
+                channel,
+                "--tag",
+                tag,
+                "--sha256",
+                digest,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_promotion_keeps_current_and_previous(self):
+        with tempfile.TemporaryDirectory() as directory:
+            channels = Path(directory) / "channels.json"
+            channels.write_text((ROOT / "channels.json").read_text(), encoding="utf-8")
+
+            for version, digest in (
+                ("3.0.0-alpha.7", "a" * 64),
+                ("3.0.0-alpha.9", "b" * 64),
+                ("3.0.0-alpha.10", "c" * 64),
+            ):
+                result = self.run_promotion(
+                    channels,
+                    channel="prerelease",
+                    tag=f"nebula-v{version}",
+                    digest=digest,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+            entries = json.loads(channels.read_text())["channels"]["prerelease"]
+            self.assertEqual(
+                [entry["version"] for entry in entries],
+                ["3.0.0-alpha.10", "3.0.0-alpha.9"],
+            )
+
+    def test_stable_and_prerelease_channels_must_match_version(self):
+        with tempfile.TemporaryDirectory() as directory:
+            channels = Path(directory) / "channels.json"
+            channels.write_text((ROOT / "channels.json").read_text(), encoding="utf-8")
+
+            stable = self.run_promotion(
+                channels,
+                channel="stable",
+                tag="nebula-v3.1.0",
+            )
+            self.assertEqual(stable.returncode, 0, stable.stderr)
+
+            mismatch = self.run_promotion(
+                channels,
+                channel="stable",
+                tag="nebula-v3.1.1-rc.1",
+            )
+            self.assertNotEqual(mismatch.returncode, 0)
+            self.assertIn("does not belong in stable", mismatch.stderr)
+
+    def test_invalid_tag_and_digest_are_rejected_without_changing_channels(self):
+        with tempfile.TemporaryDirectory() as directory:
+            channels = Path(directory) / "channels.json"
+            original = (ROOT / "channels.json").read_text()
+            channels.write_text(original, encoding="utf-8")
+
+            bad_tag = self.run_promotion(
+                channels,
+                channel="stable",
+                tag="nebula-v2.9.0",
+            )
+            self.assertNotEqual(bad_tag.returncode, 0)
+
+            bad_digest = self.run_promotion(
+                channels,
+                channel="stable",
+                tag="nebula-v3.1.0",
+                digest="ABC",
+            )
+            self.assertNotEqual(bad_digest.returncode, 0)
+            self.assertEqual(channels.read_text(), original)
+
+    def test_promotion_rejects_downgrade_and_immutable_tag_change(self):
+        with tempfile.TemporaryDirectory() as directory:
+            channels = Path(directory) / "channels.json"
+            channels.write_text((ROOT / "channels.json").read_text(), encoding="utf-8")
+
+            first = self.run_promotion(
+                channels,
+                channel="prerelease",
+                tag="nebula-v3.0.0-alpha.10",
+            )
+            self.assertEqual(first.returncode, 0, first.stderr)
+            promoted = channels.read_text()
+
+            downgrade = self.run_promotion(
+                channels,
+                channel="prerelease",
+                tag="nebula-v3.0.0-alpha.9",
+            )
+            self.assertNotEqual(downgrade.returncode, 0)
+            self.assertIn("promotion must advance", downgrade.stderr)
+            self.assertEqual(channels.read_text(), promoted)
+
+            changed_digest = self.run_promotion(
+                channels,
+                channel="prerelease",
+                tag="nebula-v3.0.0-alpha.10",
+                digest="b" * 64,
+            )
+            self.assertNotEqual(changed_digest.returncode, 0)
+            self.assertIn("conflicts with an immutable channel entry", changed_digest.stderr)
+            self.assertEqual(channels.read_text(), promoted)
+
+    def test_channel_policy_rejects_unsafe_asset_path(self):
+        with tempfile.TemporaryDirectory() as directory:
+            channels = Path(directory) / "channels.json"
+            channels.write_text(
+                json.dumps(
+                    {
+                        "schema": 1,
+                        "channels": {
+                            "stable": [
+                                {
+                                    "tag": "nebula-v3.1.0",
+                                    "version": "3.1.0",
+                                    "asset": "../../private.key",
+                                    "sha256": "a" * 64,
+                                }
+                            ],
+                            "prerelease": [],
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    ROOT / "scripts" / "channel_policy.py",
+                    channels,
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unexpected asset", result.stderr)
+
+    def test_checksum_verifier_selects_the_exact_deb_entry(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            asset = root / "Nebula-3.0.0-alpha.5-linux-x86_64.deb"
+            asset.write_bytes(b"managed deb")
+            digest = hashlib.sha256(asset.read_bytes()).hexdigest()
+            checksums = root / "SHA256SUMS-linux-x64.txt"
+            checksums.write_text(
+                "\n".join(
+                    (
+                        f"{digest}  {asset.name}",
+                        f"{'b' * 64}  {asset.name}.cyclonedx.json",
+                        f"{'c' * 64}  {asset.name}.spdx.json",
+                    )
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    ROOT / "scripts" / "verify_release_checksum.py",
+                    "--checksums",
+                    checksums,
+                    "--asset",
+                    asset,
+                    "--sha256",
+                    digest,
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            mismatch = subprocess.run(
+                [
+                    sys.executable,
+                    ROOT / "scripts" / "verify_release_checksum.py",
+                    "--checksums",
+                    checksums,
+                    "--asset",
+                    asset,
+                    "--sha256",
+                    "d" * 64,
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(mismatch.returncode, 0)
+            self.assertIn("digest disagreement", mismatch.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/v3/test_packaging.py
+++ b/tests/v3/test_packaging.py
@@ -68,6 +68,52 @@ def test_protected_release_distribution_is_linux_x86_64_only():
         assert unsupported not in workflows
 
 
+def test_apt_repository_scaffold_is_secret_free_and_verifies_promotions():
+    repository = ROOT / "packaging/repositories/nebula-apt"
+    required = (
+        ".github/workflows/ci.yml",
+        ".github/workflows/promote.yml",
+        ".github/workflows/publish.yml",
+        "scripts/build-repository.sh",
+        "scripts/channel_policy.py",
+        "scripts/promote.py",
+        "scripts/smoke-test.sh",
+        "scripts/verify_release_checksum.py",
+        "channels.json",
+    )
+    for relative in required:
+        assert (repository / relative).is_file()
+
+    workflows = "\n".join(
+        (repository / relative).read_text(encoding="utf-8")
+        for relative in (
+            ".github/workflows/promote.yml",
+            ".github/workflows/publish.yml",
+        )
+    )
+    assert "gh attestation verify" in workflows
+    assert "APT_SIGNING_SUBKEY" in workflows
+    assert "scripts/verify_release_checksum.py" in workflows
+    assert "test -s nebula-archive-keyring.asc" in workflows
+    assert 'test "$secret_fingerprint" = "$public_fingerprint"' in workflows
+    assert '$1 == "sec" && $15 == "#"' in workflows
+    assert '$1 == "ssb" && $12 ~ /s/ && $15 == "+"' in workflows
+    assert "needs: validate" in workflows
+    smoke = (repository / "scripts/smoke-test.sh").read_text(encoding="utf-8")
+    for image in ("ubuntu:24.04", "debian:12-slim", "kalilinux/kali-rolling:latest"):
+        assert image in smoke
+    builder = (repository / "scripts/build-repository.sh").read_text(
+        encoding="utf-8"
+    )
+    assert 'dpkg-scanpackages "pool/$channel"' in builder
+    assert "dpkg-scanpackages --arch" not in builder
+    assert 'dpkg-deb -f "$deb" Architecture' in builder
+    assert 'chmod -R u=rwX,go=rX "$public"' in builder
+    assert "BEGIN PGP PRIVATE KEY BLOCK" not in workflows
+    assert "macos-" not in workflows
+    assert "Homebrew" not in workflows
+
+
 def test_release_stages_and_smoke_tests_bundled_playwright_chromium():
     release = (ROOT / ".github/workflows/nebula3-release.yml").read_text(
         encoding="utf-8"

--- a/tests/v3/test_packaging.py
+++ b/tests/v3/test_packaging.py
@@ -102,9 +102,7 @@ def test_apt_repository_scaffold_is_secret_free_and_verifies_promotions():
     smoke = (repository / "scripts/smoke-test.sh").read_text(encoding="utf-8")
     for image in ("ubuntu:24.04", "debian:12-slim", "kalilinux/kali-rolling:latest"):
         assert image in smoke
-    builder = (repository / "scripts/build-repository.sh").read_text(
-        encoding="utf-8"
-    )
+    builder = (repository / "scripts/build-repository.sh").read_text(encoding="utf-8")
     assert 'dpkg-scanpackages "pool/$channel"' in builder
     assert "dpkg-scanpackages --arch" not in builder
     assert 'dpkg-deb -f "$deb" Architecture' in builder


### PR DESCRIPTION
## Summary

- add a secret-free scaffold for the separate BerylliumSec/nebula-apt repository
- verify immutable release checksums and GitHub attestations before promotion
- build and sign stable/prerelease APT channels, retaining current and previous packages
- smoke-test install, upgrade, doctor, and uninstall on Ubuntu, Debian, and Kali
- add an operational APT release skill and update release documentation
- include the alpha.7 libnspr4/libnss3 dependency fix that addresses the alpha.6 release failure

## Validation

- 569 passed, 5 skipped in the full v3 suite
- 33 packaging tests passed
- 6 APT promotion/checksum tests passed
- real published alpha.5 DEB indexed, signed, installed, self-tested, diagnosed, and removed on Ubuntu 24.04, Debian 12, and Kali rolling
- workflow YAML, shell syntax, skill metadata, pinned action SHAs, and secret scan validated

No signing material or other credentials are included.