### PR TITLE
Advance assistant research continuity

### DIFF
--- a/docs/assistant-research-continuity-contract.md
+++ b/docs/assistant-research-continuity-contract.md
@@ -1,0 +1,92 @@
+# Assistant research continuity contract
+
+## Outcome
+
+An operator can move between Terminal, Code, Files, Notes, Findings, and Assistant
+without losing an unsent prompt or replacing previously selected research context.
+The Assistant keeps the primary surface calm while making the exact context,
+runtime boundary, Core-owned memory state, and recovery actions inspectable.
+
+This pass deliberately builds on Nebula's existing durable transcripts, harness
+sessions, approvals, skills, MCP profiles, activity replay, checkpoint rewind,
+artifacts, citations, and engagement scope. It does not add a second agent runtime
+or duplicate those state authorities in the browser.
+
+## Operator journey
+
+The real entry point is Workbench > Assistant. The operator can:
+
+1. Find or start a conversation and recover its unsent device-local draft.
+2. Collect several exact text selections from project surfaces into one context
+   pack, inspect each source, and remove individual items before sending.
+3. Paste, drop, or choose supported images without leaving the composer.
+4. Send a normal turn, or type guidance into the same composer while a steerable
+   harness turn is active.
+5. Inspect Core's authoritative context-window and compaction state without
+   exposing private reasoning.
+6. Copy or quote a durable message, fork at a message, and export the authoritative
+   transcript with session identity, citations, and attachment hashes.
+7. Search saved conversation titles and runtime metadata without hiding the active
+   conversation unexpectedly.
+
+## State authorities
+
+- URL: active Workbench view and durable chat-session identity.
+- Core database: sessions, messages, lineage, context snapshots, citations,
+  attachment metadata, harness activity, and approvals.
+- Harness/provider: live turn execution and advertised capabilities.
+- Workspace context: transient exact selected-text context pack shared between
+  Workbench surfaces; it is hashed only at explicit submission.
+- `sessionStorage`: unsent prompt text keyed by project and conversation. Drafts
+  survive refresh in the current browser tab but do not become a durable transcript
+  or cross-device record.
+- Component state: expanded previews, search query, upload progress, and ephemeral
+  copy/export feedback.
+
+## Acceptance matrix
+
+| Journey step | Observable invariant | State authority | Test layer |
+| --- | --- | --- | --- |
+| Entry/discovery | Assistant exposes search and context status without crowding the transcript | URL + Core catalog + UI | component + Playwright |
+| Draft recovery | An unsent prompt survives refresh and stays isolated by project/session | sessionStorage + URL | unit + Playwright |
+| Context collection | New selections append with exact bytes, source identity, bounded length, and stable deduplication | workspace context until submit; Core after submit | unit + Playwright + real Core |
+| Image attachment | Choose, paste, and drop share the same validation, capability, count, and upload path | Core artifact store | component + Playwright |
+| Create/mutate | Send persists one user/assistant turn; steer mutates only the active advertised harness turn | Core database + harness | real Core |
+| Select/use | URL and visible selection identify the same conversation; filters never mutate selection | URL + Core | Playwright |
+| Stream/interrupt | Output remains ordered; stop remains available; steer uses visible composer text | Core/harness activity | component + real Core |
+| Context health | The meter and inspector reflect Core status, estimated usage, compaction, and memory summary | Core context endpoint | component + real Core |
+| Message reuse | Copy is exact; quote creates an editable draft; fork retains durable lineage | Core + transient composer | unit + Playwright + real Core |
+| Export | Export is built from a fresh authoritative transcript and records session identity, citations, and attachment hashes | Core database | unit + Playwright |
+| Refresh/reconnect | Durable transcript and URL identity return without duplicates; unsent text recovers from the current tab | Core + URL + sessionStorage | real Core |
+| Failure/retry | Context, export, upload, and steering failures retain usable chat state and show a local recovery action | Core error contract | component + Playwright |
+| Delete/revoke | Existing guarded deletion clears stale selection and its draft key | Core database + URL + sessionStorage | component + real Core |
+
+## Content, responsive, and accessibility invariants
+
+- Context packs collapse to compact source chips and never push the composer outside
+  the visual viewport at 320-430 px widths.
+- Search, context status, attachment removal, copy, quote, export, stop, and send have
+  screen-reader names and visible keyboard focus.
+- Touch controls remain at least 44 px; long labels, hashes, transcripts, and memory
+  summaries wrap without horizontal clipping.
+- Reduced motion does not hide state changes. Approval, user-input, failure, and
+  retry controls are never collapsed.
+- Sensitive selections remain excluded by the existing selection boundary.
+  Context text and unsent attachments are not written to browser storage.
+
+## Competitive gap basis
+
+Current first-party agent products commonly expose multi-source composer mentions,
+context-window meters, queued or inline steering, conversation search, checkpoints,
+and cross-device supervision. Nebula already has stronger engagement scope,
+reviewed execution, durable approvals, artifact receipts, context snapshots, and
+harness capability normalization. This pass closes the assistant-ergonomics gap
+without weakening those controls.
+
+## Explicit non-goals
+
+- No hidden auto-approval, unrestricted shell, or background cloud execution.
+- No browser-owned transcript, lineage, context memory, or evidence authority.
+- No capture or display of private chain-of-thought.
+- No opaque folder identifiers or vendor-specific assistant fork.
+- No claim of physical-device or LAN support until those gates are exercised.

--- a/src/nebula/v3/chat.py
+++ b/src/nebula/v3/chat.py
@@ -664,7 +664,8 @@ class ChatService:
         pending_session: ChatSession | None = None
         stored_messages: list[ChatMessage] = []
         engagement_id = request.engagement_id
-        incoming = list(request.messages)
+        durable_incoming = list(request.messages)
+        incoming = list(durable_incoming)
         if request.context_attachments:
             last = incoming[-1]
             incoming[-1] = ChatRequestMessage(
@@ -691,9 +692,10 @@ class ChatService:
                     "model cannot change within a durable chat session"
                 )
             stored_messages = self._session_messages(session)
-            incoming, new_messages = self._merge_history(stored_messages, incoming)
+            incoming, _ = self._merge_history(stored_messages, incoming)
+            _, new_messages = self._merge_history(stored_messages, durable_incoming)
         else:
-            new_messages = incoming
+            new_messages = durable_incoming
 
         selected_model = (
             request.model
@@ -718,7 +720,9 @@ class ChatService:
                 pending_session = ChatSession(
                     id=request.session_id or str(uuid4()),
                     engagement_id=engagement.id,
-                    title=self._title(incoming),
+                    # Titles describe the operator's prompt, never the expanded
+                    # provider payload containing selected-context envelopes.
+                    title=self._title(request.messages),
                     provider_profile_id=profile.id,
                     model=selected_model,
                 )

--- a/tests/v3/test_chat.py
+++ b/tests/v3/test_chat.py
@@ -386,7 +386,9 @@ def test_selected_context_is_bounded_hashed_sent_as_data_and_persisted(
     assert "BEGIN UNTRUSTED SELECTED CONTEXT" in content
     assert selected in content
     completion = asyncio.run(service.complete(prepared))
+    assert store.get(ChatSession, completion.session_id).title == "What does this mean?"
     persisted = service.session_messages(completion.session_id)
+    assert persisted[0].content == "What does this mean?"
     attachment = persisted[0].metadata["context_attachments"][0]
     assert attachment["text"] == selected
     assert attachment["source_id"] == "terminal-1"

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const testPort = process.env.NEBULA_UI_TEST_PORT ?? "1420";
+
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: false,
@@ -14,7 +16,7 @@ export default defineConfig({
     },
   },
   use: {
-    baseURL: "http://127.0.0.1:1420",
+    baseURL: `http://127.0.0.1:${testPort}`,
     colorScheme: "dark",
     reducedMotion: "reduce",
     trace: "retain-on-failure",
@@ -38,25 +40,25 @@ export default defineConfig({
     {
       name: "mobile-chromium",
       testMatch: "**/interface.spec.ts",
-      grep: /host folder picker|mission workflow|completed harness output|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /host folder picker|mission workflow|completed harness output|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"] },
     },
     {
       name: "mobile-chromium-small",
       testMatch: "**/interface.spec.ts",
-      grep: /host folder picker|mission workflow|completed harness output|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /host folder picker|mission workflow|completed harness output|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"], viewport: { width: 320, height: 700 } },
     },
     {
       name: "mobile-webkit",
       testMatch: "**/interface.spec.ts",
-      grep: /host folder picker|mission workflow|completed harness output|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /host folder picker|mission workflow|completed harness output|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["iPhone 13"] },
     },
     {
       name: "mobile-webkit-wide",
       testMatch: "**/interface.spec.ts",
-      grep: /host folder picker|mission workflow|completed harness output|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /host folder picker|mission workflow|completed harness output|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["iPhone 13"], viewport: { width: 430, height: 932 } },
     },
     {
@@ -67,8 +69,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "npm run dev -- --host 127.0.0.1",
-    url: "http://127.0.0.1:1420",
+    command: `npm run dev -- --host 127.0.0.1 --port ${testPort}`,
+    url: `http://127.0.0.1:${testPort}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -45,6 +45,7 @@ function selectElementText(element: HTMLElement) {
 describe("Nebula workspace", () => {
   beforeEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
     window.history.replaceState({}, "", "/");
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Core offline")));
   });
@@ -381,7 +382,7 @@ describe("Nebula workspace", () => {
     const user = userEvent.setup();
 
     renderApp("/sessions");
-    await user.click(await screen.findByRole("tab", { name: /Analyst chat/ }));
+    await user.click(await screen.findByRole("tab", { name: /Analyst chat/ }, { timeout: 5_000 }));
     await user.click(screen.getByRole("button", { name: "New chat" }));
     await user.click(screen.getByRole("button", { name: "Assistant settings" }));
     expect(await screen.findByRole("combobox", { name: "Chat provider" })).toHaveValue("provider-1");
@@ -468,14 +469,14 @@ describe("Nebula workspace", () => {
     await user.click(await screen.findByRole("button", { name: "Ask Nebula" }));
 
     expect(await screen.findByRole("tab", { name: "Analyst chat" })).toHaveAttribute("aria-selected", "true");
-    const attachment = screen.getByRole("group", { name: "Selected context attachment" });
+    const attachment = screen.getByRole("region", { name: "Selected context pack" });
     expect(attachment).toHaveTextContent("Project selection");
     expect(within(attachment).queryByText("Selection review", { selector: "p" })).toBeNull();
-    const expandQuote = within(attachment).getByRole("button", { name: "Expand quoted context" });
+    const expandQuote = within(attachment).getByRole("button", { name: "Expand Project selection" });
     expect(expandQuote).toHaveAttribute("aria-expanded", "false");
     await user.click(expandQuote);
     expect(within(attachment).getByText("Selection review", { selector: "p" })).toBeVisible();
-    expect(within(attachment).getByRole("button", { name: "Collapse quoted context" })).toHaveAttribute("aria-expanded", "true");
+    expect(within(attachment).getByRole("button", { name: "Collapse Project selection" })).toHaveAttribute("aria-expanded", "true");
     const composer = screen.getByRole("textbox", { name: "Message the analyst assistant" });
     expect(composer).toHaveValue("");
     expect(fetchMock.mock.calls.some(([input]) => new URL(String(input)).pathname.endsWith("/chat/completions"))).toBe(false);
@@ -531,7 +532,7 @@ describe("Nebula workspace", () => {
     await waitFor(() => expect(fetchMock.mock.calls.some(([input, init]) => new URL(String(input)).pathname.endsWith("/observations") && init?.method === "POST")).toBe(true));
   });
 
-  it("keeps chat working memory in the background", async () => {
+  it("keeps chat drafts durable while saved memory stays behind explicit disclosure", async () => {
     const entity = {
       created_at: "2026-07-12T10:00:00Z",
       updated_at: "2026-07-12T11:00:00Z",
@@ -584,7 +585,7 @@ describe("Nebula workspace", () => {
     const user = userEvent.setup();
     const rendered = renderApp("/sessions");
 
-    await user.click(await screen.findByRole("tab", { name: /Analyst chat/ }));
+    await user.click(await screen.findByRole("tab", { name: /Analyst chat/ }, { timeout: 5_000 }));
     expect(screen.queryByLabelText("Conversations")).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Show conversations" }));
     const conversationPanel = await screen.findByLabelText("Conversations");
@@ -592,10 +593,13 @@ describe("Nebula workspace", () => {
     expect(localStorage.getItem("nebula.conversations.open")).toBe("true");
     expect(await screen.findByTitle("Saved context")).toBeVisible();
     expect(await screen.findByText("Port retained")).toBeVisible();
-    expect(screen.getByTestId("router-location")).toHaveTextContent(/session=session-1/);
-    rendered.unmount();
-    renderApp("/sessions");
-    expect(await screen.findByLabelText("Conversations")).toBeVisible();
+    const conversationSearch = screen.getByRole("searchbox", { name: "Search conversations" });
+    await user.type(conversationSearch, "missing runtime");
+    expect(screen.getByText("No conversations match “missing runtime”.")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Clear conversation search" }));
+    expect(await screen.findByTitle("Saved context")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: /Saved contextmodel-1/ }));
+    await waitFor(() => expect(screen.getByTestId("router-location")).toHaveTextContent(/session=session-1/));
     expect(await screen.findByText("Port retained")).toBeVisible();
     const transcript = screen.getByText("Port retained").closest(".chat-scroll")!;
     const transcriptMutations: MutationRecord[] = [];
@@ -605,9 +609,23 @@ describe("Nebula workspace", () => {
     transcriptMutations.push(...transcriptObserver.takeRecords());
     transcriptObserver.disconnect();
     expect(transcriptMutations.filter((record) => record.addedNodes.length || record.removedNodes.length)).toEqual([]);
+    await waitFor(() => expect(fetchMock.mock.calls.some(([input]) => new URL(String(input)).pathname.endsWith("/chat/sessions/session-1/context"))).toBe(true));
     expect(screen.queryByText("The selected service uses port 8443.")).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Working memory" })).not.toBeInTheDocument();
-    expect(fetchMock.mock.calls.some(([input]) => new URL(String(input)).pathname.endsWith("/chat/sessions/session-1/context"))).toBe(false);
+    await user.click(screen.getByRole("button", { name: "Open context details, 100 percent of target input used" }));
+    const inspector = await screen.findByLabelText("Session inspector");
+    expect(within(inspector).getByText("Core compacted through message 1; the source transcript remains unchanged.")).toBeVisible();
+    await user.click(within(inspector).getByText("Inspect saved memory"));
+    expect(within(inspector).getByText("The selected service uses port 8443.")).toBeVisible();
+    rendered.unmount();
+    renderApp("/sessions");
+    const recoveredComposer = await screen.findByRole("textbox", { name: "Message the analyst assistant" });
+    expect(recoveredComposer).toHaveValue("draft");
+    expect(await screen.findByText("Port retained")).toBeVisible();
+    const assistantMessage = screen.getByText("Port retained").closest("article");
+    expect(assistantMessage).not.toBeNull();
+    await user.click(within(assistantMessage!).getByRole("button", { name: "Quote in composer" }));
+    expect((recoveredComposer as HTMLTextAreaElement).value).toContain("> Port retained");
     expect(screen.queryByRole("button", { name: "Save Assistant Response" })).not.toBeInTheDocument();
     for (const forkButton of screen.getAllByRole("button", { name: "Fork conversation here" })) {
       expect(forkButton.closest(".chat-message-actions")).not.toBeNull();
@@ -631,7 +649,7 @@ describe("Nebula workspace", () => {
     await waitFor(() => expect(screen.queryByRole("button", { name: "More actions for Port review" })).not.toBeInTheDocument());
     expect(fetchMock.mock.calls.some(([input, request]) => new URL(String(input)).pathname.endsWith("/chat-sessions/session-1") && request?.method === "DELETE")).toBe(true);
     expect(new URLSearchParams(window.location.search).get("session")).toBeNull();
-  });
+  }, 15_000);
 
   it("deletes every saved Assistant conversation after one confirmation", async () => {
     const entity = { created_at: "2026-07-12T10:00:00Z", updated_at: "2026-07-12T11:00:00Z", revision: 1 };

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -620,7 +620,7 @@ describe("Nebula workspace", () => {
     rendered.unmount();
     renderApp("/sessions");
     const recoveredComposer = await screen.findByRole("textbox", { name: "Message the analyst assistant" });
-    expect(recoveredComposer).toHaveValue("draft");
+    await waitFor(() => expect(recoveredComposer).toHaveValue("draft"));
     expect(await screen.findByText("Port retained")).toBeVisible();
     const assistantMessage = screen.getByText("Port retained").closest("article");
     expect(assistantMessage).not.toBeNull();

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -568,6 +568,10 @@ kbd { font-size: 11px; }
 .session-list > header .session-list-header-actions { flex-direction: row; gap: 2px; }
 .session-list > header span { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }
 .session-list > header strong { margin-top: 2px; font-size: 12px; }
+.session-list-search { display: flex; min-height: 42px; align-items: center; gap: 7px; margin: 7px 8px 0; padding: 0 7px 0 10px; border: 1px solid var(--border-soft); border-radius: 8px; color: var(--muted); background: var(--canvas); }
+.session-list-search:focus-within { border-color: var(--focus); }
+.session-list-search input { min-width: 0; height: 38px; flex: 1; border: 0; outline: 0; color: var(--text); background: transparent; font: inherit; font-size: 12px; }
+.session-list-search .icon-button { width: 32px; height: 32px; }
 .session-list nav { display: grid; grid-auto-rows: max-content; align-content: start; gap: 3px; padding: 8px; }
 .session-list nav > button { display: grid; grid-template-columns: 18px minmax(0, 1fr); gap: 8px; align-items: center; min-height: 46px; padding: 7px 9px; border: 0; border-radius: 8px; color: var(--muted); background: transparent; text-align: left; cursor: pointer; }
 .session-list nav > button:hover { background: var(--surface-hover); }
@@ -582,7 +586,7 @@ kbd { font-size: 11px; }
 .session-item-actions { position: relative; display: grid; place-items: center; }
 .session-actions-trigger { width: 34px; height: 34px; opacity: 0; pointer-events: none; transition: opacity 120ms ease, background-color 120ms ease; }
 .session-list-item:hover .session-actions-trigger, .session-list-item:focus-within .session-actions-trigger, .session-list-item.actions-open .session-actions-trigger { opacity: 1; pointer-events: auto; }
-.session-actions-menu { position: fixed; z-index: 220; display: grid; width: 156px; padding: 5px; border: 1px solid var(--border); border-radius: var(--radius-control); background: var(--surface-raised); box-shadow: none; }
+.session-actions-menu { position: fixed; z-index: 220; display: grid; width: 196px; padding: 5px; border: 1px solid var(--border); border-radius: var(--radius-control); background: var(--surface-raised); box-shadow: none; }
 .session-actions-menu > button { display: flex; min-height: 38px; align-items: center; gap: 9px; padding: 0 10px; border: 0; border-radius: var(--radius-control); color: var(--muted-strong); background: transparent; font-size: 12px; text-align: left; cursor: pointer; }
 .session-actions-menu > button:hover, .session-actions-menu > button:focus-visible { color: var(--text); background: var(--surface-hover); outline: 0; }
 .session-actions-menu > button.danger { color: var(--red); }
@@ -633,9 +637,24 @@ kbd { font-size: 11px; }
 .browser-unavailable { min-height: 590px; }
 .persistent-terminal[hidden] { display: none !important; }
 .persistent-code-editor[hidden] { display: none !important; }
+.session-inspector { min-height: 0; overflow-y: auto; overscroll-behavior: contain; }
 .session-inspector > header { min-height: 54px; }
 .session-inspector > header span, .session-inspector dt, .session-inspector dd, .session-inspector code { font-size: 11px; }
 .session-inspector > header strong, .session-inspector h3 { font-size: 12px; }
+.session-context-health > p, .session-context-error p, .session-context-summary small, .session-memory p, .session-memory li, .session-memory small { margin: 0; color: var(--muted); font-size: 11px; line-height: 1.45; }
+.session-context-summary { display: flex; align-items: flex-start; gap: 8px; }
+.session-context-summary > .status-dot { flex: 0 0 auto; margin-top: 5px; }
+.session-context-summary > div { display: grid; min-width: 0; gap: 2px; }
+.session-context-summary strong { color: var(--text); font-size: 12px; text-transform: capitalize; }
+.session-context-progress { height: 5px; margin: 9px 0; overflow: hidden; border-radius: 999px; background: var(--surface-muted); }
+.session-context-progress > span { display: block; height: 100%; border-radius: inherit; background: var(--blue); }
+.session-context-error { display: grid; justify-items: start; gap: 7px; }
+.session-memory { margin-top: 10px; border-top: 1px solid var(--border-soft); }
+.session-memory > summary { padding: 9px 0 0; color: var(--blue); font-size: 11px; cursor: pointer; }
+.session-memory > div { display: grid; gap: 9px; padding-top: 9px; }
+.session-memory section { display: grid; gap: 3px; padding: 0; border: 0; }
+.session-memory section strong { color: var(--text); font-size: 11px; }
+.session-memory ul { display: grid; gap: 4px; margin: 0; padding-left: 17px; }
 .chat-panel { position: relative; min-height: 0; container: chat-panel / size; border-color: var(--border-soft); border-radius: var(--radius-panel); }
 .chat-empty-state { min-height: 0; padding: 24px; }
 .chat-empty-state .button { margin-top: 16px; }
@@ -678,11 +697,11 @@ kbd { font-size: 11px; }
 .chat-message header span { font-size: 11px; }
 .chat-message-actions { display: flex; min-height: 28px; align-items: center; gap: 4px; margin-top: 4px; opacity: 0; transition: opacity 120ms ease; }
 .chat-message:hover .chat-message-actions, .chat-message:focus-within .chat-message-actions { opacity: 1; }
-.chat-message-actions .chat-fork-button { width: 28px; height: 28px; color: var(--muted); }
-.chat-message-actions .chat-fork-button:hover, .chat-message-actions .chat-fork-button:focus-visible { color: var(--text-strong); background: var(--surface-hover); }
+.chat-message-actions .icon-button { width: 28px; height: 28px; color: var(--muted); }
+.chat-message-actions .icon-button:hover, .chat-message-actions .icon-button:focus-visible { color: var(--text-strong); background: var(--surface-hover); }
 @media (hover: none), (pointer: coarse) {
   .chat-message-actions { min-height: 44px; opacity: 1; }
-  .chat-message-actions .chat-fork-button { width: 44px; height: 44px; }
+  .chat-message-actions .icon-button { width: 44px; height: 44px; }
 }
 @media (prefers-reduced-motion: reduce) { .chat-message-actions { transition: none; } }
 .assistant-streaming-text { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
@@ -944,6 +963,12 @@ kbd { font-size: 11px; }
 .chat-composer { border-radius: var(--radius-panel); }
 .chat-composer textarea { min-height: 44px; max-height: 160px; overflow-y: hidden; font-size: 13px; line-height: 1.45; }
 .chat-composer footer span { font-size: 11px; }
+.chat-composer footer .chat-runtime-summary { min-width: 0; max-width: none; flex: 1 1 auto; }
+.chat-context-meter { min-width: 61px; min-height: 34px; flex: 0 0 auto; gap: 5px; padding: 1px 4px; }
+.chat-context-meter > span { display: grid; width: 28px; height: 28px; place-items: center; border-radius: 50%; color: var(--text); background: radial-gradient(circle, var(--surface-muted) 57%, transparent 59%), conic-gradient(var(--blue) var(--context-percent, 0%), var(--border-soft) 0); font: 9px var(--font-mono); }
+.chat-context-meter > small { color: var(--muted); font-size: 11px; }
+.chat-context-meter.status-failed > span { background: var(--red-muted); color: var(--red); }
+.chat-action-status { display: flex; min-height: 28px; align-items: center; justify-content: center; gap: 5px; margin: 4px 12px 0; color: var(--green); font-size: 11px; }
 
 .chat-content-image {
   display: block;
@@ -1017,10 +1042,18 @@ kbd { font-size: 11px; }
 .mobile-companion-nav { display: none; }
 .mobile-more-backdrop { display: none; }
 .mobile-desktop-handoff { display: none; }
-.chat-context-attachment { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 6px 10px; padding: 7px 7px 7px 11px; border-bottom: 1px solid var(--border-soft); background: color-mix(in srgb, var(--blue-muted) 52%, var(--surface-muted)); }
+.chat-context-pack { max-height: 220px; overflow-y: auto; overscroll-behavior: contain; border-bottom: 1px solid var(--border-soft); background: color-mix(in srgb, var(--blue-muted) 36%, var(--surface-muted)); }
+.chat-context-pack > header { position: sticky; z-index: 1; top: 0; display: flex; min-height: 42px; align-items: center; justify-content: space-between; gap: 10px; padding: 5px 7px 5px 11px; border-bottom: 1px solid var(--border-soft); background: color-mix(in srgb, var(--surface-muted) 90%, transparent); }
+.chat-context-pack > header > div { display: flex; min-width: 0; align-items: baseline; gap: 8px; }
+.chat-context-pack > header strong { color: var(--text); font-size: 11px; }
+.chat-context-pack > header small { overflow: hidden; color: var(--muted); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.chat-context-pack > header .button { min-height: 32px; flex: 0 0 auto; }
+.chat-context-attachment { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 6px 10px; padding: 7px 7px 7px 11px; border-bottom: 1px solid var(--border-soft); background: transparent; }
+.chat-context-attachment:last-child { border-bottom: 0; }
 .chat-context-attachment-summary { display: flex; min-width: 0; align-items: baseline; gap: 8px; }.chat-context-attachment strong { overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }.chat-context-attachment small { color: var(--muted); font-size: 11px; }
 .chat-context-attachment-actions { display: flex; align-items: center; gap: 2px; }.chat-context-attachment-actions button:first-child svg { transition: transform 150ms ease; }.chat-context-attachment-actions button:first-child[aria-expanded="true"] svg { transform: rotate(180deg); }
 .chat-context-attachment p { grid-column: 1 / -1; max-height: 180px; overflow: auto; margin: 0 4px 3px 0; padding: 8px; border-radius: var(--radius-control); background: color-mix(in srgb, var(--surface) 78%, transparent); color: var(--muted-strong); font: 11px/1.45 var(--font-mono); overflow-wrap: anywhere; white-space: pre-wrap; }
+.chat-context-pack-notice { display: flex; min-height: 36px; align-items: center; justify-content: space-between; gap: 8px; padding: 4px 7px 4px 11px; border-top: 1px solid var(--border-soft); color: var(--orange); font-size: 11px; }
 @media (prefers-reduced-motion: reduce) { .chat-context-attachment-actions button:first-child svg { transition: none; } }
 
 .notes-panel { display: grid; min-height: 590px; grid-template-columns: 220px minmax(0, 1fr); overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius-control); background: var(--surface); }
@@ -1725,6 +1758,13 @@ kbd { font-size: 11px; }
   .chat-composer { margin: 6px; }
   .chat-composer footer { gap: 6px; }
   .chat-composer footer span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .chat-context-pack { max-height: 150px; }
+  .chat-context-pack > header { min-height: 44px; }
+  .chat-context-pack > header > div { display: grid; gap: 1px; }
+  .chat-context-attachment-summary { display: grid; gap: 2px; }
+  .chat-context-meter { width: 44px; min-width: 44px; height: 44px; padding: 0; }
+  .chat-context-meter > span { width: 30px; height: 30px; }
+  .chat-context-meter > small { display: none; }
   .chat-composer .button.square { width: 44px; flex: 0 0 44px; padding: 0; }
   .chat-settings-popover { right: auto; bottom: 127px; left: 50%; width: calc(100% - 12px); max-height: min(72%, 520px); border-radius: var(--radius-panel); }
   .chat-settings-fields { grid-template-columns: minmax(0, 1fr); }

--- a/ui/src/components/MissionControls.test.tsx
+++ b/ui/src/components/MissionControls.test.tsx
@@ -56,6 +56,7 @@ describe("NewMissionButton", () => {
     await user.click(screen.getByText("Advanced"));
     expect(screen.getByText("Supervised security automation")).toBeInTheDocument();
     expect(screen.getByText("Harness native")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText("Model")).toHaveValue("gpt-5.6-sol"));
     expect(screen.getByLabelText("Mission harness effort")).toHaveValue("high");
     expect(screen.getByLabelText("Mission harness speed")).toHaveValue("priority");
     await user.click(screen.getByRole("button", { name: "Add stage" }));

--- a/ui/src/components/MissionControls.test.tsx
+++ b/ui/src/components/MissionControls.test.tsx
@@ -45,7 +45,7 @@ vi.mock("../state/WorkspaceContext", () => ({
 describe("NewMissionButton", () => {
   it("submits frozen harness options, durable stages, and a recurring schedule", async () => {
     const user = userEvent.setup();
-    const scheduledLocal = "2026-08-24T09:30";
+    const scheduledLocal = "2099-08-24T09:30";
     startMission.mockClear();
     render(<DialogProvider><NewMissionButton /></DialogProvider>);
     const trigger = await screen.findByRole("button", { name: "Automate task" });

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useLayoutEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent, type KeyboardEvent, type ReactNode } from "react";
+import { lazy, Suspense, useEffect, useLayoutEffect, useMemo, useRef, useState, type ChangeEvent, type ClipboardEvent as ReactClipboardEvent, type CSSProperties, type DragEvent as ReactDragEvent, type FormEvent, type KeyboardEvent, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import {
   AssistantRuntimeProvider,
@@ -11,6 +11,8 @@ import {
   Braces,
   Check,
   ChevronDown,
+  Copy,
+  Download,
   FileClock,
   FolderOpen,
   Globe2,
@@ -19,6 +21,7 @@ import {
   LoaderCircle,
   Maximize2,
   MessageSquare,
+  MessageSquareQuote,
   Minimize2,
   MoreHorizontal,
   NotebookPen,
@@ -44,6 +47,7 @@ import type {
   ChatContentBlock,
   ChatSessionSummary,
   ChatStreamEvent,
+  ContextStatus,
   ExecutionCapabilities,
   ExecutionLanguage,
   HarnessProfile,
@@ -68,7 +72,7 @@ import { PageHeader } from "../components/PageHeader";
 import { PostToolAssistant } from "../components/PostToolAssistant";
 import { TerminalCommandHistoryPanel } from "../components/TerminalCommandHistoryPanel";
 import { ModalSurface, useConfirmation } from "../components/DialogSystem";
-import { createHashedSelectionAttachment } from "../components/selection";
+import { copySelectionText, createHashedSelectionAttachment } from "../components/selection";
 import { WorkspacePanel } from "../components/WorkspacePanel";
 import { HarnessSkillAutocomplete, findHarnessSkillToken, type HarnessSkillTokenRange } from "../components/HarnessSkillAutocomplete";
 import { WorkbenchBrowser } from "../components/WorkbenchBrowser";
@@ -97,9 +101,22 @@ import {
 } from "./chatMessageReconciliation";
 import { DiagnosticErrorNotice, logCaughtDiagnostic } from "../diagnostics";
 import { readConversationPanelOpen, writeConversationPanelOpen } from "./workbenchPreferences";
+import { chatDraftStorageKey, clearChatDraft, readChatDraft, writeChatDraft } from "./chatDraftStorage";
+import { chatTranscriptFilename, formatChatTranscript } from "./chatTranscriptExport";
 
 type SessionView = "chat" | "code" | "terminal" | "browser" | "missions" | "activity" | "workspace" | "notes";
 const screenFitViews = new Set<SessionView>(["terminal", "code", "workspace"]);
+const readableContextStatuses = new Set<ContextStatus["status"]>(["not_needed", "ready", "stale", "failed", "runtime_managed"]);
+
+function isReadableContextStatus(value: ContextStatus, expectedOwnerId: string): boolean {
+  return value.ownerType === "chat_session"
+    && value.ownerId === expectedOwnerId
+    && readableContextStatuses.has(value.status)
+    && Number.isFinite(value.estimatedInputTokens)
+    && Number.isFinite(value.targetInputTokens)
+    && Number.isFinite(value.compactedThrough);
+}
+
 interface ToolLifecycleCard {
   assistantId: string;
   toolCallId: string;
@@ -407,12 +424,15 @@ function persistedMessage(message: PersistedChatMessage): ConversationMessage {
 export function SessionsPage() {
   const confirm = useConfirmation();
   const {
-    assistantDraft,
-    clearAssistantDraft,
+    assistantDraftNotice,
+    assistantDrafts,
+    clearAssistantDraftNotice,
+    clearAssistantDrafts,
     clearExecutionDraft,
     clearNoteDraft,
     executionDraft,
     noteDraft,
+    removeAssistantDraft,
     requestNebulaDraft,
   } = useWorkbenchDrafts();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -483,6 +503,8 @@ export function SessionsPage() {
   const [runCandidate, setRunCandidate] = useState<FencedRunCandidate>();
   const [executionRefresh, setExecutionRefresh] = useState(0);
   const [sessions, setSessions] = useState<ChatSessionSummary[]>([]);
+  const [sessionQuery, setSessionQuery] = useState("");
+  const [exportingSessionId, setExportingSessionId] = useState<string>();
   const [deletingSessionId, setDeletingSessionId] = useState<string>();
   const [deletingAllSessions, setDeletingAllSessions] = useState(false);
   const [sessionActionsId, setSessionActionsId] = useState<string>();
@@ -531,7 +553,12 @@ export function SessionsPage() {
   const [pendingResponse, setPendingResponse] = useState<PendingChatResponse>();
   const [messages, setMessages] = useState<ConversationMessage[]>([]);
   const [draft, setDraft] = useState("");
-  const [quotedContextExpanded, setQuotedContextExpanded] = useState(false);
+  const [expandedContextIndex, setExpandedContextIndex] = useState<number>();
+  const [contextStatus, setContextStatus] = useState<ContextStatus>();
+  const [contextStatusError, setContextStatusError] = useState<string>();
+  const [contextStatusLoading, setContextStatusLoading] = useState(false);
+  const [contextRefreshKey, setContextRefreshKey] = useState(0);
+  const [messageActionStatus, setMessageActionStatus] = useState<string>();
   const [pendingImages, setPendingImages] = useState<PendingChatImage[]>([]);
   const [uploadingImage, setUploadingImage] = useState(false);
   const [sending, setSending] = useState(false);
@@ -559,6 +586,7 @@ export function SessionsPage() {
   const sessionActionsMenuRef = useRef<HTMLDivElement>(null);
   const streamDeltaRef = useRef(new Map<string, string>());
   const streamFrameRef = useRef<number | undefined>(undefined);
+  const draftStorageKeyRef = useRef("");
   const chatRuntimeStore = useMemo(() => ({
     messages,
     convertMessage: convertConversationMessage,
@@ -594,6 +622,38 @@ export function SessionsPage() {
     () => new Map(messages.map((message) => [message.runtimeId ?? message.id, message])),
     [messages],
   );
+  const activeDraftStorageKey = engagement
+    ? chatDraftStorageKey(engagement.id, sessionId || undefined)
+    : "";
+  useEffect(() => {
+    if (!activeDraftStorageKey || draftStorageKeyRef.current !== activeDraftStorageKey) return;
+    writeChatDraft(sessionStorage, activeDraftStorageKey, draft);
+  }, [activeDraftStorageKey, draft]);
+  useEffect(() => {
+    const previousKey = draftStorageKeyRef.current;
+    if (previousKey && previousKey !== activeDraftStorageKey) {
+      writeChatDraft(sessionStorage, previousKey, draft);
+    }
+    draftStorageKeyRef.current = activeDraftStorageKey;
+    setDraft(activeDraftStorageKey ? readChatDraft(sessionStorage, activeDraftStorageKey) : "");
+    setSkillToken(undefined);
+    setHarnessSkillPath("");
+  // The outgoing draft is intentionally captured at the identity boundary.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeDraftStorageKey]);
+  const visibleSessions = useMemo(() => {
+    const query = sessionQuery.trim().toLocaleLowerCase();
+    if (!query) return sessions;
+    return sessions.filter((session) => [
+      session.title,
+      session.model,
+      session.backend === "harness" ? "agent harness" : "provider",
+    ].some((value) => value?.toLocaleLowerCase().includes(query)));
+  }, [sessionQuery, sessions]);
+  const activeContextStatus = contextStatus?.ownerId === sessionId ? contextStatus : undefined;
+  const contextPercent = activeContextStatus && activeContextStatus.status !== "runtime_managed" && activeContextStatus.targetInputTokens > 0
+    ? Math.min(100, Math.round((activeContextStatus.estimatedInputTokens / activeContextStatus.targetInputTokens) * 100))
+    : undefined;
   const enabledProviders = useMemo(() => providers.filter((provider) => provider.enabled), [providers]);
   const selectedProvider = enabledProviders.find((provider) => provider.id === providerId);
   const selectedHarness = harnesses.find((harness) => harness.id === harnessId);
@@ -690,12 +750,11 @@ export function SessionsPage() {
   }, [requestedView]);
 
   useEffect(() => {
-    if (!assistantDraft) return;
-    setQuotedContextExpanded(false);
+    if (!assistantDrafts.length) return;
+    setExpandedContextIndex(undefined);
     setConversationOpen(true);
-    setDraft((current) => current.trim() ? current : "");
     globalThis.requestAnimationFrame?.(() => composerRef.current?.focus());
-  }, [assistantDraft]);
+  }, [assistantDrafts]);
 
   useLayoutEffect(() => {
     if (view !== "chat") return;
@@ -938,7 +997,7 @@ export function SessionsPage() {
     setSending(false);
     setSessions([]);
     setSessionId("");
-    setConversationOpen(Boolean(assistantDraft || requestedSessionId));
+    setConversationOpen(Boolean(assistantDrafts.length || requestedSessionId));
     setHarnessSessionId("");
     setHarnessMode("");
     setHarnessSkillPath("");
@@ -947,7 +1006,6 @@ export function SessionsPage() {
     setHarnessActivityError(undefined);
     setHarnessProgress(undefined);
     setMessages([]);
-    setDraft(assistantDraft ? "" : "");
     setChatError(undefined);
     setRunCandidate(undefined);
     setToolCards([]);
@@ -955,6 +1013,30 @@ export function SessionsPage() {
     setHarnessInteractions([]);
     setPendingResponse(undefined);
   }, [engagement?.id]);
+
+  useEffect(() => {
+    if (!api || coreState !== "online" || !sessionId || sending) {
+      if (!sessionId) {
+        setContextStatus(undefined);
+        setContextStatusError(undefined);
+      }
+      return;
+    }
+    const controller = new AbortController();
+    setContextStatusLoading(true);
+    setContextStatusError(undefined);
+    void api.getChatContext(sessionId, controller.signal).then((status) => {
+      if (!isReadableContextStatus(status, sessionId)) throw new Error("Core returned an unreadable context status.");
+      setContextStatus(status);
+    }).catch((error) => {
+      if (controller.signal.aborted) return;
+      void logCaughtDiagnostic("interface.sessions_page.context_status", "Assistant context status could not be loaded.", error, "sessions_page");
+      setContextStatusError(error instanceof Error ? error.message : "Context status is unavailable.");
+    }).finally(() => {
+      if (!controller.signal.aborted) setContextStatusLoading(false);
+    });
+    return () => controller.abort();
+  }, [api, contextRefreshKey, coreState, sending, sessionId]);
 
   useEffect(() => {
     if (!api || coreState !== "online" || !engagement) {
@@ -996,6 +1078,12 @@ export function SessionsPage() {
   useEffect(() => () => {
     if (streamFrameRef.current !== undefined) cancelAnimationFrame(streamFrameRef.current);
   }, []);
+
+  useEffect(() => {
+    if (!messageActionStatus) return;
+    const timeout = window.setTimeout(() => setMessageActionStatus(undefined), 3_000);
+    return () => window.clearTimeout(timeout);
+  }, [messageActionStatus]);
 
   const flushStreamDeltas = () => {
     streamFrameRef.current = undefined;
@@ -1073,6 +1161,7 @@ export function SessionsPage() {
     setChatError(undefined);
     try {
       await api.deleteChatSession(session.id);
+      if (engagement) clearChatDraft(sessionStorage, chatDraftStorageKey(engagement.id, session.id));
       setSessions((current) => current.filter((item) => item.id !== session.id));
       if (sessionId === session.id) {
         resetConversation(false);
@@ -1100,6 +1189,11 @@ export function SessionsPage() {
     setChatError(undefined);
     const results = await Promise.allSettled(targets.map((session) => api.deleteChatSession(session.id)));
     const deletedIds = new Set(targets.filter((_, index) => results[index]?.status === "fulfilled").map((session) => session.id));
+    if (engagement) {
+      for (const deletedId of deletedIds) {
+        clearChatDraft(sessionStorage, chatDraftStorageKey(engagement.id, deletedId));
+      }
+    }
     const failures = results.filter((result) => result.status === "rejected");
     setSessions((current) => current.filter((session) => !deletedIds.has(session.id)));
     if (deletedIds.has(sessionId)) {
@@ -1169,6 +1263,52 @@ export function SessionsPage() {
     } catch (error) {
       void logCaughtDiagnostic("interface.sessions_page.caught_failure_07", "A handled interface operation failed.", error, "sessions_page");
       setRenameError(error instanceof Error ? error.message : "Could not rename the conversation.");
+    }
+  };
+
+  const exportConversation = async (session: ChatSessionSummary) => {
+    if (!api || !engagement || exportingSessionId) return;
+    setSessionActionsId(undefined);
+    const approved = await confirm({
+      title: `Export ${session.title}?`,
+      message: "The Markdown transcript can contain sensitive prompts, responses, citations, and selected-context hashes. Tool artifacts and raw evidence stay in the project evidence bundle.",
+      confirmLabel: "Export transcript",
+    });
+    if (!approved) return;
+    setExportingSessionId(session.id);
+    setChatError(undefined);
+    try {
+      const authoritative = await api.listChatMessages(session.id);
+      const blob = new Blob([formatChatTranscript({
+        session,
+        engagementName: engagement.name,
+        messages: authoritative,
+      })], { type: "text/markdown;charset=utf-8" });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = chatTranscriptFilename(session);
+      anchor.click();
+      globalThis.setTimeout(() => URL.revokeObjectURL(url), 0);
+    } catch (error) {
+      void logCaughtDiagnostic("interface.sessions_page.transcript_export", "A saved assistant transcript could not be exported.", error, "sessions_page");
+      setChatError(error instanceof Error ? error.message : "Could not export the saved transcript.");
+    } finally {
+      setExportingSessionId(undefined);
+    }
+  };
+
+  const copyConversationLink = async (session: ChatSessionSummary) => {
+    setSessionActionsId(undefined);
+    const url = new URL(window.location.origin + window.location.pathname);
+    url.searchParams.set("view", "chat");
+    url.searchParams.set("session", session.id);
+    try {
+      await copySelectionText(url.toString());
+      setMessageActionStatus("Conversation link copied without authentication material.");
+    } catch (error) {
+      void logCaughtDiagnostic("interface.sessions_page.link_copy", "A conversation link could not be copied.", error, "sessions_page");
+      setChatError(error instanceof Error ? error.message : "Could not copy the conversation link.");
     }
   };
 
@@ -1454,6 +1594,28 @@ export function SessionsPage() {
     }
   };
 
+  const copyMessage = async (message: ConversationMessage) => {
+    try {
+      await copySelectionText(message.content);
+      setMessageActionStatus(`${message.role === "assistant" ? "Assistant response" : "Operator message"} copied exactly.`);
+    } catch (error) {
+      void logCaughtDiagnostic("interface.sessions_page.message_copy", "A chat message could not be copied.", error, "sessions_page");
+      setChatError(error instanceof Error ? error.message : "Could not copy the message.");
+    }
+  };
+
+  const quoteMessage = (message: ConversationMessage) => {
+    const quoted = message.content.split("\n").map((line) => `> ${line}`).join("\n");
+    setDraft((current) => current ? `${current}\n\n${quoted}\n\n` : `${quoted}\n\n`);
+    setMessageActionStatus("Quoted message added to the editable composer draft.");
+    globalThis.requestAnimationFrame?.(() => {
+      const composer = composerRef.current;
+      if (!composer) return;
+      composer.focus();
+      composer.setSelectionRange(composer.value.length, composer.value.length);
+    });
+  };
+
   useEffect(() => {
     if (!requestedSessionId) {
       explicitNewConversationRef.current = false;
@@ -1701,18 +1863,22 @@ export function SessionsPage() {
     }
   };
 
-  const attachImages = async (event: ChangeEvent<HTMLInputElement>) => {
-    const files = [...(event.target.files ?? [])];
-    event.target.value = "";
-    if (!files.length || !api || !engagement) return;
+  const attachImageFiles = async (files: File[]) => {
+    if (!files.length || !api || !engagement || uploadingImage) return;
     if (!imageInputEnabled) {
       setChatError("The selected runtime has not advertised image input support.");
+      return;
+    }
+    const remaining = Math.max(0, 4 - pendingImages.length);
+    if (!remaining) {
+      setChatError("A message can contain up to four images. Remove one before adding another.");
       return;
     }
     setUploadingImage(true);
     setChatError(undefined);
     try {
-      const uploaded = await Promise.all(files.slice(0, 4).map(async (file) => {
+      const acceptedFiles = files.slice(0, remaining);
+      const uploaded = await Promise.all(acceptedFiles.map(async (file) => {
         if (!["image/png", "image/jpeg", "image/webp"].includes(file.type)) {
           throw new Error(`${file.name} is not a PNG, JPEG, or WebP image.`);
         }
@@ -1745,13 +1911,36 @@ export function SessionsPage() {
           },
         };
       }));
-      setPendingImages((current) => [...current, ...uploaded].slice(0, 4));
+      setPendingImages((current) => [...current, ...uploaded]);
+      if (files.length > acceptedFiles.length) {
+        setChatError(`Attached ${acceptedFiles.length} image${acceptedFiles.length === 1 ? "" : "s"}; a message can contain up to four.`);
+      }
     } catch (error) {
       logCaughtDiagnostic("interface.chat.image_upload_failed", "A chat image could not be attached.", error, "chat-media");
       setChatError(error instanceof Error ? error.message : "The image could not be attached.");
     } finally {
       setUploadingImage(false);
     }
+  };
+
+  const attachImages = async (event: ChangeEvent<HTMLInputElement>) => {
+    const files = [...(event.target.files ?? [])];
+    event.target.value = "";
+    await attachImageFiles(files);
+  };
+
+  const pasteComposerImages = (event: ReactClipboardEvent<HTMLTextAreaElement>) => {
+    const files = [...event.clipboardData.files].filter((file) => file.type.startsWith("image/"));
+    if (!files.length) return;
+    event.preventDefault();
+    void attachImageFiles(files);
+  };
+
+  const dropComposerImages = (event: ReactDragEvent<HTMLFormElement>) => {
+    const files = [...event.dataTransfer.files].filter((file) => file.type.startsWith("image/"));
+    if (!files.length) return;
+    event.preventDefault();
+    void attachImageFiles(files);
   };
 
   const removePendingImage = (index: number) => {
@@ -1795,6 +1984,12 @@ export function SessionsPage() {
 
   const submit = async (event: FormEvent) => {
     event.preventDefault();
+    if (sending) {
+      if (runtimeKind === "harness" && selectedHarness?.capabilities?.steering && draft.trim()) {
+        await steerCurrentHarness(draft);
+      }
+      return;
+    }
     const content = draft.trim() || (pendingImages.length ? "Attached image" : "");
     const providerRuntime = runtimeKind === "provider" ? selectedProvider : undefined;
     const harnessRuntime = runtimeKind === "harness" ? selectedHarness : undefined;
@@ -1836,8 +2031,8 @@ export function SessionsPage() {
 
     let contextAttachments: ChatCompletionRequest["contextAttachments"];
     try {
-      contextAttachments = assistantDraft
-        ? [await createHashedSelectionAttachment(assistantDraft)]
+      contextAttachments = assistantDrafts.length
+        ? await Promise.all(assistantDrafts.map(createHashedSelectionAttachment))
         : undefined;
     } catch (attachmentError) {
       void logCaughtDiagnostic("interface.sessions_page.caught_failure_12", "A handled interface operation failed.", attachmentError, "sessions_page");
@@ -1872,10 +2067,11 @@ export function SessionsPage() {
       durable: false,
     };
     setMessages((current) => [...current, userMessage, assistantMessage]);
+    if (activeDraftStorageKey) clearChatDraft(sessionStorage, activeDraftStorageKey);
     setDraft("");
     pendingImages.forEach((image) => URL.revokeObjectURL(image.previewUrl));
     setPendingImages([]);
-    clearAssistantDraft();
+    clearAssistantDrafts();
     setChatError(undefined);
     setSending(true);
     if (runtimeKind === "harness") {
@@ -2209,15 +2405,22 @@ export function SessionsPage() {
     abortRef.current?.abort();
   };
 
-  const steerCurrentHarness = async () => {
+  const steerCurrentHarness = async (guidance?: string) => {
     if (!api || harnessControlBusy) return;
     const turnId = harnessProgress?.turnId ?? harnessActivity?.turnId;
     if (!turnId) return;
-    const text = globalThis.prompt("Add guidance to the active harness turn");
-    if (!text?.trim()) return;
+    const text = guidance?.trim();
+    if (!text) {
+      composerRef.current?.focus();
+      return;
+    }
     setHarnessControlBusy(true);
+    setChatError(undefined);
     try {
-      await api.steerHarnessTurn(turnId, text.trim());
+      await api.steerHarnessTurn(turnId, text);
+      if (activeDraftStorageKey) clearChatDraft(sessionStorage, activeDraftStorageKey);
+      setDraft("");
+      setMessageActionStatus("Guidance sent to the active harness turn.");
     } catch (error) {
       void logCaughtDiagnostic("interface.sessions_page.harness_steer", "The active harness turn could not be steered.", error, "sessions_page");
       setChatError(error instanceof Error ? error.message : "Could not steer the harness turn.");
@@ -2409,6 +2612,12 @@ export function SessionsPage() {
     };
   }, [workbenchActionsOpen]);
   const canSend = Boolean(api && coreState === "online" && engagement && runtimeReady && model.trim() && (draft.trim() || pendingImages.length) && !sending && !uploadingImage);
+  const canSteerCurrentHarness = Boolean(
+    sending
+    && runtimeKind === "harness"
+    && selectedHarness?.capabilities?.steering
+    && (harnessProgress?.turnId || harnessActivity?.turnId),
+  );
   const visibleHarnessProgress: HarnessProgress | undefined = runtimeKind !== "harness" || !harnessSessionId
     ? harnessProgress
     : harnessProgress ?? (harnessActivityError
@@ -2498,12 +2707,13 @@ export function SessionsPage() {
 
       <div className={`session-layout ${view}${mobileListOpen ? " mobile-list-open" : ""}${view === "chat" && conversationPanelOpen ? " conversation-panel-open" : ""}${view === "chat" && sessionInspectorOpen ? " inspector-open" : ""}`}>
         {view === "chat" && (conversationPanelOpen || mobileListOpen) && <aside className="session-list" id="workbench-conversations" aria-label="Conversations">
-          <header><div><span>Conversations</span><strong>{sessions.length} saved</strong></div><div className="session-list-header-actions"><details ref={conversationMenuRef} className="conversation-list-menu"><summary className="icon-button subtle" role="button" aria-label="More conversation actions" aria-haspopup="menu" title="More conversation actions"><MoreHorizontal size={17} /></summary><div role="menu"><button className="danger" type="button" role="menuitem" title={sending || pendingResponse ? "Wait for the active response to finish" : "Delete all conversations"} disabled={!sessions.length || Boolean(deletingSessionId) || deletingAllSessions || sending || Boolean(pendingResponse)} onClick={() => { if (conversationMenuRef.current) conversationMenuRef.current.open = false; void deleteAllConversations(); }}>{deletingAllSessions ? <LoaderCircle className="spin" size={14} /> : <Trash2 size={14} />} Delete all conversations</button></div></details><button className="icon-button subtle" type="button" aria-label="New conversation" disabled={!engagement} onClick={newConversation}><Plus size={16} /></button><button className="icon-button subtle conversation-pane-close" type="button" aria-label="Hide conversations" onClick={closeConversationPanel}><PanelLeftClose size={16} /></button></div></header>
+          <header><div><span>Conversations</span><strong>{sessionQuery ? `${visibleSessions.length} of ${sessions.length}` : `${sessions.length} saved`}</strong></div><div className="session-list-header-actions"><details ref={conversationMenuRef} className="conversation-list-menu"><summary className="icon-button subtle" role="button" aria-label="More conversation actions" aria-haspopup="menu" title="More conversation actions"><MoreHorizontal size={17} /></summary><div role="menu"><button className="danger" type="button" role="menuitem" title={sending || pendingResponse ? "Wait for the active response to finish" : "Delete all conversations"} disabled={!sessions.length || Boolean(deletingSessionId) || deletingAllSessions || sending || Boolean(pendingResponse)} onClick={() => { if (conversationMenuRef.current) conversationMenuRef.current.open = false; void deleteAllConversations(); }}>{deletingAllSessions ? <LoaderCircle className="spin" size={14} /> : <Trash2 size={14} />} Delete all conversations</button></div></details><button className="icon-button subtle" type="button" aria-label="New conversation" disabled={!engagement} onClick={newConversation}><Plus size={16} /></button><button className="icon-button subtle conversation-pane-close" type="button" aria-label="Hide conversations" onClick={closeConversationPanel}><PanelLeftClose size={16} /></button></div></header>
+          <label className="session-list-search"><Search size={14} aria-hidden="true" /><span className="sr-only">Search conversations</span><input type="search" aria-label="Search conversations" value={sessionQuery} placeholder="Search title or runtime" onChange={(event) => setSessionQuery(event.target.value)} />{sessionQuery && <button className="icon-button subtle" type="button" aria-label="Clear conversation search" onClick={() => setSessionQuery("")}><X size={13} /></button>}</label>
           <nav>
             <button className={conversationOpen && !sessionId ? "active" : undefined} type="button" onClick={newConversation}><MessageSquare size={16} /><span><strong>New conversation</strong><small>{runtimeKind === "harness" ? selectedHarness?.name ?? "Choose a harness" : selectedProvider?.name ?? "Choose a provider"}</small></span></button>
-            {sessions.map((session) => {
+            {visibleSessions.map((session) => {
               const actionsOpen = sessionActionsId === session.id;
-              const actionsDisabled = deletingAllSessions || deletingSessionId === session.id || (session.id === sessionId && (sending || Boolean(pendingResponse)));
+              const actionsDisabled = deletingAllSessions || deletingSessionId === session.id || exportingSessionId === session.id || (session.id === sessionId && (sending || Boolean(pendingResponse)));
               const actionsDisabledReason = session.id === sessionId && (sending || pendingResponse) ? "Wait for the active response to finish" : undefined;
               return <div className={`session-list-item${session.id === sessionId ? " active" : ""}${renamingSessionId === session.id ? " renaming" : ""}${actionsOpen ? " actions-open" : ""}`} key={session.id}>{renamingSessionId === session.id ? <form className="session-rename-form" onSubmit={(event) => void renameConversation(event, session)}><label className="sr-only" htmlFor={`conversation-name-${session.id}`}>Conversation name</label><input id={`conversation-name-${session.id}`} aria-label={`Rename conversation ${session.title}`} autoFocus maxLength={300} value={renameDraft} onKeyDown={(event) => { if (event.key === "Escape") cancelRenamingConversation(); }} onChange={(event) => setRenameDraft(event.target.value)} /><button className="icon-button subtle" type="submit" aria-label="Save conversation name" disabled={!renameDraft.trim()}><Check size={14} /></button><button className="icon-button subtle" type="button" aria-label={`Cancel renaming ${session.title}`} onClick={cancelRenamingConversation}><X size={14} /></button></form> : <><button className="session-select" type="button" onClick={() => { setSessionActionsId(undefined); void selectSession(session.id); }}><MessageSquare size={16} /><span><strong title={session.title}>{session.title}</strong><small title={session.model || undefined}>{session.model || "Saved conversation"}</small></span></button><div className="session-item-actions"><button
                 ref={actionsOpen ? sessionActionsButtonRef : undefined}
@@ -2523,8 +2733,8 @@ export function SessionsPage() {
                     return;
                   }
                   const bounds = event.currentTarget.getBoundingClientRect();
-                  const menuWidth = 156;
-                  const menuHeight = 92;
+                  const menuWidth = 196;
+                  const menuHeight = 176;
                   const openAbove = window.innerHeight - bounds.bottom < menuHeight + 8 && bounds.top > menuHeight + 8;
                   setSessionActionsPosition({
                     left: Math.max(8, Math.min(bounds.right - menuWidth, window.innerWidth - menuWidth - 8)),
@@ -2549,8 +2759,9 @@ export function SessionsPage() {
                   const next = event.key === 'Home' ? 0 : event.key === 'End' ? items.length - 1 : event.key === 'ArrowDown' ? (current + 1) % items.length : (current - 1 + items.length) % items.length;
                   items[next]?.focus();
                 }}
-              ><button type="button" role="menuitem" onClick={() => startRenamingConversation(session)}><Pencil size={15} /> Rename</button><button className="danger" type="button" role="menuitem" onClick={() => { setSessionActionsId(undefined); void deleteConversation(session); }}><Trash2 size={15} /> Delete</button></div>, document.body)}</div></>}</div>;
+              ><button type="button" role="menuitem" onClick={() => void copyConversationLink(session)}><Copy size={15} /> Copy link</button><button type="button" role="menuitem" disabled={Boolean(exportingSessionId)} onClick={() => void exportConversation(session)}>{exportingSessionId === session.id ? <LoaderCircle className="spin" size={15} /> : <Download size={15} />} Export transcript</button><button type="button" role="menuitem" onClick={() => startRenamingConversation(session)}><Pencil size={15} /> Rename</button><button className="danger" type="button" role="menuitem" onClick={() => { setSessionActionsId(undefined); void deleteConversation(session); }}><Trash2 size={15} /> Delete</button></div>, document.body)}</div></>}</div>;
             })}
+            {sessionQuery && !visibleSessions.length && <div className="empty-state mini"><Search size={18} /><p>No conversations match “{sessionQuery}”.</p></div>}
             {renameError && <DiagnosticErrorNotice error={renameError} fallback="The session could not be renamed." compact />}
           </nav>
         </aside>}
@@ -2706,7 +2917,7 @@ export function SessionsPage() {
                       {runtimeKind === "harness" && ["error", "cancelled"].includes(message.state) && message.harnessTurnId && <button className="button quiet" type="button" disabled={harnessControlBusy} onClick={() => void retryHarnessMessage(message)}>Retry as linked turn</button>}
                       {message.citations.map((citation) => <Link className="citation-chip" to={`/knowledge?source=${encodeURIComponent(citation.sourceId)}`} title={citation.excerpt} key={`${citation.sourceId}-${citation.chunkId}`}><Braces size={13} /> {citation.name}{citation.page ? ` · p. ${citation.page}` : ""}</Link>)}
                       {message.usage && message.usage.totalTokens > 0 && <details className="chat-message-usage"><summary>{message.usage.totalTokens.toLocaleString()} tokens</summary><span>{message.usage.inputTokens.toLocaleString()} input · {message.usage.outputTokens.toLocaleString()} output</span></details>}
-                      {message.durable && sessionId && <footer className="chat-message-actions" aria-label="Message actions"><button className="icon-button subtle chat-fork-button" type="button" aria-label="Fork conversation here" title="Fork conversation here · files remain shared" disabled={sending} onClick={() => void forkConversation(message)}><GitFork size={14} /></button></footer>}
+                      {message.content && <footer className="chat-message-actions" aria-label="Message actions"><button className="icon-button subtle" type="button" aria-label="Copy message" title="Copy exact message" onClick={() => void copyMessage(message)}><Copy size={14} /></button><button className="icon-button subtle" type="button" aria-label="Quote in composer" title={sending && runtimeKind === "harness" && selectedHarness?.capabilities?.steering ? "Quote as guidance for the active turn" : "Quote in an editable draft"} onClick={() => quoteMessage(message)}><MessageSquareQuote size={14} /></button>{message.durable && sessionId && <button className="icon-button subtle chat-fork-button" type="button" aria-label="Fork conversation here" title="Fork conversation here · files remain shared" disabled={sending} onClick={() => void forkConversation(message)}><GitFork size={14} /></button>}</footer>}
                     </div>
                   </article>
                   );
@@ -2719,22 +2930,30 @@ export function SessionsPage() {
               </AssistantRuntimeProvider>
               {pendingResponse && pendingResponse.request.backend !== "harness" && <div className="chat-inline-approval-actions"><button className="button secondary" type="button" onClick={() => void decideInlineApproval("edit")}>Edit pending request</button></div>}
               {chatError && <DiagnosticErrorNotice error={chatError} fallback="The chat operation could not be completed." compact />}
+              {messageActionStatus && <div className="chat-action-status" role="status" aria-live="polite"><Check size={13} aria-hidden="true" /> {messageActionStatus}</div>}
               {showHarnessStatusRail && harnessActivity && <section className="harness-status-rail" aria-label="Harness status"><span className={`status-dot ${harnessActivity.live ? harnessActivity.busy ? "pending" : "available" : "unavailable"}`} /><strong>{!harnessActivity.live ? "Connection unavailable" : pendingHarnessRequests ? "Action required" : "Working"}</strong>{harnessActivity.goal && <span title={harnessActivity.goal.objective}>Goal: {harnessActivity.goal.status}{typeof harnessActivity.goal.progress === "number" ? ` · ${Math.round(harnessActivity.goal.progress * 100)}%` : ""}</span>}{harnessActivity.plan?.length ? <span>{harnessActivity.plan.filter((entry) => entry.status === "completed").length}/{harnessActivity.plan.length} plan steps</span> : null}{pendingHarnessRequests > 0 && <span>{pendingHarnessRequests} request{pendingHarnessRequests === 1 ? "" : "s"}</span>}</section>}
-              <form className="chat-composer" onSubmit={(event) => void submit(event)}>
-                {assistantDraft && <div className="chat-context-attachment" role="group" aria-label="Selected context attachment">
-                  <div className="chat-context-attachment-summary"><strong>{assistantDraft.source.label}</strong><small>{assistantDraft.text.length.toLocaleString()} characters{assistantDraft.truncated ? " · truncated to the first 20,000" : ""}</small></div>
-                  <div className="chat-context-attachment-actions"><button className="icon-button subtle" type="button" aria-label={quotedContextExpanded ? "Collapse quoted context" : "Expand quoted context"} aria-expanded={quotedContextExpanded} onClick={() => setQuotedContextExpanded((expanded) => !expanded)}><ChevronDown size={14} /></button><button className="icon-button subtle" type="button" aria-label="Remove selected context" onClick={clearAssistantDraft}><X size={14} /></button></div>
-                  {quotedContextExpanded && <p>{assistantDraft.text}</p>}
-                </div>}
+              <form className="chat-composer" onSubmit={(event) => void submit(event)} onDragOver={(event) => { if ([...event.dataTransfer.items].some((item) => item.kind === "file" && item.type.startsWith("image/"))) event.preventDefault(); }} onDrop={dropComposerImages}>
+                {assistantDrafts.length > 0 && <section className="chat-context-pack" aria-label="Selected context pack">
+                  <header><div><strong>Context pack</strong><small>{assistantDrafts.length} selection{assistantDrafts.length === 1 ? "" : "s"} · {assistantDrafts.reduce((total, item) => total + item.text.length, 0).toLocaleString()} characters</small></div><button className="button quiet" type="button" onClick={clearAssistantDrafts}>Clear all</button></header>
+                  <div role="list">{assistantDrafts.map((item, index) => {
+                    const expanded = expandedContextIndex === index;
+                    return <div className="chat-context-attachment" role="listitem" key={`${item.source.kind}:${item.source.id ?? item.source.label}:${index}`}>
+                      <div className="chat-context-attachment-summary"><strong>{item.source.label}</strong><small>{item.source.kind.replaceAll("_", " ")} · {item.text.length.toLocaleString()} characters{item.truncated ? " · truncated" : ""}</small></div>
+                      <div className="chat-context-attachment-actions"><button className="icon-button subtle" type="button" aria-label={expanded ? `Collapse ${item.source.label}` : `Expand ${item.source.label}`} aria-expanded={expanded} onClick={() => setExpandedContextIndex(expanded ? undefined : index)}><ChevronDown size={14} /></button><button className="icon-button subtle" type="button" aria-label={`Remove ${item.source.label} from context`} onClick={() => removeAssistantDraft(index)}><X size={14} /></button></div>
+                      {expanded && <p>{item.text}</p>}
+                    </div>;
+                  })}</div>
+                  {assistantDraftNotice && <div className="chat-context-pack-notice" role="status"><span>{assistantDraftNotice}</span><button className="icon-button subtle" type="button" aria-label="Dismiss context notice" onClick={clearAssistantDraftNotice}><X size={13} /></button></div>}
+                </section>}
                 {pendingImages.length > 0 && <div className="chat-image-attachments" role="list" aria-label="Image attachments">{pendingImages.map((image, index) => <div role="listitem" key={`${image.block.artifactId}-${index}`}><img src={image.previewUrl} alt={image.filename} /><button className="icon-button subtle" type="button" aria-label={`Remove ${image.filename}`} onClick={() => removePendingImage(index)}><X size={14} /></button></div>)}</div>}
                 <label className="sr-only" htmlFor="analyst-message">Message the analyst assistant</label>
                 <div className="chat-composer-input" role="combobox" aria-label="Skill suggestions" aria-autocomplete="list" aria-expanded={Boolean(skillToken)} aria-controls={skillToken ? "harness-skill-menu" : undefined} aria-activedescendant={skillToken && matchingHarnessSkills.length ? `harness-skill-option-${skillMenuIndex}` : undefined}>
-                  <textarea ref={composerRef} id="analyst-message" data-selection-actions-disabled="true" value={draft} disabled={!engagement || !runtimeReady || loadingHistory} placeholder={!engagement ? "Create or select a project to chat…" : runtimeReady ? "Ask about this project…" : "Add a model or harness in Settings…"} rows={1} onFocus={() => setAssistantSettingsOpen(false)} onKeyDown={onComposerKeyDown} onChange={(event) => updateComposerDraft(event.target.value, event.target.selectionStart ?? event.target.value.length)} />
+                  <textarea ref={composerRef} id="analyst-message" data-selection-actions-disabled="true" value={draft} disabled={!engagement || !runtimeReady || loadingHistory} placeholder={!engagement ? "Create or select a project to chat…" : canSteerCurrentHarness ? "Add guidance while the harness works…" : runtimeReady ? "Ask about this project…" : "Add a model or harness in Settings…"} rows={1} onFocus={() => setAssistantSettingsOpen(false)} onPaste={pasteComposerImages} onKeyDown={onComposerKeyDown} onChange={(event) => updateComposerDraft(event.target.value, event.target.selectionStart ?? event.target.value.length)} />
                   {skillToken && <HarnessSkillAutocomplete skills={harnessSkills} token={skillToken} activeIndex={skillMenuIndex} onActiveIndexChange={setSkillMenuIndex} onSelect={selectHarnessSkill} onClose={() => setSkillToken(undefined)} />}
                 </div>
-                <footer><button ref={assistantSettingsButtonRef} className={`button quiet chat-runtime-summary chat-settings-trigger${runtimeReady ? "" : " needs-attention"}`} type="button" aria-label="Assistant settings" aria-expanded={assistantSettingsOpen} aria-controls="assistant-settings-popover" title={runtimeReady ? `${assistantSource}${runtimeConfiguration ? ` · ${runtimeConfiguration}` : ""}` : "Choose an assistant runtime"} onClick={() => setAssistantSettingsOpen((open) => !open)}><Settings2 size={15} aria-hidden="true" /><span><strong>{assistantSource}</strong><small> · {runtimeConfiguration || "Choose a model"}</small></span></button><input ref={imageInputRef} className="sr-only" type="file" aria-label="Choose image attachments" accept="image/png,image/jpeg,image/webp" multiple onChange={(event) => void attachImages(event)} /><button className="button quiet square chat-composer-attachment" type="button" aria-label="Attach images" disabled={!imageInputEnabled || uploadingImage || pendingImages.length >= 4} title={imageInputEnabled ? "Attach PNG, JPEG, or WebP images" : "The selected runtime does not advertise image input"} onClick={() => imageInputRef.current?.click()}>{uploadingImage ? <LoaderCircle className="spin" size={15} /> : <ImagePlus size={15} />}</button>{sending ? <button className="button secondary square chat-composer-submit" type="button" aria-label="Stop response" disabled={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false} title={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false ? "This harness does not advertise turn interruption" : undefined} onClick={() => void stopCurrentResponse()}><Square size={15} /></button> : <button className="button primary square chat-composer-submit" type="submit" disabled={!canSend} aria-label="Send message"><Send size={16} /></button>}</footer>
+                <footer><button ref={assistantSettingsButtonRef} className={`button quiet chat-runtime-summary chat-settings-trigger${runtimeReady ? "" : " needs-attention"}`} type="button" aria-label="Assistant settings" aria-expanded={assistantSettingsOpen} aria-controls="assistant-settings-popover" title={runtimeReady ? `${assistantSource}${runtimeConfiguration ? ` · ${runtimeConfiguration}` : ""}` : "Choose an assistant runtime"} onClick={() => setAssistantSettingsOpen((open) => !open)}><Settings2 size={15} aria-hidden="true" /><span><strong>{assistantSource}</strong><small> · {runtimeConfiguration || "Choose a model"}</small></span></button>{sessionId && <button className={`button quiet chat-context-meter status-${activeContextStatus?.status ?? "loading"}`} type="button" aria-label={contextPercent === undefined ? "Open context details" : `Open context details, ${contextPercent} percent of target input used`} title={activeContextStatus?.status === "runtime_managed" ? "Context is managed by the harness runtime" : contextPercent === undefined ? "Read authoritative context status" : `${activeContextStatus?.estimatedInputTokens.toLocaleString()} of ${activeContextStatus?.targetInputTokens.toLocaleString()} target input tokens`} onClick={() => { localStorage.setItem("nebula.session-inspector.open", "true"); setSessionInspectorOpen(true); }}><span aria-hidden="true" style={contextPercent === undefined ? undefined : { "--context-percent": `${contextPercent}%` } as CSSProperties}>{contextPercent === undefined ? "—" : contextPercent}</span><small>context</small></button>}<input ref={imageInputRef} className="sr-only" type="file" aria-label="Choose image attachments" accept="image/png,image/jpeg,image/webp" multiple onChange={(event) => void attachImages(event)} /><button className="button quiet square chat-composer-attachment" type="button" aria-label="Attach images" disabled={!imageInputEnabled || uploadingImage || pendingImages.length >= 4} title={imageInputEnabled ? "Choose, paste, or drop PNG, JPEG, or WebP images" : "The selected runtime does not advertise image input"} onClick={() => imageInputRef.current?.click()}>{uploadingImage ? <LoaderCircle className="spin" size={15} /> : <ImagePlus size={15} />}</button>{canSteerCurrentHarness && draft.trim() && <button className="button primary square chat-composer-submit" type="submit" disabled={harnessControlBusy} aria-label="Send guidance now" title="Steer the active harness turn"><Send size={16} /></button>}{sending ? <button className="button secondary square chat-composer-submit" type="button" aria-label="Stop response" disabled={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false} title={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false ? "This harness does not advertise turn interruption" : undefined} onClick={() => void stopCurrentResponse()}><Square size={15} /></button> : <button className="button primary square chat-composer-submit" type="submit" disabled={!canSend} aria-label="Send message"><Send size={16} /></button>}</footer>
               </form>
-              {showHarnessProgress && visibleHarnessProgress && <div className={`chat-harness-progress phase-${visibleHarnessProgress.phase}`} role="status" aria-live="polite"><span className={`status-dot ${visibleHarnessProgress.phase === "failed" || visibleHarnessProgress.phase === "status_unavailable" ? "unavailable" : "pending"}`} /><div><strong>{harnessPhaseLabel(visibleHarnessProgress.phase)}</strong><small>{visibleHarnessProgress.detail}</small>{visibleHarnessProgress.sessionId && <code title={visibleHarnessProgress.sessionId}>Session {visibleHarnessProgress.sessionId.slice(0, 8)}{visibleHarnessProgress.previousSessionId ? " · independent parallel session" : ""}</code>}</div>{sending && selectedHarness?.capabilities?.steering && <button className="button quiet harness-steer-button" type="button" disabled={harnessControlBusy} onClick={() => void steerCurrentHarness()}><Plus size={13} aria-hidden="true" /> Add guidance</button>}</div>}
+              {showHarnessProgress && visibleHarnessProgress && <div className={`chat-harness-progress phase-${visibleHarnessProgress.phase}`} role="status" aria-live="polite"><span className={`status-dot ${visibleHarnessProgress.phase === "failed" || visibleHarnessProgress.phase === "status_unavailable" ? "unavailable" : "pending"}`} /><div><strong>{harnessPhaseLabel(visibleHarnessProgress.phase)}</strong><small>{visibleHarnessProgress.detail}</small>{visibleHarnessProgress.sessionId && <code title={visibleHarnessProgress.sessionId}>Session {visibleHarnessProgress.sessionId.slice(0, 8)}{visibleHarnessProgress.previousSessionId ? " · independent parallel session" : ""}</code>}</div>{sending && selectedHarness?.capabilities?.steering && <button className="button quiet harness-steer-button" type="button" disabled={harnessControlBusy} onClick={() => composerRef.current?.focus()}><Plus size={13} aria-hidden="true" /> Add guidance</button>}</div>}
             </div>
           )}
         </section>
@@ -2743,6 +2962,13 @@ export function SessionsPage() {
           <header><div><span>Context</span><strong>Session details</strong></div></header>
           <dl><div><dt>Active operator</dt><dd>{activeOperator?.displayName ?? "No active operator"}</dd></div><div><dt>Conversation</dt><dd>{conversationOpen ? sessionId ? sessions.find((session) => session.id === sessionId)?.title ?? "Saved chat" : "Unsaved chat" : "None selected"}</dd></div><div><dt>Runtime</dt><dd>{runtimeKind === "harness" ? selectedHarness?.name ?? "Harness" : selectedProvider?.name ?? "Not selected"}</dd></div>{runtimeKind === "harness" && <div><dt>Model configuration</dt><dd>{model || "Not selected"}{harnessReasoningEffort ? ` · ${harnessReasoningEffort} effort` : ""}{harnessServiceTier ? ` · ${harnessServiceTier} speed` : ""}</dd></div>}{runtimeKind === "harness" && harnessSessionId && <div><dt>Harness session</dt><dd><code title={harnessSessionId}>{harnessSessionId}</code></dd></div>}<div><dt>Code Run</dt><dd><span className={`status-dot ${executionCapabilities?.ready ? "healthy" : "unavailable"}`} /> {executionCapabilities?.ready ? "Review available" : "Unavailable"}</dd></div></dl>
           {sessionId && sessions.find((session) => session.id === sessionId)?.backend === "harness" && <button className="button primary full" type="button" disabled={sending} onClick={() => void continueAsMission()}><Bot size={15} /> Continue as mission</button>}
+          <section className="session-context-health"><h3>Working context</h3>{!sessionId ? <p>Context becomes durable after the first saved turn.</p> : contextStatusLoading && !activeContextStatus ? <div className="chat-thinking"><LoaderCircle className="spin" size={14} /> Reading Core context…</div> : contextStatusError ? <div className="session-context-error"><p>{contextStatusError}</p><button className="button quiet" type="button" onClick={() => setContextRefreshKey((value) => value + 1)}>Retry</button></div> : activeContextStatus ? <><div className="session-context-summary"><span className={`status-dot ${activeContextStatus.status === "failed" ? "unavailable" : activeContextStatus.status === "stale" ? "pending" : "healthy"}`} /><div><strong>{activeContextStatus.status === "runtime_managed" ? "Harness managed" : activeContextStatus.status.replaceAll("_", " ")}</strong><small>{activeContextStatus.status === "runtime_managed" ? "The selected harness owns compaction and reports its usage through activity." : `${activeContextStatus.estimatedInputTokens.toLocaleString()} estimated · ${activeContextStatus.targetInputTokens.toLocaleString()} target input tokens`}</small></div></div>{contextPercent !== undefined && <div className="session-context-progress" aria-label={`${contextPercent} percent of target input used`}><span style={{ width: `${contextPercent}%` }} /></div>}{activeContextStatus.compactedThrough > 0 && <p>Core compacted through message {activeContextStatus.compactedThrough}; the source transcript remains unchanged.</p>}{activeContextStatus.snapshot?.memory && <details className="session-memory"><summary>Inspect saved memory</summary><div>{activeContextStatus.snapshot.memory.objective && <section><strong>Objective</strong><p>{activeContextStatus.snapshot.memory.objective}</p></section>}<section><strong>Summary</strong><p>{activeContextStatus.snapshot.memory.summary}</p></section>{([
+              ["Confirmed facts", activeContextStatus.snapshot.memory.confirmedFacts],
+              ["Decisions", activeContextStatus.snapshot.memory.decisions],
+              ["Constraints", activeContextStatus.snapshot.memory.constraints],
+              ["Corrections", activeContextStatus.snapshot.memory.corrections],
+              ["Open questions", activeContextStatus.snapshot.memory.openQuestions],
+            ] as const).map(([label, items]) => items.length ? <section key={label}><strong>{label}</strong><ul>{items.map((item, index) => <li key={`${label}-${index}`}>{item.text}</li>)}</ul></section> : null)}<small>{activeContextStatus.snapshot.sourceReferences.length} source reference{activeContextStatus.snapshot.sourceReferences.length === 1 ? "" : "s"} · private reasoning is not stored</small></div></details>}</> : <p>Context status has not been recorded yet.</p>}</section>
           <section><h3>Knowledge boundary</h3><div className="scope-chip-list"><span>{knowledgeSources.length} project · {libraryItems.length} Library</span><span>{providerIsLocal ? "Local retrieval" : includeKnowledge && canUseKnowledge ? "Confirm each cloud request" : "Text only"}</span></div></section>
           <section><h3>Execution boundary</h3><div className="empty-state mini"><Braces size={19} /><p>{canUseTools ? "Bash commands run in this session's isolated container; configured approvals pause this response." : commandRuntimeUnavailableReason ?? "Command runtime is unavailable for this session."}</p></div></section>
           <section><h3>Session evidence</h3><div className="empty-state mini"><Braces size={19} /><p>Citations identify canonical ingested chunks and transcript messages.</p></div></section>

--- a/ui/src/pages/chatDraftStorage.test.ts
+++ b/ui/src/pages/chatDraftStorage.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { chatDraftStorageKey, clearChatDraft, readChatDraft, writeChatDraft } from "./chatDraftStorage";
+
+describe("assistant draft recovery", () => {
+  it("isolates unsent text by project and conversation", () => {
+    const storage = window.sessionStorage;
+    const first = chatDraftStorageKey("project/a", "session 1");
+    const second = chatDraftStorageKey("project/a", "session 2");
+    writeChatDraft(storage, first, "  exact unsent text\n");
+    writeChatDraft(storage, second, "another draft");
+
+    expect(readChatDraft(storage, first)).toBe("  exact unsent text\n");
+    expect(readChatDraft(storage, second)).toBe("another draft");
+    clearChatDraft(storage, first);
+    expect(readChatDraft(storage, first)).toBe("");
+    expect(readChatDraft(storage, second)).toBe("another draft");
+  });
+
+  it("removes empty drafts instead of retaining stale values", () => {
+    const key = chatDraftStorageKey("project", undefined);
+    writeChatDraft(window.sessionStorage, key, "draft");
+    writeChatDraft(window.sessionStorage, key, "");
+    expect(window.sessionStorage.getItem(key)).toBeNull();
+  });
+});

--- a/ui/src/pages/chatDraftStorage.ts
+++ b/ui/src/pages/chatDraftStorage.ts
@@ -1,0 +1,34 @@
+const DRAFT_PREFIX = "nebula.assistant.draft.v1";
+
+export function chatDraftStorageKey(engagementId: string, sessionId?: string): string {
+  return `${DRAFT_PREFIX}:${encodeURIComponent(engagementId)}:${encodeURIComponent(sessionId || "new")}`;
+}
+
+export function readChatDraft(storage: Storage, key: string): string {
+  try {
+    return storage.getItem(key) ?? "";
+  } catch {
+    // diagnostic-expected: constrained browsers may deny session storage.
+    return "";
+  }
+}
+
+export function writeChatDraft(storage: Storage, key: string, value: string): void {
+  try {
+    if (value) storage.setItem(key, value);
+    else storage.removeItem(key);
+  } catch {
+    // diagnostic-expected: draft recovery must not block the composer.
+    // Draft recovery is a device-local convenience. Chat remains usable when
+    // storage is disabled, full, or unavailable on a constrained LAN browser.
+  }
+}
+
+export function clearChatDraft(storage: Storage, key: string): void {
+  try {
+    storage.removeItem(key);
+  } catch {
+    // diagnostic-expected: draft cleanup must not block session deletion.
+    // See writeChatDraft: storage failure must not block the composer.
+  }
+}

--- a/ui/src/pages/chatTranscriptExport.test.ts
+++ b/ui/src/pages/chatTranscriptExport.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { ChatSessionSummary, PersistedChatMessage } from "../api/types";
+import { chatTranscriptFilename, formatChatTranscript } from "./chatTranscriptExport";
+
+const session: ChatSessionSummary = {
+  id: "session-123456789",
+  engagementId: "project-1",
+  title: "TLS / scope review",
+  backend: "harness",
+  harnessProfileId: "harness-1",
+  parentSessionId: "session-parent",
+  forkedFromMessageId: "message-parent",
+  model: "gpt-test",
+  toolsEnabled: true,
+  createdAt: "2026-08-24T10:00:00Z",
+  updatedAt: "2026-08-24T10:01:00Z",
+  revision: 1,
+};
+
+const messages: PersistedChatMessage[] = [{
+  id: "message-1",
+  engagementId: "project-1",
+  sessionId: session.id,
+  sequence: 1,
+  role: "user",
+  content: "Review 443/tcp.",
+  citations: [],
+  contextAttachments: [{
+    sourceKind: "terminal",
+    sourceId: "terminal-1",
+    sourceLabel: "Nmap result",
+    text: "443/tcp open https",
+    sha256: "a".repeat(64),
+    truncated: false,
+  }],
+  createdAt: "2026-08-24T10:00:30Z",
+  updatedAt: "2026-08-24T10:00:30Z",
+}];
+
+describe("assistant transcript export", () => {
+  it("records durable lineage and selected-context integrity metadata", () => {
+    const output = formatChatTranscript({
+      session,
+      engagementName: "External assessment",
+      messages,
+      exportedAt: new Date("2026-08-24T11:00:00Z"),
+    });
+    expect(output).toContain("Nebula session: `session-123456789`");
+    expect(output).toContain("Parent session: `session-parent`");
+    expect(output).toContain("Forked from message: `message-parent`");
+    expect(output).toContain("SHA-256: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`");
+    expect(output).toContain("```text\n443/tcp open https\n```");
+    expect(output).toContain("Review 443/tcp.");
+    expect(output).toContain("authoritative saved transcript");
+  });
+
+  it("builds a bounded portable filename", () => {
+    expect(chatTranscriptFilename(session)).toBe("TLS-scope-review-23456789.md");
+  });
+});

--- a/ui/src/pages/chatTranscriptExport.ts
+++ b/ui/src/pages/chatTranscriptExport.ts
@@ -1,0 +1,84 @@
+import type { ChatSessionSummary, PersistedChatMessage } from "../api/types";
+
+export interface ChatTranscriptExportInput {
+  session: ChatSessionSummary;
+  engagementName: string;
+  messages: PersistedChatMessage[];
+  exportedAt?: Date;
+}
+
+function safeFilename(value: string): string {
+  const normalized = value.trim().replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return (normalized || "nebula-conversation").slice(0, 120);
+}
+
+function line(label: string, value: string | number | undefined): string {
+  return `- ${label}: ${value === undefined || value === "" ? "not recorded" : value}`;
+}
+
+function markdownFence(value: string): string {
+  const longestRun = Math.max(0, ...[...value.matchAll(/`+/g)].map((match) => match[0].length));
+  return "`".repeat(Math.max(3, longestRun + 1));
+}
+
+export function formatChatTranscript(input: ChatTranscriptExportInput): string {
+  const { session, engagementName, messages } = input;
+  const exportedAt = (input.exportedAt ?? new Date()).toISOString();
+  const output = [
+    `# ${session.title}`,
+    "",
+    line("Nebula session", `\`${session.id}\``),
+    line("Project", engagementName),
+    line("Runtime", session.backend === "harness" ? "agent harness" : "provider"),
+    line("Model", session.model),
+    line("Created", session.createdAt),
+    line("Updated", session.updatedAt),
+    line("Exported", exportedAt),
+  ];
+  if (session.parentSessionId) output.push(line("Parent session", `\`${session.parentSessionId}\``));
+  if (session.forkedFromMessageId) output.push(line("Forked from message", `\`${session.forkedFromMessageId}\``));
+
+  for (const message of messages) {
+    output.push(
+      "",
+      `## ${message.role === "assistant" ? "Assistant" : "Operator"} · message ${message.sequence}`,
+      "",
+      line("Message ID", `\`${message.id}\``),
+      line("Recorded", message.createdAt),
+    );
+    if (message.harnessTurnId) output.push(line("Harness turn", `\`${message.harnessTurnId}\``));
+    if (message.usage?.totalTokens) output.push(line("Tokens", message.usage.totalTokens));
+    output.push("", message.content || "_No text content._");
+
+    if (message.contextAttachments.length) {
+      output.push("", "### Exact selected context");
+      for (const attachment of message.contextAttachments) {
+        const fence = markdownFence(attachment.text);
+        output.push(
+          "",
+          `#### ${attachment.sourceLabel} (${attachment.sourceKind})`,
+          "",
+          line("SHA-256", `\`${attachment.sha256}\``),
+          line("Characters", `${attachment.text.length}${attachment.truncated ? " · truncated" : ""}`),
+          line("Source ID", attachment.sourceId ? `\`${attachment.sourceId}\`` : undefined),
+          "",
+          `${fence}text`,
+          attachment.text,
+          fence,
+        );
+      }
+    }
+    if (message.citations.length) {
+      output.push("", "### Citations");
+      for (const citation of message.citations) {
+        output.push(`- ${citation.name}${citation.page ? ` · page ${citation.page}` : ""} · source \`${citation.sourceId}\` · chunk \`${citation.chunkId}\``);
+      }
+    }
+  }
+  output.push("", "---", "Exported from Nebula's authoritative saved transcript. Live tool artifacts and raw evidence remain in the project evidence bundle.", "");
+  return output.join("\n");
+}
+
+export function chatTranscriptFilename(session: ChatSessionSummary): string {
+  return `${safeFilename(session.title)}-${safeFilename(session.id).slice(-8) || "session"}.md`;
+}

--- a/ui/src/state/WorkbenchDraftContext.test.ts
+++ b/ui/src/state/WorkbenchDraftContext.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import type { SelectionActionDraft } from "../components/selection";
+import { ASSISTANT_CONTEXT_CHARACTER_LIMIT, mergeAssistantDraft } from "./WorkbenchDraftContext";
+
+function draft(text: string, id: string): SelectionActionDraft {
+  return {
+    text,
+    originalLength: text.length,
+    truncated: false,
+    source: { kind: "terminal", id, label: `Terminal ${id}` },
+    anchor: { left: 0, top: 0, right: 0, bottom: 0 },
+  };
+}
+
+describe("assistant context packs", () => {
+  it("appends distinct exact selections and deduplicates identical sources and bytes", () => {
+    const first = draft("443/tcp open", "one");
+    const second = draft("certificate expired", "two");
+    const merged = mergeAssistantDraft([first], second);
+    expect(merged.drafts).toEqual([first, second]);
+    const duplicate = mergeAssistantDraft(merged.drafts, second);
+    expect(duplicate.drafts).toBe(merged.drafts);
+    expect(duplicate.notice).toMatch(/already in the context pack/);
+  });
+
+  it("bounds the aggregate pack without splitting a surrogate pair", () => {
+    const current = [draft("x".repeat(ASSISTANT_CONTEXT_CHARACTER_LIMIT - 1), "one")];
+    const merged = mergeAssistantDraft(current, draft("😀tail", "two"));
+    expect(merged.drafts).toEqual(current);
+    expect(merged.notice).toMatch(/full/);
+  });
+
+  it("marks the newest item truncated when only a bounded suffix fits", () => {
+    const current = [draft("x".repeat(ASSISTANT_CONTEXT_CHARACTER_LIMIT - 3), "one")];
+    const merged = mergeAssistantDraft(current, draft("abcde", "two"));
+    expect(merged.drafts[1]).toMatchObject({ text: "abc", truncated: true });
+    expect(merged.drafts.reduce((total, item) => total + item.text.length, 0)).toBe(ASSISTANT_CONTEXT_CHARACTER_LIMIT);
+  });
+});

--- a/ui/src/state/WorkbenchDraftContext.tsx
+++ b/ui/src/state/WorkbenchDraftContext.tsx
@@ -23,17 +23,72 @@ export interface NebulaDraftRequest {
 }
 
 interface WorkbenchDraftContextValue {
-  assistantDraft?: SelectionActionDraft;
+  assistantDrafts: SelectionActionDraft[];
+  assistantDraftNotice?: string;
   noteDraft?: SelectionActionDraft;
   executionDraft?: SelectionActionDraft;
   requestNebulaDraft(request: NebulaDraftRequest): void;
   requestNoteDraft(request: NebulaDraftRequest): void;
-  clearAssistantDraft(): void;
+  removeAssistantDraft(index: number): void;
+  clearAssistantDrafts(): void;
+  clearAssistantDraftNotice(): void;
   clearNoteDraft(): void;
   clearExecutionDraft(): void;
 }
 
 const WorkbenchDraftContext = createContext<WorkbenchDraftContextValue | undefined>(undefined);
+
+export const ASSISTANT_CONTEXT_CHARACTER_LIMIT = 20_000;
+export const ASSISTANT_CONTEXT_ITEM_LIMIT = 20;
+
+interface AssistantDraftMerge {
+  drafts: SelectionActionDraft[];
+  notice?: string;
+}
+
+function sameAssistantDraft(left: SelectionActionDraft, right: SelectionActionDraft): boolean {
+  return left.source.kind === right.source.kind
+    && left.source.id === right.source.id
+    && left.source.label === right.source.label
+    && left.text === right.text;
+}
+
+/** Keeps the browser pack inside Core's exact 20-item / 20,000-character contract. */
+export function mergeAssistantDraft(
+  current: SelectionActionDraft[],
+  next: SelectionActionDraft,
+): AssistantDraftMerge {
+  if (current.some((item) => sameAssistantDraft(item, next))) {
+    return { drafts: current, notice: `${next.source.label} is already in the context pack.` };
+  }
+  if (current.length >= ASSISTANT_CONTEXT_ITEM_LIMIT) {
+    return { drafts: current, notice: `A context pack can contain up to ${ASSISTANT_CONTEXT_ITEM_LIMIT} selections.` };
+  }
+  const used = current.reduce((total, item) => total + item.text.length, 0);
+  let remaining = ASSISTANT_CONTEXT_CHARACTER_LIMIT - used;
+  if (remaining <= 0) {
+    return { drafts: current, notice: "The 20,000-character context pack is full. Remove a selection before adding another." };
+  }
+  if (next.text.length <= remaining) return { drafts: [...current, next] };
+  if (
+    remaining > 0
+    && next.text.charCodeAt(remaining - 1) >= 0xd800
+    && next.text.charCodeAt(remaining - 1) <= 0xdbff
+    && next.text.charCodeAt(remaining) >= 0xdc00
+    && next.text.charCodeAt(remaining) <= 0xdfff
+  ) remaining -= 1;
+  if (remaining <= 0) {
+    return { drafts: current, notice: "The 20,000-character context pack is full. Remove a selection before adding another." };
+  }
+  return {
+    drafts: [...current, {
+      ...next,
+      text: next.text.slice(0, remaining),
+      truncated: true,
+    }],
+    notice: `${next.source.label} was bounded to the remaining ${remaining.toLocaleString()} context characters.`,
+  };
+}
 
 function toSelectionDraft(request: NebulaDraftRequest): SelectionActionDraft | undefined {
   const draft = createSelectionDraft({
@@ -64,14 +119,15 @@ function sourceForRoute(pathname: string, element: Element | null): SelectionSou
 export function WorkbenchDraftProvider({ children }: PropsWithChildren) {
   const location = useLocation();
   const navigate = useNavigate();
-  const [assistantDraft, setAssistantDraft] = useState<SelectionActionDraft>();
+  const [assistantContext, setAssistantContext] = useState<AssistantDraftMerge>({ drafts: [] });
+  const { drafts: assistantDrafts, notice: assistantDraftNotice } = assistantContext;
   const [noteDraft, setNoteDraft] = useState<SelectionActionDraft>();
   const [executionDraft, setExecutionDraft] = useState<SelectionActionDraft>();
 
   const requestNebulaDraft = useCallback((request: NebulaDraftRequest) => {
     const next = toSelectionDraft(request);
     if (!next) return;
-    setAssistantDraft(next);
+    setAssistantContext((current) => mergeAssistantDraft(current.drafts, next));
     navigate("/?view=chat");
   }, [navigate]);
 
@@ -83,7 +139,7 @@ export function WorkbenchDraftProvider({ children }: PropsWithChildren) {
   }, [navigate]);
 
   const openAssistantSelection = useCallback((draft: SelectionActionDraft) => {
-    setAssistantDraft(draft);
+    setAssistantContext((current) => mergeAssistantDraft(current.drafts, draft));
     navigate("/?view=chat");
   }, [navigate]);
   const openNoteSelection = useCallback((draft: SelectionActionDraft) => {
@@ -94,7 +150,17 @@ export function WorkbenchDraftProvider({ children }: PropsWithChildren) {
     setExecutionDraft(draft);
     navigate("/?view=terminal");
   }, [navigate]);
-  const clearAssistantDraft = useCallback(() => setAssistantDraft(undefined), []);
+  const removeAssistantDraft = useCallback((index: number) => {
+    setAssistantContext((current) => ({
+      drafts: current.drafts.filter((_, currentIndex) => currentIndex !== index),
+    }));
+  }, []);
+  const clearAssistantDrafts = useCallback(() => {
+    setAssistantContext({ drafts: [] });
+  }, []);
+  const clearAssistantDraftNotice = useCallback(() => {
+    setAssistantContext((current) => ({ drafts: current.drafts }));
+  }, []);
   const clearNoteDraft = useCallback(() => setNoteDraft(undefined), []);
   const clearExecutionDraft = useCallback(() => setExecutionDraft(undefined), []);
   const resolveSource = useCallback(
@@ -103,21 +169,27 @@ export function WorkbenchDraftProvider({ children }: PropsWithChildren) {
   );
 
   const value = useMemo<WorkbenchDraftContextValue>(() => ({
-    assistantDraft,
+    assistantDrafts,
+    assistantDraftNotice,
     noteDraft,
     executionDraft,
     requestNebulaDraft,
     requestNoteDraft,
-    clearAssistantDraft,
+    removeAssistantDraft,
+    clearAssistantDrafts,
+    clearAssistantDraftNotice,
     clearNoteDraft,
     clearExecutionDraft,
   }), [
-    assistantDraft,
-    clearAssistantDraft,
+    assistantDrafts,
+    assistantDraftNotice,
+    clearAssistantDraftNotice,
+    clearAssistantDrafts,
     clearNoteDraft,
     clearExecutionDraft,
     executionDraft,
     noteDraft,
+    removeAssistantDraft,
     requestNebulaDraft,
     requestNoteDraft,
   ]);

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -624,6 +624,48 @@ test("terminal pointer selection has a visible high-contrast highlight", async (
     && background !== "rgb(0, 0, 0)")).toBe(true);
 });
 
+test("assistant context pack stays exact, compact, and accessible", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop" && !testInfo.project.name.startsWith("mobile-"), "Covered by one desktop and the permanent mobile browser projects.");
+  await openWorkspace(page, "/project", "Scratch Project");
+  const heading = page.getByRole("heading", { name: "Scratch Project", exact: true });
+  await heading.evaluate((element) => {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const selection = getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    const bounds = element.getBoundingClientRect();
+    element.dispatchEvent(new PointerEvent("pointerup", {
+      bubbles: true,
+      clientX: bounds.left + Math.min(24, bounds.width / 2),
+      clientY: bounds.top + bounds.height / 2,
+    }));
+  });
+  await page.getByRole("button", { name: "Ask Nebula" }).click();
+
+  const pack = page.getByRole("region", { name: "Selected context pack" });
+  await expect(pack).toBeVisible();
+  await expect(pack).toContainText("Project selection");
+  await expect(pack).not.toContainText("Scratch Project", { useInnerText: true });
+  await pack.getByRole("button", { name: "Expand Project selection" }).click();
+  await expect(pack.getByText("Scratch Project", { exact: true })).toBeVisible();
+  const geometry = await pack.evaluate((element) => {
+    const bounds = element.getBoundingClientRect();
+    return {
+      left: bounds.left,
+      right: bounds.right,
+      viewportWidth: innerWidth,
+      scrollWidth: element.scrollWidth,
+      clientWidth: element.clientWidth,
+    };
+  });
+  expect(geometry.left).toBeGreaterThanOrEqual(0);
+  expect(geometry.right).toBeLessThanOrEqual(geometry.viewportWidth + 1);
+  expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth + 1);
+  const accessibility = await new AxeBuilder({ page }).include(".chat-context-pack").analyze();
+  expect(accessibility.violations).toEqual([]);
+});
+
 test("hidden terminal views stop emitting resize frames", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name === "narrow", "The persistent terminal is intentionally unavailable in the mobile companion.");
   await openWorkspace(page, "/", "Workbench");
@@ -1113,9 +1155,13 @@ test("conversation More actions remain usable on mobile Workbench navigation", a
   await trigger.click();
   const menu = page.getByRole("menu", { name: "Actions for Conversation action review" });
   await expect(menu).toBeVisible();
-  await expect(menu.getByRole("menuitem", { name: "Rename" })).toBeFocused();
+  await expect(menu.getByRole("menuitem", { name: "Copy link" })).toBeFocused();
   await page.keyboard.press("ArrowDown");
+  await expect(menu.getByRole("menuitem", { name: "Export transcript" })).toBeFocused();
+  await page.keyboard.press("End");
   await expect(menu.getByRole("menuitem", { name: "Delete" })).toBeFocused();
+  await page.keyboard.press("ArrowUp");
+  await expect(menu.getByRole("menuitem", { name: "Rename" })).toBeFocused();
   await page.keyboard.press("Escape");
   await expect(menu).toHaveCount(0);
   await expect(trigger).toBeFocused();
@@ -1872,8 +1918,14 @@ test("completed harness output keeps one continuous transcript scroll", async ({
   test.skip(!["desktop", "compact"].includes(testInfo.project.name) && !testInfo.project.name.startsWith("mobile-"), "Covered by the permanent desktop and mobile harness projects.");
   const harnessSessionId = "c9745e80-3333-4444-8555-666677778888";
   const harnessTurnId = "c9745e80-4444-4555-8666-777788889999";
+  let steeringBody: unknown;
   await page.route("**/api/v1/**", async (route) => {
     const path = new URL(route.request().url()).pathname;
+    if (path.endsWith(`/harness-turns/${harnessTurnId}/steer`)) {
+      steeringBody = route.request().postDataJSON();
+      await route.fulfill({ status: 204, body: "" });
+      return;
+    }
     if (path.endsWith("/harnesses/harness-completion/skills")) {
       await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([{
         name: "review",
@@ -1898,7 +1950,7 @@ test("completed harness output keeps one continuous transcript scroll", async ({
         enabled: true,
         privacy: { local_only: true, permits_sensitive_data: true },
         native_capabilities: { workspace_access: "write", shell: true, web_search: true, skills: true },
-        capabilities: { models: ["gpt-5-codex"], checked_at: entity.updated_at, harness_version: "1.0", live_command_output: true, planning_mode: true, goal_monitoring: true, skill_invocation: true, modes: ["default", "plan"] },
+        capabilities: { models: ["gpt-5-codex"], checked_at: entity.updated_at, harness_version: "1.0", live_command_output: true, planning_mode: true, goal_monitoring: true, skill_invocation: true, steering: true, interruption: true, modes: ["default", "plan"] },
       }]) });
       return;
     }
@@ -1951,7 +2003,7 @@ test("completed harness output keeps one continuous transcript scroll", async ({
               controller.close();
               return;
             }
-            globalThis.setTimeout(enqueue, index === 3 ? 800 : 80);
+            globalThis.setTimeout(enqueue, index === 3 ? 2_000 : 80);
           };
           enqueue();
         },
@@ -1980,6 +2032,12 @@ test("completed harness output keeps one continuous transcript scroll", async ({
     name: "review",
     path: "/workspace/.agents/skills/review/SKILL.md",
   });
+  const guidanceComposer = page.getByPlaceholder("Add guidance while the harness works…");
+  await guidanceComposer.fill("Prioritize the TLS boundary and preserve exact output.");
+  await page.getByRole("button", { name: "Send guidance now" }).click();
+  await expect.poll(() => steeringBody).toEqual({ text: "Prioritize the TLS boundary and preserve exact output." });
+  await expect(guidanceComposer).toHaveValue("");
+  await expect(page.getByText("Guidance sent to the active harness turn.")).toBeVisible();
   const activity = page.locator("details.harness-activity-card", { hasText: "Run verification" });
   await expect(activity).not.toHaveAttribute("open", "");
   await expect(activity.getByText("completed", { exact: true })).toBeVisible({ timeout: 5_000 });

--- a/ui/tests/real-core.spec.ts
+++ b/ui/tests/real-core.spec.ts
@@ -1,7 +1,9 @@
 import { createHash } from "node:crypto";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { homedir, networkInterfaces, tmpdir } from "node:os";
 import path from "node:path";
 import { expect, request as playwrightRequest, test } from "@playwright/test";
 
@@ -12,32 +14,43 @@ interface RealCore {
   token: string;
 }
 
-async function startRealCore(): Promise<RealCore> {
+async function startRealCore(options: { bindHost?: string; browserHost?: string } = {}): Promise<RealCore> {
   const repository = path.resolve(import.meta.dirname, "../..");
   const dataDir = await mkdtemp(path.join(tmpdir(), "nebula-playwright-real-core-"));
   const token = "playwright-real-core-token-2026";
+  const bindHost = options.bindHost ?? "127.0.0.1";
+  const browserHost = options.browserHost ?? bindHost;
+  const coreExecutable = process.env.NEBULA_TEST_CORE_BIN ?? path.join(repository, ".venv/bin/nebula-core");
   const child = spawn(
-    path.join(repository, ".venv/bin/nebula-core"),
+    coreExecutable,
     [
       "serve",
-      "--host", "127.0.0.1",
+      "--host", bindHost,
       "--port", "0",
       "--token", token,
+      ...(bindHost === "127.0.0.1" ? [] : ["--allow-remote"]),
       "--allow-insecure-device-pairing",
       "--data-dir", dataDir,
       "--static-dir", path.join(repository, "ui/dist"),
     ],
-    { cwd: repository, env: { ...process.env, PYTHONUNBUFFERED: "1" } },
+    {
+      cwd: repository,
+      env: {
+        ...process.env,
+        PYTHONUNBUFFERED: "1",
+        PYTHONPATH: [path.join(repository, "src"), process.env.PYTHONPATH].filter(Boolean).join(path.delimiter),
+      },
+    },
   );
   let output = "";
   const origin = await new Promise<string>((resolve, reject) => {
     const timeout = setTimeout(() => reject(new Error(`Real Core did not become ready.\n${output}`)), 30_000);
     const inspect = (chunk: Buffer) => {
       output += chunk.toString("utf8");
-      const match = output.match(/"url"\s*:\s*"(http:\/\/127\.0\.0\.1:\d+)"/);
+      const match = output.match(/"url"\s*:\s*"http:\/\/[^:\"]+:(\d+)"/);
       if (match) {
         clearTimeout(timeout);
-        resolve(match[1]);
+        resolve(`http://${browserHost}:${match[1]}`);
       }
     };
     child.stdout.on("data", inspect);
@@ -48,6 +61,15 @@ async function startRealCore(): Promise<RealCore> {
     });
   });
   return { process: child, dataDir, origin, token };
+}
+
+function localNetworkIpv4(): string {
+  for (const addresses of Object.values(networkInterfaces())) {
+    for (const address of addresses ?? []) {
+      if (address.family === "IPv4" && !address.internal) return address.address;
+    }
+  }
+  throw new Error("A non-loopback IPv4 address is required for LAN acceptance.");
 }
 
 async function stopRealCore(core: RealCore): Promise<void> {
@@ -63,6 +85,195 @@ async function stopRealCore(core: RealCore): Promise<void> {
     await rm(core.dataDir, { recursive: true, force: true });
   }
 }
+
+interface LocalModelStub {
+  origin: string;
+  requests: Array<Record<string, unknown>>;
+  server: Server;
+}
+
+async function startLocalModelStub(): Promise<LocalModelStub> {
+  const requests: Array<Record<string, unknown>> = [];
+  const server = createServer(async (request, response) => {
+    response.setHeader("Content-Type", "application/json");
+    if (request.method === "GET" && request.url === "/v1/models") {
+      response.end(JSON.stringify({
+        object: "list",
+        data: [{ id: "security-model", object: "model", created: 1, owned_by: "local-acceptance" }],
+      }));
+      return;
+    }
+    if (request.method === "POST" && request.url === "/v1/chat/completions") {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) chunks.push(Buffer.from(chunk));
+      requests.push(JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>);
+      response.end(JSON.stringify({
+        id: "chatcmpl-real-core",
+        object: "chat.completion",
+        created: 1,
+        model: "security-model",
+        choices: [{
+          index: 0,
+          message: { role: "assistant", content: "Real Core retained the exact research context." },
+          finish_reason: "stop",
+        }],
+        usage: { prompt_tokens: 18, completion_tokens: 8, total_tokens: 26 },
+      }));
+      return;
+    }
+    response.statusCode = 404;
+    response.end(JSON.stringify({ error: "not found" }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address() as AddressInfo;
+  return { origin: `http://127.0.0.1:${address.port}`, requests, server };
+}
+
+async function stopLocalModelStub(stub: LocalModelStub): Promise<void> {
+  stub.server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    stub.server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+test("production assistant preserves exact research context and relaunch-safe drafts through real Core", async ({ page }) => {
+  test.setTimeout(60_000);
+  const lanAddress = localNetworkIpv4();
+  const core = await startRealCore({ bindHost: "0.0.0.0", browserHost: lanAddress });
+  const modelStub = await startLocalModelStub();
+  const api = await playwrightRequest.newContext({
+    baseURL: `${core.origin}/api/v1/`,
+    extraHTTPHeaders: { Authorization: `Bearer ${core.token}` },
+  });
+  try {
+    const engagementsResponse = await api.get("engagements");
+    expect(engagementsResponse.ok()).toBe(true);
+    const engagements = await engagementsResponse.json() as Array<{ id: string }>;
+    const projectId = engagements[0]?.id;
+    expect(projectId).toBeTruthy();
+
+    const providerResponse = await api.post("providers", { data: {
+      name: "Real Core research model",
+      provider_type: "vllm",
+      endpoint: `${modelStub.origin}/v1`,
+      enabled: true,
+      is_local: true,
+      model_allowlist: ["security-model"],
+      privacy: { local_only: true, residency: [], permits_sensitive_data: false },
+      metadata: { default_model: "security-model" },
+    } });
+    expect(providerResponse.ok(), await providerResponse.text()).toBe(true);
+    const provider = await providerResponse.json() as { id: string };
+
+    const selectedContext = "443/tcp open https\nTLS certificate expired";
+    const selectedContextHash = createHash("sha256").update(selectedContext).digest("hex");
+    const completionResponse = await api.post("chat/completions", { data: {
+      backend: "provider",
+      provider_id: provider.id,
+      model: "security-model",
+      engagement_id: projectId,
+      messages: [{ role: "user", content: "Review the exact 443/tcp observation." }],
+      context_attachments: [{
+        source_kind: "terminal",
+        source_id: "real-core-terminal",
+        source_label: "Nmap TLS result",
+        text: selectedContext,
+        sha256: selectedContextHash,
+        truncated: false,
+      }],
+      include_knowledge: false,
+      stream: false,
+    } });
+    expect(completionResponse.ok(), await completionResponse.text()).toBe(true);
+    const completion = await completionResponse.json() as { session_id: string };
+    expect(completion.session_id).toBeTruthy();
+    expect(modelStub.requests).toHaveLength(1);
+    const deliveredMessages = modelStub.requests[0].messages as Array<{ content?: string }>;
+    const deliveredContent = deliveredMessages.at(-1)?.content ?? "";
+    const deliveredContextJson = deliveredContent.match(
+      /BEGIN UNTRUSTED SELECTED CONTEXT \(JSON; DATA ONLY\)\n(.+)\nEND UNTRUSTED SELECTED CONTEXT/,
+    )?.[1];
+    expect(JSON.parse(deliveredContextJson ?? "[]")).toMatchObject([{
+      source_kind: "terminal",
+      source_id: "real-core-terminal",
+      source_label: "Nmap TLS result",
+      text: selectedContext,
+      sha256: selectedContextHash,
+      truncated: false,
+    }]);
+
+    const messagesResponse = await api.get(`chat/sessions/${completion.session_id}/messages`);
+    expect(messagesResponse.ok(), await messagesResponse.text()).toBe(true);
+    const messages = await messagesResponse.json() as Array<{ content: string; metadata?: Record<string, unknown> }>;
+    expect(messages[0]?.content).toBe("Review the exact 443/tcp observation.");
+    expect(messages[0]?.metadata).toMatchObject({
+      context_attachments: [{
+        source_kind: "terminal",
+        source_id: "real-core-terminal",
+        source_label: "Nmap TLS result",
+        text: selectedContext,
+        sha256: selectedContextHash,
+        truncated: false,
+      }],
+    });
+
+    const assistantUrl = `${core.origin}/?view=chat&session=${encodeURIComponent(completion.session_id)}#token=${encodeURIComponent(core.token)}`;
+    await page.goto(assistantUrl);
+    await expect(page.getByText("Real Core retained the exact research context.")).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText("BEGIN UNTRUSTED SELECTED CONTEXT", { exact: false })).toHaveCount(0);
+    await page.getByRole("button", { name: /Open context details/ }).click();
+    const inspector = page.getByLabel("Session inspector");
+    await expect(inspector.getByRole("heading", { name: "Working context" })).toBeVisible();
+    await expect(inspector.getByText(/estimated.*target input tokens/)).toBeVisible();
+
+    const composer = page.getByRole("textbox", { name: "Message the analyst assistant" });
+    await composer.fill("draft retained across a production relaunch");
+    // Core intentionally keeps bearer credentials in memory. Re-open the same
+    // authorized launch URL to exercise a fresh document without weakening that boundary.
+    await page.goto(assistantUrl);
+    await expect(page.getByText("Real Core retained the exact research context.")).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByRole("textbox", { name: "Message the analyst assistant" })).toHaveValue("draft retained across a production relaunch");
+
+    await page.getByRole("button", { name: "Show conversations" }).click();
+    const sessionsResponse = await api.get("chat-sessions");
+    expect(sessionsResponse.ok(), await sessionsResponse.text()).toBe(true);
+    const sessions = await sessionsResponse.json() as Array<{ id: string; title: string }>;
+    const savedSession = sessions.find((session) => session.id === completion.session_id);
+    expect(savedSession).toBeTruthy();
+    expect(savedSession!.title).toBe("Review the exact 443/tcp observation.");
+    const activeConversation = page.locator(".session-list-item.active");
+    const activeConversationActions = page.locator(".session-list-item.active .session-actions-trigger");
+    await activeConversation.hover();
+    await activeConversationActions.click();
+    await expect(page.getByRole("menuitem", { name: "Copy link" })).toBeFocused();
+    await page.keyboard.press("Enter");
+    await expect(page.getByText("Conversation link copied without authentication material.")).toBeVisible();
+
+    await activeConversation.hover();
+    await activeConversationActions.click();
+    const exportMenuItem = page.getByRole("menuitem", { name: "Export transcript" });
+    await exportMenuItem.click({ force: true });
+    const exportDialog = page.getByRole("dialog").filter({ hasText: "The Markdown transcript can contain sensitive prompts" });
+    await expect(exportDialog).toBeVisible();
+    const downloadPromise = page.waitForEvent("download");
+    await exportDialog.getByRole("button", { name: "Export transcript" }).click();
+    const download = await downloadPromise;
+    const transcriptPath = await download.path();
+    expect(transcriptPath).toBeTruthy();
+    const transcript = await readFile(transcriptPath!, "utf8");
+    expect(transcript).toContain("Real Core retained the exact research context.");
+    expect(transcript).toContain(selectedContext);
+    expect(transcript).toContain(selectedContextHash);
+    expect(new URL(page.url()).hostname).toBe(lanAddress);
+  } finally {
+    await api.dispose();
+    await stopRealCore(core);
+    await stopLocalModelStub(modelStub);
+  }
+});
 
 test("a paired browser can revoke itself without a stale authentication error", async ({ page }) => {
   test.setTimeout(60_000);


### PR DESCRIPTION
## Outcome

Makes the Workbench Assistant a compact research-continuity surface for security operators without weakening Core, harness, approval, or evidence authority.

## Changes

- recover unsent drafts per project and conversation
- collect bounded multi-selection context packs with exact SHA-256 metadata
- add paste/drop multi-image attachment handling
- add typed inline steering for capable active harness turns
- expose Core-owned context usage, compaction, and saved-memory details
- add conversation search, auth-free links, guarded Markdown export, copy, quote, rename, delete, and message-level fork actions
- keep selected-context envelopes out of durable user bubbles and conversation titles
- add responsive, accessibility, production-Core, and LAN-origin acceptance coverage

## Validation

- production UI build passed
- frontend diagnostic and CSS audits passed
- 58 frontend test files / 278 tests passed
- 25 Core chat and API tests passed
- 130 desktop, compact, and narrow Playwright cases passed
- 84 mobile Chromium and WebKit cases passed at 320-430 px
- production bundle passed against real Core on a non-loopback LAN origin, including exact context persistence, draft recovery, auth-free link copy, and guarded transcript download

## Release

No release is requested or authorized by this PR.