### PR TITLE
Queue assistant follow-ups for providers and non-steerable harnesses

### DIFF
--- a/docs/assistant-research-continuity-contract.md
+++ b/docs/assistant-research-continuity-contract.md
@@ -20,8 +20,9 @@ The real entry point is Workbench > Assistant. The operator can:
 2. Collect several exact text selections from project surfaces into one context
    pack, inspect each source, and remove individual items before sending.
 3. Paste, drop, or choose supported images without leaving the composer.
-4. Send a normal turn, or type guidance into the same composer while a steerable
-   harness turn is active.
+4. Send a normal turn, type guidance into the same composer while a steerable
+   harness turn is active, or queue plain-text follow-ups while any other active
+   turn finishes.
 5. Inspect Core's authoritative context-window and compaction state without
    exposing private reasoning.
 6. Copy or quote a durable message, fork at a message, and export the authoritative
@@ -37,9 +38,11 @@ The real entry point is Workbench > Assistant. The operator can:
 - Harness/provider: live turn execution and advertised capabilities.
 - Workspace context: transient exact selected-text context pack shared between
   Workbench surfaces; it is hashed only at explicit submission.
-- `sessionStorage`: unsent prompt text keyed by project and conversation. Drafts
-  survive refresh in the current browser tab but do not become a durable transcript
-  or cross-device record.
+- `sessionStorage`: unsent prompt text and ordered plain-text follow-ups keyed by
+  project and conversation. Drafts and queued follow-ups survive refresh in the
+  current browser tab but do not become a durable transcript or cross-device record.
+  A follow-up that was marked sending when the tab reloads requires explicit
+  operator review before retry, preventing an unverified duplicate provider turn.
 - Component state: expanded previews, search query, upload progress, and ephemeral
   copy/export feedback.
 
@@ -51,14 +54,14 @@ The real entry point is Workbench > Assistant. The operator can:
 | Draft recovery | An unsent prompt survives refresh and stays isolated by project/session | sessionStorage + URL | unit + Playwright |
 | Context collection | New selections append with exact bytes, source identity, bounded length, and stable deduplication | workspace context until submit; Core after submit | unit + Playwright + real Core |
 | Image attachment | Choose, paste, and drop share the same validation, capability, count, and upload path | Core artifact store | component + Playwright |
-| Create/mutate | Send persists one user/assistant turn; steer mutates only the active advertised harness turn | Core database + harness | real Core |
-| Select/use | URL and visible selection identify the same conversation; filters never mutate selection | URL + Core | Playwright |
-| Stream/interrupt | Output remains ordered; stop remains available; steer uses visible composer text | Core/harness activity | component + real Core |
+| Create/mutate | Send persists one user/assistant turn; steer mutates only the active advertised harness turn; non-steerable follow-ups are accepted in visible order and handed to Core one at a time | Core database + harness + sessionStorage queue | component + Playwright |
+| Select/use | URL and visible selection identify the same conversation; filters never mutate selection; queue keys do not cross conversations | URL + Core + sessionStorage | Playwright |
+| Stream/interrupt | Output remains ordered; stop remains available; steer uses visible composer text; queued follow-ups do not start until the active request finishes | Core/harness activity + queue state | component + Playwright |
 | Context health | The meter and inspector reflect Core status, estimated usage, compaction, and memory summary | Core context endpoint | component + real Core |
 | Message reuse | Copy is exact; quote creates an editable draft; fork retains durable lineage | Core + transient composer | unit + Playwright + real Core |
 | Export | Export is built from a fresh authoritative transcript and records session identity, citations, and attachment hashes | Core database | unit + Playwright |
-| Refresh/reconnect | Durable transcript and URL identity return without duplicates; unsent text recovers from the current tab | Core + URL + sessionStorage | real Core |
-| Failure/retry | Context, export, upload, and steering failures retain usable chat state and show a local recovery action | Core error contract | component + Playwright |
+| Refresh/reconnect | Durable transcript and URL identity return without duplicates; unsent text and queued follow-ups recover from the current tab; an interrupted send is paused for review | Core + URL + sessionStorage | Playwright + real Core |
+| Failure/retry | Context, export, upload, steering, and queued-send failures retain usable chat state and show a local recovery action | Core error contract + queue state | component + Playwright |
 | Delete/revoke | Existing guarded deletion clears stale selection and its draft key | Core database + URL + sessionStorage | component + real Core |
 
 ## Content, responsive, and accessibility invariants
@@ -72,7 +75,8 @@ The real entry point is Workbench > Assistant. The operator can:
 - Reduced motion does not hide state changes. Approval, user-input, failure, and
   retry controls are never collapsed.
 - Sensitive selections remain excluded by the existing selection boundary.
-  Context text and unsent attachments are not written to browser storage.
+  Context text and unsent attachments are not written to browser storage. Queued
+  follow-ups are deliberately text-only and visibly labeled as tab-local.
 
 ## Competitive gap basis
 
@@ -86,6 +90,9 @@ without weakening those controls.
 ## Explicit non-goals
 
 - No hidden auto-approval, unrestricted shell, or background cloud execution.
+- No server-side or cross-device provider queue in this pass; queued text is a
+  bounded tab-local handoff to the existing durable chat API and requires review
+  after a reload if its send status is ambiguous.
 - No browser-owned transcript, lineage, context memory, or evidence authority.
 - No capture or display of private chain-of-thought.
 - No opaque folder identifiers or vendor-specific assistant fork.

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -40,19 +40,19 @@ export default defineConfig({
     {
       name: "mobile-chromium",
       testMatch: "**/interface.spec.ts",
-      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|assistant follow-up queue|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"] },
     },
     {
       name: "mobile-chromium-small",
       testMatch: "**/interface.spec.ts",
-      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|assistant follow-up queue|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"], viewport: { width: 320, height: 700 } },
     },
     {
       name: "mobile-webkit",
       testMatch: "**/interface.spec.ts",
-      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|assistant follow-up queue|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["iPhone 13"] },
     },
     {

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -1142,6 +1142,30 @@ kbd { font-size: 11px; }
 .chat-context-meter.status-failed > span { background: var(--red-muted); color: var(--red); }
 .chat-action-status { display: flex; min-height: 28px; align-items: center; justify-content: center; gap: 5px; margin: 4px 12px 0; color: var(--green); font-size: 11px; }
 
+.chat-follow-up-queue { margin: 6px 12px 0; overflow: hidden; border: 1px solid var(--border-soft); border-radius: var(--radius-control); background: var(--surface-muted); }
+.chat-follow-up-queue > header, .chat-follow-up-queue > footer { display: flex; min-height: 40px; align-items: center; justify-content: space-between; gap: 10px; padding: 6px 8px 6px 11px; }
+.chat-follow-up-queue > header { border-bottom: 1px solid var(--border-soft); }
+.chat-follow-up-queue > header > div { display: flex; min-width: 0; align-items: center; gap: 7px; }
+.chat-follow-up-queue > header > div > svg { flex: 0 0 auto; color: var(--blue); }
+.chat-follow-up-queue > header span { display: grid; min-width: 0; gap: 2px; }
+.chat-follow-up-queue strong { color: var(--text); font-size: 11px; }
+.chat-follow-up-queue header small, .chat-follow-up-queue footer span { color: var(--muted); font-size: 11px; }
+.chat-follow-up-queue > header .button, .chat-follow-up-queue > footer .button { min-height: 32px; flex: 0 0 auto; }
+.chat-follow-up-queue ol { display: grid; max-height: 190px; margin: 0; padding: 0; overflow-y: auto; list-style: none; }
+.chat-follow-up-queue li { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; padding: 8px 8px 8px 11px; border-bottom: 1px solid var(--border-soft); }
+.chat-follow-up-queue li:last-child { border-bottom: 0; }
+.chat-follow-up-queue li > div:first-child { display: flex; min-width: 0; align-items: flex-start; gap: 7px; }
+.chat-follow-up-index { display: grid; width: 20px; height: 20px; flex: 0 0 auto; place-items: center; border-radius: 50%; color: var(--muted); background: var(--canvas); font: 11px var(--font-mono); }
+.chat-follow-up-queue p { min-width: 0; margin: 1px 0 0; color: var(--text); font-size: 11px; line-height: 1.4; overflow-wrap: anywhere; white-space: pre-wrap; }
+.chat-follow-up-meta { display: flex; min-width: 86px; max-width: 190px; align-items: flex-end; gap: 4px; color: var(--muted); font-size: 11px; text-align: right; }
+.chat-follow-up-meta > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.chat-follow-up-meta > small { max-width: 180px; overflow: hidden; color: var(--orange); text-overflow: ellipsis; white-space: nowrap; }
+.chat-follow-up-meta > div { display: flex; align-items: center; gap: 2px; }
+.chat-follow-up-meta .icon-button { width: 28px; height: 28px; }
+.chat-follow-up-sending { background: color-mix(in srgb, var(--blue-muted) 35%, transparent); }
+.chat-follow-up-failed { background: color-mix(in srgb, var(--red-muted) 35%, transparent); }
+.chat-follow-up-queue > footer { justify-content: space-between; border-top: 1px solid var(--border-soft); }
+
 .chat-content-image {
   display: block;
   width: min(100%, 720px);
@@ -1959,6 +1983,10 @@ kbd { font-size: 11px; }
   .chat-composer { margin: 6px; }
   .chat-composer footer { gap: 6px; }
   .chat-composer footer span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .chat-follow-up-queue { margin: 6px; }
+  .chat-follow-up-queue > header, .chat-follow-up-queue > footer { min-height: 44px; }
+  .chat-follow-up-queue li { grid-template-columns: minmax(0, 1fr) auto; }
+  .chat-follow-up-meta { min-width: 72px; max-width: 112px; }
   .chat-context-pack { max-height: 150px; }
   .chat-context-pack > header { min-height: 44px; }
   .chat-context-pack > header > div { display: grid; gap: 1px; }

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -19,6 +19,7 @@ import {
   GitFork,
   ImagePlus,
   LoaderCircle,
+  ListTodo,
   Maximize2,
   MessageSquare,
   MessageSquareQuote,
@@ -103,6 +104,15 @@ import {
 import { DiagnosticErrorNotice, logCaughtDiagnostic } from "../diagnostics";
 import { readConversationPanelOpen, writeConversationPanelOpen } from "./workbenchPreferences";
 import { chatDraftStorageKey, clearChatDraft, readChatDraft, writeChatDraft } from "./chatDraftStorage";
+import {
+  chatFollowUpStorageKey,
+  clearChatFollowUps,
+  maxChatFollowUps,
+  readChatFollowUps,
+  validateChatFollowUpText,
+  writeChatFollowUps,
+  type ChatFollowUp,
+} from "./chatFollowUpStorage";
 import { chatTranscriptFilename, formatChatTranscript } from "./chatTranscriptExport";
 
 type SessionView = "chat" | "code" | "terminal" | "browser" | "missions" | "activity" | "workspace" | "notes";
@@ -557,6 +567,7 @@ export function SessionsPage() {
   const [pendingResponse, setPendingResponse] = useState<PendingChatResponse>();
   const [messages, setMessages] = useState<ConversationMessage[]>([]);
   const [draft, setDraft] = useState("");
+  const [queuedFollowUps, setQueuedFollowUps] = useState<ChatFollowUp[]>([]);
   const [expandedContextIndex, setExpandedContextIndex] = useState<number>();
   const [contextStatus, setContextStatus] = useState<ContextStatus>();
   const [contextStatusError, setContextStatusError] = useState<string>();
@@ -591,6 +602,10 @@ export function SessionsPage() {
   const streamDeltaRef = useRef(new Map<string, string>());
   const streamFrameRef = useRef<number | undefined>(undefined);
   const draftStorageKeyRef = useRef("");
+  const followUpStorageKeyRef = useRef("");
+  const followUpAutoDrainRef = useRef(false);
+  const followUpDrainIdRef = useRef<string | undefined>(undefined);
+  const submitMessageRef = useRef<((queuedFollowUp?: ChatFollowUp) => Promise<void>) | undefined>(undefined);
   const chatRuntimeStore = useMemo(() => ({
     messages,
     convertMessage: convertConversationMessage,
@@ -629,6 +644,9 @@ export function SessionsPage() {
   const activeDraftStorageKey = engagement
     ? chatDraftStorageKey(engagement.id, sessionId || undefined)
     : "";
+  const activeFollowUpStorageKey = engagement
+    ? chatFollowUpStorageKey(engagement.id, sessionId || undefined)
+    : "";
   useEffect(() => {
     if (!activeDraftStorageKey || draftStorageKeyRef.current !== activeDraftStorageKey) return;
     writeChatDraft(sessionStorage, activeDraftStorageKey, draft);
@@ -645,6 +663,39 @@ export function SessionsPage() {
   // The outgoing draft is intentionally captured at the identity boundary.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeDraftStorageKey]);
+  useEffect(() => {
+    if (!activeFollowUpStorageKey || followUpStorageKeyRef.current !== activeFollowUpStorageKey) return;
+    writeChatFollowUps(sessionStorage, activeFollowUpStorageKey, queuedFollowUps);
+  }, [activeFollowUpStorageKey, queuedFollowUps]);
+  useEffect(() => {
+    const previousKey = followUpStorageKeyRef.current;
+    let recovered = activeFollowUpStorageKey ? readChatFollowUps(sessionStorage, activeFollowUpStorageKey) : [];
+    const movingFromUnattachedConversation = Boolean(
+      previousKey
+      && activeFollowUpStorageKey
+      && previousKey.endsWith(":new")
+      && !activeFollowUpStorageKey.endsWith(":new"),
+    );
+    if (movingFromUnattachedConversation) {
+      const unattached = readChatFollowUps(sessionStorage, previousKey);
+      if (unattached.length) {
+        recovered = [...recovered, ...unattached]
+          .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+          .slice(0, maxChatFollowUps());
+        writeChatFollowUps(sessionStorage, activeFollowUpStorageKey, recovered);
+        clearChatFollowUps(sessionStorage, previousKey);
+      }
+    }
+    followUpStorageKeyRef.current = activeFollowUpStorageKey;
+    setQueuedFollowUps(recovered);
+    if (activeFollowUpStorageKey !== previousKey && !movingFromUnattachedConversation) {
+      // Queued items recovered after navigation or reload require an explicit
+      // operator action. Only items accepted during this mounted active turn
+      // are drained automatically.
+      followUpAutoDrainRef.current = false;
+      followUpDrainIdRef.current = undefined;
+    }
+  }, [activeFollowUpStorageKey]);
   const visibleSessions = useMemo(() => {
     const query = sessionQuery.trim().toLocaleLowerCase();
     if (!query) return sessions;
@@ -661,6 +712,7 @@ export function SessionsPage() {
   const enabledProviders = useMemo(() => providers.filter((provider) => provider.enabled), [providers]);
   const selectedProvider = enabledProviders.find((provider) => provider.id === providerId);
   const selectedHarness = harnesses.find((harness) => harness.id === harnessId);
+  const runtimeReady = runtimeKind === "provider" ? Boolean(selectedProvider) : Boolean(selectedHarness);
   const selectedHarnessSkill = harnessSkills.find((skill) => skill.path === harnessSkillPath);
   const matchingHarnessSkills = useMemo(() => {
     const query = skillToken?.query.toLocaleLowerCase() ?? "";
@@ -1139,6 +1191,8 @@ export function SessionsPage() {
 
   const resetConversation = (open: boolean) => {
     sessionSelectionGenerationRef.current += 1;
+    followUpAutoDrainRef.current = false;
+    followUpDrainIdRef.current = undefined;
     if (!detachActiveHarnessStream()) abortRef.current?.abort();
     harnessFollowDetachRef.current?.();
     harnessFollowDetachRef.current = undefined;
@@ -1185,7 +1239,10 @@ export function SessionsPage() {
     setChatError(undefined);
     try {
       await api.deleteChatSession(session.id);
-      if (engagement) clearChatDraft(sessionStorage, chatDraftStorageKey(engagement.id, session.id));
+      if (engagement) {
+        clearChatDraft(sessionStorage, chatDraftStorageKey(engagement.id, session.id));
+        clearChatFollowUps(sessionStorage, chatFollowUpStorageKey(engagement.id, session.id));
+      }
       setSessions((current) => current.filter((item) => item.id !== session.id));
       if (sessionId === session.id) {
         resetConversation(false);
@@ -1216,6 +1273,7 @@ export function SessionsPage() {
     if (engagement) {
       for (const deletedId of deletedIds) {
         clearChatDraft(sessionStorage, chatDraftStorageKey(engagement.id, deletedId));
+        clearChatFollowUps(sessionStorage, chatFollowUpStorageKey(engagement.id, deletedId));
       }
     }
     const failures = results.filter((result) => result.status === "rejected");
@@ -1395,6 +1453,8 @@ export function SessionsPage() {
     const selectionGeneration = sessionSelectionGenerationRef.current + 1;
     sessionSelectionGenerationRef.current = selectionGeneration;
     const selectionIsCurrent = () => sessionSelectionGenerationRef.current === selectionGeneration;
+    followUpAutoDrainRef.current = false;
+    followUpDrainIdRef.current = undefined;
     detachActiveHarnessStream();
     setSending(false);
     setConversationOpen(true);
@@ -1889,6 +1949,10 @@ export function SessionsPage() {
 
   const attachImageFiles = async (files: File[]) => {
     if (!files.length || !api || !engagement || uploadingImage) return;
+    if (sending || pendingResponse) {
+      setChatError("Image attachments are available after the active response finishes; follow-ups are text-only.");
+      return;
+    }
     if (!imageInputEnabled) {
       setChatError("The selected runtime has not advertised image input support.");
       return;
@@ -2006,18 +2070,68 @@ export function SessionsPage() {
     }
   };
 
-  const submit = async (event: FormEvent) => {
-    event.preventDefault();
-    if (sending) {
-      if (runtimeKind === "harness" && selectedHarness?.capabilities?.steering && draft.trim()) {
-        await steerCurrentHarness(draft);
+  const queueFollowUp = (text: string): boolean => {
+    const validationError = validateChatFollowUpText(text);
+    if (validationError) {
+      setChatError(validationError);
+      return false;
+    }
+    if (pendingImages.length || assistantDrafts.length) {
+      setChatError("Only plain text can be queued while a response is active. Wait for the response before adding attachments or selected context.");
+      return false;
+    }
+    if (queuedFollowUps.length >= maxChatFollowUps()) {
+      setChatError(`The follow-up queue is full (${maxChatFollowUps()} messages). Remove one before adding another.`);
+      return false;
+    }
+    const item: ChatFollowUp = {
+      id: makeId("follow-up"),
+      text: text.trim(),
+      createdAt: new Date().toISOString(),
+      status: "queued",
+    };
+    setQueuedFollowUps((current) => [...current, item]);
+    followUpAutoDrainRef.current = true;
+    setDraft("");
+    if (activeDraftStorageKey) clearChatDraft(sessionStorage, activeDraftStorageKey);
+    setSkillToken(undefined);
+    setHarnessSkillPath("");
+    setChatError(undefined);
+    setMessageActionStatus("Follow-up queued; it will send after the active response finishes.");
+    return true;
+  };
+
+  const submit = async (event?: FormEvent, queuedFollowUp?: ChatFollowUp) => {
+    event?.preventDefault();
+    const activeTurn = sending || Boolean(pendingResponse);
+    if (activeTurn && !queuedFollowUp) {
+      const text = draft.trim();
+      const canSteer = sending
+        && runtimeKind === "harness"
+        && Boolean(selectedHarness?.capabilities?.steering)
+        && Boolean(harnessProgress?.turnId || harnessActivity?.turnId)
+        && !harnessControlBusy
+        && !pendingImages.length
+        && !assistantDrafts.length;
+      if (canSteer && text) {
+        await steerCurrentHarness(text);
+      } else if (text || pendingImages.length || assistantDrafts.length) {
+        queueFollowUp(text);
       }
       return;
     }
-    const content = draft.trim() || (pendingImages.length ? "Attached image" : "");
+    const content = (queuedFollowUp?.text ?? draft.trim()) || (pendingImages.length ? "Attached image" : "");
     const providerRuntime = runtimeKind === "provider" ? selectedProvider : undefined;
     const harnessRuntime = runtimeKind === "harness" ? selectedHarness : undefined;
-    if (!content || sending || !api || coreState !== "online" || !engagement || (!providerRuntime && !harnessRuntime) || !model.trim()) return;
+    if (!content || sending || pendingResponse || !api || coreState !== "online" || !engagement || (!providerRuntime && !harnessRuntime) || !model.trim()) return;
+
+    const failQueuedFollowUp = (detail: string) => {
+      if (!queuedFollowUp) return;
+      followUpAutoDrainRef.current = false;
+      setQueuedFollowUps((current) => current.map((item) => item.id === queuedFollowUp.id
+        ? { ...item, status: "failed", detail }
+        : item));
+    };
 
     const wantsKnowledge = includeKnowledge && knowledgeItemCount > 0;
     let allowCloudKnowledge = false;
@@ -2025,7 +2139,9 @@ export function SessionsPage() {
     const knowledgeRuntimePermitsSensitive = runtimeKind === "harness" ? harnessRuntime?.permitsSensitiveData : providerRuntime?.permitsSensitiveData;
     if (wantsKnowledge && !knowledgeRuntimeIsLocal) {
       if (!knowledgeRuntimePermitsSensitive) {
-        setChatError("This runtime profile is text-only. Enable project/document data in Settings or turn off knowledge retrieval.");
+        const detail = "This runtime profile is text-only. Enable project/document data in Settings or turn off knowledge retrieval.";
+        setChatError(detail);
+        failQueuedFollowUp(detail);
         return;
       }
       allowCloudKnowledge = true;
@@ -2042,7 +2158,9 @@ export function SessionsPage() {
     const toolRuntimePermitsSensitive = runtimeKind === "harness" ? harnessRuntime?.permitsSensitiveData : providerRuntime?.permitsSensitiveData;
     if (wantsTools && !toolRuntimeIsLocal && toolRuntimeName) {
       if (!toolRuntimePermitsSensitive) {
-        setChatError("This runtime profile does not permit tool results to leave the device.");
+        const detail = "This runtime profile does not permit tool results to leave the device.";
+        setChatError(detail);
+        failQueuedFollowUp(detail);
         return;
       }
       allowCloudToolResults = await confirm({
@@ -2050,24 +2168,41 @@ export function SessionsPage() {
         message: `Allow this turn to send bounded tool inputs and results to ${toolRuntimeName}? Canonical output remains local and risky calls still require approval.`,
         confirmLabel: "Allow this turn",
       });
-      if (!allowCloudToolResults) return;
+      if (!allowCloudToolResults) {
+        failQueuedFollowUp("Tool-result sharing was cancelled. Review the queued message before retrying.");
+        return;
+      }
     }
 
     let contextAttachments: ChatCompletionRequest["contextAttachments"];
     try {
-      contextAttachments = assistantDrafts.length
+      contextAttachments = !queuedFollowUp && assistantDrafts.length
         ? await Promise.all(assistantDrafts.map(createHashedSelectionAttachment))
         : undefined;
     } catch (attachmentError) {
       void logCaughtDiagnostic("interface.sessions_page.caught_failure_12", "A handled interface operation failed.", attachmentError, "sessions_page");
-      setChatError(attachmentError instanceof Error ? attachmentError.message : "Could not attach the selected text.");
+      const detail = attachmentError instanceof Error ? attachmentError.message : "Could not attach the selected text.";
+      setChatError(detail);
+      failQueuedFollowUp(detail);
       return;
+    }
+
+    if (queuedFollowUp) {
+      setQueuedFollowUps((current) => current.map((item) => item.id === queuedFollowUp.id
+        ? { ...item, status: "sending", detail: undefined }
+        : item));
     }
 
     const now = new Date().toISOString();
     const userId = makeId("user");
     const assistantId = makeId("assistant");
     const durableHistory = messages.filter((message) => message.durable && message.state === "complete");
+    const outgoingContentBlocks = queuedFollowUp
+      ? [{ type: "text" as const, text: content }]
+      : [
+        ...(draft.trim() ? [{ type: "text" as const, text: draft.trim() }] : []),
+        ...pendingImages.map((image) => image.block),
+      ];
     const userMessage: ConversationMessage = {
       id: userId,
       role: "user",
@@ -2076,10 +2211,7 @@ export function SessionsPage() {
       citations: [],
       state: "complete",
       durable: false,
-      contentBlocks: [
-        ...(draft.trim() ? [{ type: "text" as const, text: draft.trim() }] : []),
-        ...pendingImages.map((image) => image.block),
-      ],
+      contentBlocks: outgoingContentBlocks,
     };
     const assistantMessage: ConversationMessage = {
       id: assistantId,
@@ -2091,11 +2223,13 @@ export function SessionsPage() {
       durable: false,
     };
     setMessages((current) => [...current, userMessage, assistantMessage]);
-    if (activeDraftStorageKey) clearChatDraft(sessionStorage, activeDraftStorageKey);
-    setDraft("");
-    pendingImages.forEach((image) => URL.revokeObjectURL(image.previewUrl));
-    setPendingImages([]);
-    clearAssistantDrafts();
+    if (!queuedFollowUp) {
+      if (activeDraftStorageKey) clearChatDraft(sessionStorage, activeDraftStorageKey);
+      setDraft("");
+      pendingImages.forEach((image) => URL.revokeObjectURL(image.previewUrl));
+      setPendingImages([]);
+      clearAssistantDrafts();
+    }
     setChatError(undefined);
     setSending(true);
     if (runtimeKind === "harness") {
@@ -2153,6 +2287,7 @@ export function SessionsPage() {
       setSkillToken(undefined);
     }
 
+    let requestCompleted = false;
     try {
       const response = await api.streamChat(chatRequest, (streamEvent) => {
         if (controller.signal.aborted) return;
@@ -2162,16 +2297,30 @@ export function SessionsPage() {
         if (streamEvent.type === "done") returnedSessionId = streamEvent.sessionId ?? returnedSessionId;
         applyChatEvent(streamEvent, assistantId, userId, chatRequest);
       }, controller.signal);
+      requestCompleted = true;
       returnedSessionId = response?.sessionId ?? returnedSessionId;
       if (response && returnedSessionId) {
         await refreshSessions(returnedSessionId);
       }
     } catch (error) {
       const detached = detachedHarnessStreamsRef.current.has(controller);
-      if (detached) return;
+      if (detached) {
+        failQueuedFollowUp("The response was detached before this follow-up completed. Review it before retrying.");
+        return;
+      }
+      if (requestCompleted) {
+        setChatError(error instanceof Error ? error.message : "The response completed, but the conversation could not be refreshed.");
+        return;
+      }
       void logCaughtDiagnostic("interface.sessions_page.caught_failure_13", "A handled interface operation failed.", error, "sessions_page");
+      followUpAutoDrainRef.current = false;
       const cancelled = controller.signal.aborted;
       const detail = cancelled ? "Response stopped by the operator." : error instanceof Error ? error.message : "Chat completion failed.";
+      if (queuedFollowUp) {
+        setQueuedFollowUps((current) => current.map((item) => item.id === queuedFollowUp.id
+          ? { ...item, status: "failed", detail }
+          : item));
+      }
       setMessages((current) => current.map((message) => message.id === assistantId
         ? { ...message, state: cancelled ? "cancelled" : "error", detail }
         : message));
@@ -2190,6 +2339,12 @@ export function SessionsPage() {
         setSessionId("");
       }
     } finally {
+      if (queuedFollowUp && followUpDrainIdRef.current === queuedFollowUp.id) {
+        followUpDrainIdRef.current = undefined;
+      }
+      if (queuedFollowUp && requestCompleted) {
+        setQueuedFollowUps((current) => current.filter((item) => item.id !== queuedFollowUp.id));
+      }
       if (abortRef.current === controller) {
         abortRef.current = undefined;
         streamBackendRef.current = undefined;
@@ -2197,6 +2352,25 @@ export function SessionsPage() {
       }
     }
   };
+
+  submitMessageRef.current = (queuedFollowUp) => submit(undefined, queuedFollowUp);
+  useEffect(() => {
+    const next = queuedFollowUps[0];
+    if (!followUpAutoDrainRef.current
+      || !next
+      || next.status !== "queued"
+      || followUpDrainIdRef.current
+      || sending
+      || pendingResponse
+      || loadingHistory
+      || coreState !== "online"
+      || !api
+      || !engagement
+      || !runtimeReady
+      || !model.trim()) return;
+    followUpDrainIdRef.current = next.id;
+    void submitMessageRef.current?.(next);
+  }, [api, coreState, engagement, loadingHistory, model, pendingResponse, queuedFollowUps, runtimeReady, sending]);
 
   const decideInlineApproval = async (decision: "approve" | "edit" | "reject" | "stop") => {
     if (!pendingResponse || !api) return;
@@ -2231,6 +2405,7 @@ export function SessionsPage() {
       });
       if (pendingResponse.request.backend === "harness") {
         if (decision === "stop") {
+          followUpAutoDrainRef.current = false;
           setMessages((current) => current.map((message) => message.id === pendingResponse.assistantId
             ? { ...message, state: "cancelled", detail: "Response stopped by the operator." }
             : message));
@@ -2243,6 +2418,7 @@ export function SessionsPage() {
         return;
       }
       if (decision === "stop") {
+        followUpAutoDrainRef.current = false;
         setMessages((current) => current.map((message) => message.id === pendingResponse.assistantId
         ? { ...message, state: "cancelled", detail: "Response stopped by the operator." }
           : message));
@@ -2411,6 +2587,7 @@ export function SessionsPage() {
   };
 
   const stopCurrentResponse = async () => {
+    followUpAutoDrainRef.current = false;
     if (runtimeKind === "harness" && api) {
       const turnId = harnessProgress?.turnId ?? harnessActivity?.turnId
         ?? [...messages].reverse().find((message) => message.state === "streaming")?.harnessTurnId;
@@ -2566,7 +2743,6 @@ export function SessionsPage() {
     }
   };
 
-  const runtimeReady = runtimeKind === "provider" ? Boolean(selectedProvider) : Boolean(selectedHarness);
   useEffect(() => {
     if (!sessionActionsId) return;
     const closeOnOutsidePointer = (event: PointerEvent) => {
@@ -2635,13 +2811,29 @@ export function SessionsPage() {
       document.removeEventListener("keydown", closeActions);
     };
   }, [workbenchActionsOpen]);
-  const canSend = Boolean(api && coreState === "online" && engagement && runtimeReady && model.trim() && (draft.trim() || pendingImages.length) && !sending && !uploadingImage);
+  const composerBusy = sending || Boolean(pendingResponse);
+  const canSend = Boolean(api && coreState === "online" && engagement && runtimeReady && model.trim() && (draft.trim() || pendingImages.length) && !composerBusy && !uploadingImage);
   const canSteerCurrentHarness = Boolean(
     sending
     && runtimeKind === "harness"
     && selectedHarness?.capabilities?.steering
-    && (harnessProgress?.turnId || harnessActivity?.turnId),
+    && (harnessProgress?.turnId || harnessActivity?.turnId)
+    && !harnessControlBusy,
   );
+  const queueMode = composerBusy && !canSteerCurrentHarness;
+  const removeQueuedFollowUp = (id: string) => {
+    setQueuedFollowUps((current) => current.filter((item) => item.id !== id));
+    if (followUpDrainIdRef.current === id) followUpDrainIdRef.current = undefined;
+    setMessageActionStatus("Queued follow-up removed.");
+  };
+  const retryQueuedFollowUp = (id: string) => {
+    if (queuedFollowUps[0]?.id !== id) return;
+    followUpAutoDrainRef.current = true;
+    setQueuedFollowUps((current) => current.map((item) => item.id === id
+      ? { ...item, status: "queued", detail: undefined }
+      : item));
+    setChatError(undefined);
+  };
   const visibleHarnessProgress: HarnessProgress | undefined = runtimeKind !== "harness" || !harnessSessionId
     ? harnessProgress
     : harnessProgress ?? (harnessActivityError
@@ -2963,6 +3155,14 @@ export function SessionsPage() {
               {chatError && <DiagnosticErrorNotice error={chatError} fallback="The chat operation could not be completed." compact />}
               {messageActionStatus && <div className="chat-action-status" role="status" aria-live="polite"><Check size={13} aria-hidden="true" /> {messageActionStatus}</div>}
               {showHarnessStatusRail && harnessActivity && <section className="harness-status-rail" aria-label="Harness status"><span className={`status-dot ${harnessActivity.live ? harnessActivity.busy ? "pending" : "available" : "unavailable"}`} /><strong>{!harnessActivity.live ? "Connection unavailable" : pendingHarnessRequests ? "Action required" : "Working"}</strong>{harnessActivity.goal && <span title={harnessActivity.goal.objective}>Goal: {harnessActivity.goal.status}{typeof harnessActivity.goal.progress === "number" ? ` · ${Math.round(harnessActivity.goal.progress * 100)}%` : ""}</span>}{harnessActivity.plan?.length ? <span>{harnessActivity.plan.filter((entry) => entry.status === "completed").length}/{harnessActivity.plan.length} plan steps</span> : null}{pendingHarnessRequests > 0 && <span>{pendingHarnessRequests} request{pendingHarnessRequests === 1 ? "" : "s"}</span>}</section>}
+              {queuedFollowUps.length > 0 && <section className="chat-follow-up-queue" aria-label="Queued follow-up messages" aria-live="polite">
+                <header><div><ListTodo size={14} aria-hidden="true" /><span><strong>Follow-up queue</strong><small>{queuedFollowUps.length} message{queuedFollowUps.length === 1 ? "" : "s"} · text only · current browser tab</small></span></div><button className="button quiet" type="button" disabled={queuedFollowUps.some((item) => item.status === "sending")} onClick={() => { followUpAutoDrainRef.current = false; followUpDrainIdRef.current = undefined; setQueuedFollowUps([]); setMessageActionStatus("Follow-up queue cleared."); }}>Clear</button></header>
+                <ol>{queuedFollowUps.map((item, index) => <li key={item.id} className={`chat-follow-up-${item.status}`}>
+                  <div><span className="chat-follow-up-index">{index + 1}</span><p>{item.text}</p></div>
+                  <div className="chat-follow-up-meta"><span>{item.status === "sending" ? "Sending next" : item.status === "failed" ? "Needs review" : index === 0 && (sending || pendingResponse) ? "After current response" : "Waiting"}</span>{item.detail && <small>{item.detail}</small>}<div>{item.status === "failed" && index === 0 && <button className="button quiet" type="button" onClick={() => retryQueuedFollowUp(item.id)}>Retry</button>}<button className="icon-button subtle" type="button" aria-label={`Remove queued message ${index + 1}`} disabled={item.status === "sending"} onClick={() => removeQueuedFollowUp(item.id)}><X size={14} aria-hidden="true" /></button></div></div>
+                </li>)}</ol>
+                {!sending && !pendingResponse && queuedFollowUps[0]?.status === "queued" && !followUpAutoDrainRef.current && <footer><span>Recovered follow-ups are paused for review.</span><button className="button secondary" type="button" onClick={() => retryQueuedFollowUp(queuedFollowUps[0].id)}>Send next</button></footer>}
+              </section>}
               <form className="chat-composer" onSubmit={(event) => void submit(event)} onDragOver={(event) => { if ([...event.dataTransfer.items].some((item) => item.kind === "file" && item.type.startsWith("image/"))) event.preventDefault(); }} onDrop={dropComposerImages}>
                 {assistantDrafts.length > 0 && <section className="chat-context-pack" aria-label="Selected context pack">
                   <header><div><strong>Context pack</strong><small>{assistantDrafts.length} selection{assistantDrafts.length === 1 ? "" : "s"} · {assistantDrafts.reduce((total, item) => total + item.text.length, 0).toLocaleString()} characters</small></div><button className="button quiet" type="button" onClick={clearAssistantDrafts}>Clear all</button></header>
@@ -2979,10 +3179,10 @@ export function SessionsPage() {
                 {pendingImages.length > 0 && <div className="chat-image-attachments" role="list" aria-label="Image attachments">{pendingImages.map((image, index) => <div role="listitem" key={`${image.block.artifactId}-${index}`}><img src={image.previewUrl} alt={image.filename} /><button className="icon-button subtle" type="button" aria-label={`Remove ${image.filename}`} onClick={() => removePendingImage(index)}><X size={14} /></button></div>)}</div>}
                 <label className="sr-only" htmlFor="analyst-message">Message the analyst assistant</label>
                 <div className="chat-composer-input" role="combobox" aria-label="Skill suggestions" aria-autocomplete="list" aria-expanded={Boolean(skillToken)} aria-controls={skillToken ? "harness-skill-menu" : undefined} aria-activedescendant={skillToken && matchingHarnessSkills.length ? `harness-skill-option-${skillMenuIndex}` : undefined}>
-                  <textarea ref={composerRef} id="analyst-message" data-selection-actions-disabled="true" value={draft} disabled={!engagement || !runtimeReady || loadingHistory} placeholder={!engagement ? "Create or select a project to chat…" : canSteerCurrentHarness ? "Add guidance while the harness works…" : runtimeReady ? "Ask about this project…" : "Add a model or harness in Settings…"} rows={1} onFocus={() => setAssistantSettingsOpen(false)} onPaste={pasteComposerImages} onKeyDown={onComposerKeyDown} onChange={(event) => updateComposerDraft(event.target.value, event.target.selectionStart ?? event.target.value.length)} />
+                  <textarea ref={composerRef} id="analyst-message" data-selection-actions-disabled="true" value={draft} disabled={!engagement || !runtimeReady || loadingHistory} placeholder={!engagement ? "Create or select a project to chat…" : canSteerCurrentHarness ? "Add guidance while the harness works…" : queueMode ? "Queue the next message while this response finishes…" : runtimeReady ? "Ask about this project…" : "Add a model or harness in Settings…"} rows={1} onFocus={() => setAssistantSettingsOpen(false)} onPaste={pasteComposerImages} onKeyDown={onComposerKeyDown} onChange={(event) => updateComposerDraft(event.target.value, event.target.selectionStart ?? event.target.value.length)} />
                   {skillToken && <HarnessSkillAutocomplete skills={harnessSkills} token={skillToken} activeIndex={skillMenuIndex} onActiveIndexChange={setSkillMenuIndex} onSelect={selectHarnessSkill} onClose={() => setSkillToken(undefined)} />}
                 </div>
-                <footer><button ref={assistantSettingsButtonRef} className={`button quiet chat-runtime-summary chat-settings-trigger${runtimeReady ? "" : " needs-attention"}`} type="button" aria-label="Assistant settings" aria-expanded={assistantSettingsOpen} aria-controls="assistant-settings-popover" title={runtimeReady ? `${assistantSource}${runtimeConfiguration ? ` · ${runtimeConfiguration}` : ""}` : "Choose an assistant runtime"} onClick={() => setAssistantSettingsOpen((open) => !open)}><Settings2 size={15} aria-hidden="true" /><span><strong>{assistantSource}</strong><small> · {runtimeConfiguration || "Choose a model"}</small></span></button>{sessionId && <button className={`button quiet chat-context-meter status-${activeContextStatus?.status ?? "loading"}`} type="button" aria-label={contextPercent === undefined ? "Open context details" : `Open context details, ${contextPercent} percent of target input used`} title={activeContextStatus?.status === "runtime_managed" ? "Context is managed by the harness runtime" : contextPercent === undefined ? "Read authoritative context status" : `${activeContextStatus?.estimatedInputTokens.toLocaleString()} of ${activeContextStatus?.targetInputTokens.toLocaleString()} target input tokens`} onClick={() => { localStorage.setItem("nebula.session-inspector.open", "true"); setSessionInspectorOpen(true); }}><span aria-hidden="true" style={contextPercent === undefined ? undefined : { "--context-percent": `${contextPercent}%` } as CSSProperties}>{contextPercent === undefined ? "—" : contextPercent}</span><small>context</small></button>}<input ref={imageInputRef} className="sr-only" type="file" aria-label="Choose image attachments" accept="image/png,image/jpeg,image/webp" multiple onChange={(event) => void attachImages(event)} /><button className="button quiet square chat-composer-attachment" type="button" aria-label="Attach images" disabled={!imageInputEnabled || uploadingImage || pendingImages.length >= 4} title={imageInputEnabled ? "Choose, paste, or drop PNG, JPEG, or WebP images" : "The selected runtime does not advertise image input"} onClick={() => imageInputRef.current?.click()}>{uploadingImage ? <LoaderCircle className="spin" size={15} /> : <ImagePlus size={15} />}</button>{canSteerCurrentHarness && draft.trim() && <button className="button primary square chat-composer-submit" type="submit" disabled={harnessControlBusy} aria-label="Send guidance now" title="Steer the active harness turn"><Send size={16} /></button>}{sending ? <button className="button secondary square chat-composer-submit" type="button" aria-label="Stop response" disabled={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false} title={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false ? "This harness does not advertise turn interruption" : undefined} onClick={() => void stopCurrentResponse()}><Square size={15} /></button> : <button className="button primary square chat-composer-submit" type="submit" disabled={!canSend} aria-label="Send message"><Send size={16} /></button>}</footer>
+                <footer><button ref={assistantSettingsButtonRef} className={`button quiet chat-runtime-summary chat-settings-trigger${runtimeReady ? "" : " needs-attention"}`} type="button" aria-label="Assistant settings" aria-expanded={assistantSettingsOpen} aria-controls="assistant-settings-popover" title={runtimeReady ? `${assistantSource}${runtimeConfiguration ? ` · ${runtimeConfiguration}` : ""}` : "Choose an assistant runtime"} onClick={() => setAssistantSettingsOpen((open) => !open)}><Settings2 size={15} aria-hidden="true" /><span><strong>{assistantSource}</strong><small> · {runtimeConfiguration || "Choose a model"}</small></span></button>{sessionId && <button className={`button quiet chat-context-meter status-${activeContextStatus?.status ?? "loading"}`} type="button" aria-label={contextPercent === undefined ? "Open context details" : `Open context details, ${contextPercent} percent of target input used`} title={activeContextStatus?.status === "runtime_managed" ? "Context is managed by the harness runtime" : contextPercent === undefined ? "Read authoritative context status" : `${activeContextStatus?.estimatedInputTokens.toLocaleString()} of ${activeContextStatus?.targetInputTokens.toLocaleString()} target input tokens`} onClick={() => { localStorage.setItem("nebula.session-inspector.open", "true"); setSessionInspectorOpen(true); }}><span aria-hidden="true" style={contextPercent === undefined ? undefined : { "--context-percent": `${contextPercent}%` } as CSSProperties}>{contextPercent === undefined ? "—" : contextPercent}</span><small>context</small></button>}<input ref={imageInputRef} className="sr-only" type="file" aria-label="Choose image attachments" accept="image/png,image/jpeg,image/webp" multiple onChange={(event) => void attachImages(event)} /><button className="button quiet square chat-composer-attachment" type="button" aria-label="Attach images" disabled={composerBusy || !imageInputEnabled || uploadingImage || pendingImages.length >= 4} title={composerBusy ? "Attachments are available after the active response finishes" : imageInputEnabled ? "Choose, paste, or drop PNG, JPEG, or WebP images" : "The selected runtime does not advertise image input"} onClick={() => imageInputRef.current?.click()}>{uploadingImage ? <LoaderCircle className="spin" size={15} /> : <ImagePlus size={15} />}</button>{canSteerCurrentHarness && draft.trim() && <button className="button primary square chat-composer-submit" type="submit" disabled={harnessControlBusy} aria-label="Send guidance now" title="Steer the active harness turn"><Send size={16} /></button>}{queueMode && draft.trim() && <button className="button primary square chat-composer-submit" type="submit" aria-label="Queue follow-up message" title="Queue this text after the active response"><ListTodo size={16} /></button>}{sending && <button className="button secondary square chat-composer-submit" type="button" aria-label="Stop response" disabled={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false} title={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false ? "This harness does not advertise turn interruption" : undefined} onClick={() => void stopCurrentResponse()}><Square size={15} /></button>}{!composerBusy && <button className="button primary square chat-composer-submit" type="submit" disabled={!canSend} aria-label="Send message"><Send size={16} /></button>}</footer>
               </form>
               {showHarnessProgress && visibleHarnessProgress && <div className={`chat-harness-progress phase-${visibleHarnessProgress.phase}`} role="status" aria-live="polite"><span className={`status-dot ${visibleHarnessProgress.phase === "failed" || visibleHarnessProgress.phase === "status_unavailable" ? "unavailable" : "pending"}`} /><div><strong>{harnessPhaseLabel(visibleHarnessProgress.phase)}</strong><small>{visibleHarnessProgress.detail}</small>{visibleHarnessProgress.sessionId && <code title={visibleHarnessProgress.sessionId}>Session {visibleHarnessProgress.sessionId.slice(0, 8)}{visibleHarnessProgress.previousSessionId ? " · independent parallel session" : ""}</code>}</div>{sending && selectedHarness?.capabilities?.steering && <button className="button quiet harness-steer-button" type="button" disabled={harnessControlBusy} onClick={() => composerRef.current?.focus()}><Plus size={13} aria-hidden="true" /> Add guidance</button>}</div>}
             </div>

--- a/ui/src/pages/chatFollowUpStorage.test.ts
+++ b/ui/src/pages/chatFollowUpStorage.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  chatFollowUpStorageKey,
+  clearChatFollowUps,
+  maxChatFollowUps,
+  readChatFollowUps,
+  validateChatFollowUpText,
+  writeChatFollowUps,
+  type ChatFollowUp,
+} from "./chatFollowUpStorage";
+
+const item = (id: string, status: ChatFollowUp["status"] = "queued"): ChatFollowUp => ({
+  id,
+  text: `message ${id}`,
+  createdAt: "2026-08-24T12:00:00Z",
+  status,
+});
+
+describe("assistant follow-up queue recovery", () => {
+  it("isolates ordered follow-ups by project and conversation", () => {
+    const storage = window.sessionStorage;
+    const first = chatFollowUpStorageKey("project/a", "session 1");
+    const second = chatFollowUpStorageKey("project/a", "session 2");
+    writeChatFollowUps(storage, first, [item("one"), item("two")]);
+    writeChatFollowUps(storage, second, [item("other")]);
+
+    expect(readChatFollowUps(storage, first).map((value) => value.id)).toEqual(["one", "two"]);
+    expect(readChatFollowUps(storage, second).map((value) => value.id)).toEqual(["other"]);
+    clearChatFollowUps(storage, first);
+    expect(readChatFollowUps(storage, first)).toEqual([]);
+    expect(readChatFollowUps(storage, second)).toHaveLength(1);
+  });
+
+  it("requires review after a reload during send", () => {
+    const key = chatFollowUpStorageKey("project", "session");
+    writeChatFollowUps(window.sessionStorage, key, [item("replayed", "sending")]);
+
+    expect(readChatFollowUps(window.sessionStorage, key)).toEqual([expect.objectContaining({
+      id: "replayed",
+      status: "failed",
+      detail: expect.stringContaining("reloaded"),
+    })]);
+  });
+
+  it("validates text and bounds the persisted queue", () => {
+    expect(validateChatFollowUpText("  ")).toContain("Write a message");
+    expect(validateChatFollowUpText("ok")).toBeUndefined();
+    expect(validateChatFollowUpText("x".repeat(32_001))).toContain("32,000");
+
+    const key = chatFollowUpStorageKey("project", "session");
+    writeChatFollowUps(window.sessionStorage, key, Array.from({ length: maxChatFollowUps() + 3 }, (_, index) => item(String(index))));
+    expect(readChatFollowUps(window.sessionStorage, key)).toHaveLength(maxChatFollowUps());
+  });
+});

--- a/ui/src/pages/chatFollowUpStorage.ts
+++ b/ui/src/pages/chatFollowUpStorage.ts
@@ -1,0 +1,87 @@
+export type ChatFollowUpStatus = "queued" | "sending" | "failed";
+
+export interface ChatFollowUp {
+  id: string;
+  text: string;
+  createdAt: string;
+  status: ChatFollowUpStatus;
+  detail?: string;
+}
+
+const FOLLOW_UP_PREFIX = "nebula.assistant.follow-up.v1";
+const MAX_FOLLOW_UPS = 20;
+const MAX_FOLLOW_UP_LENGTH = 32_000;
+
+export function chatFollowUpStorageKey(engagementId: string, sessionId?: string): string {
+  return `${FOLLOW_UP_PREFIX}:${encodeURIComponent(engagementId)}:${encodeURIComponent(sessionId || "new")}`;
+}
+
+function isFollowUp(value: unknown): value is ChatFollowUp {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<ChatFollowUp>;
+  return typeof candidate.id === "string"
+    && typeof candidate.text === "string"
+    && typeof candidate.createdAt === "string"
+    && (candidate.status === "queued" || candidate.status === "sending" || candidate.status === "failed");
+}
+
+/**
+ * Recover a queue after a browser reload without replaying an item that may
+ * already have reached Core. A sending item therefore needs operator review.
+ */
+export function readChatFollowUps(storage: Storage, key: string): ChatFollowUp[] {
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(isFollowUp)
+      .slice(0, MAX_FOLLOW_UPS)
+      .map((item) => item.status === "sending"
+        ? {
+          ...item,
+          status: "failed" as const,
+          detail: "The browser was reloaded while this message was being sent. Review it before retrying.",
+        }
+        : item);
+  } catch {
+    // diagnostic-expected: queue recovery must not block the composer when
+    // constrained browsers deny, corrupt, or fill session storage.
+    return [];
+  }
+}
+
+export function writeChatFollowUps(storage: Storage, key: string, items: ChatFollowUp[]): void {
+  try {
+    if (!items.length) {
+      storage.removeItem(key);
+      return;
+    }
+    storage.setItem(key, JSON.stringify(items.slice(0, MAX_FOLLOW_UPS)));
+  } catch {
+    // diagnostic-expected: queue persistence is a recovery convenience and
+    // must never prevent the active assistant from continuing.
+  }
+}
+
+export function clearChatFollowUps(storage: Storage, key: string): void {
+  try {
+    storage.removeItem(key);
+  } catch {
+    // diagnostic-expected: cleanup must not block conversation navigation.
+  }
+}
+
+export function validateChatFollowUpText(text: string): string | undefined {
+  const normalized = text.trim();
+  if (!normalized) return "Write a message before queueing it.";
+  if (normalized.length > MAX_FOLLOW_UP_LENGTH) {
+    return `Queued messages are limited to ${MAX_FOLLOW_UP_LENGTH.toLocaleString()} characters.`;
+  }
+  return undefined;
+}
+
+export function maxChatFollowUps(): number {
+  return MAX_FOLLOW_UPS;
+}

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -1640,6 +1640,123 @@ test("streaming chat follows the bottom without overriding reader scroll intent"
   expect(await chatScroll.evaluate((element) => element.scrollTop)).toBeLessThanOrEqual(readerPosition + 2);
 });
 
+test("assistant follow-up queue sends ordered provider messages after the active turn", async ({ page }, testInfo) => {
+  test.skip(!["desktop", "narrow", "mobile-chromium-small", "mobile-webkit"].includes(testInfo.project.name), "Covered by the permanent desktop and mobile assistant queue projects.");
+  const provider = {
+    ...entity,
+    id: "provider-follow-up-queue",
+    name: "Queue test provider",
+    provider_type: "vllm",
+    endpoint: "http://127.0.0.1:8000/v1",
+    enabled: true,
+    is_local: true,
+    secret_ref: null,
+    model_allowlist: ["queue-test-model"],
+    capabilities: { streaming: true },
+    privacy: { local_only: true, permits_sensitive_data: true },
+    metadata: { default_model: "queue-test-model" },
+  };
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    if (path.endsWith("/providers") && request.method() === "GET") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([provider]) });
+      return;
+    }
+    if (path.endsWith(`/providers/${provider.id}/health`) && request.method() === "POST") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ provider_id: provider.id, healthy: true, models: ["queue-test-model"] }) });
+      return;
+    }
+    if (path.endsWith("/chat-sessions") && request.method() === "GET") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    if (path.includes("/chat/sessions/") && (path.endsWith("/messages") || path.endsWith("/pending-turn"))) {
+      await route.fulfill({ status: 200, contentType: "application/json", body: path.endsWith("/pending-turn") ? "null" : "[]" });
+      return;
+    }
+    await route.fallback();
+  });
+  await page.addInitScript(() => {
+    const nativeFetch = globalThis.fetch.bind(globalThis);
+    let requestNumber = 0;
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (!url.endsWith("/chat/completions")) return nativeFetch(input, init);
+      const request = JSON.parse(String(init?.body ?? "{}")) as { messages?: Array<{ content?: string }> };
+      requestNumber += 1;
+      const current = requestNumber;
+      const requests = (globalThis as typeof globalThis & { __queueChatRequests?: unknown[] }).__queueChatRequests ??= [];
+      requests.push(request);
+      const encoder = new TextEncoder();
+      const answer = current === 1 ? "The first response is still running." : "The queued follow-up completed.";
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          const enqueue = (frame: unknown) => controller.enqueue(encoder.encode(`data: ${JSON.stringify(frame)}\n\n`));
+          enqueue({ type: "started", provider_id: "provider-follow-up-queue", model: "queue-test-model", session_id: "queue-session", turn_id: `queue-turn-${current}` });
+          enqueue({ type: "delta", provider_id: "provider-follow-up-queue", model: "queue-test-model", delta: answer });
+          const finish = () => {
+            enqueue({
+              type: "done",
+              provider_id: "provider-follow-up-queue",
+              model: "queue-test-model",
+              session_id: "queue-session",
+              turn_id: `queue-turn-${current}`,
+              message: { id: `queue-assistant-${current}`, role: "assistant", content: answer },
+              usage: { input_tokens: 4, output_tokens: 8, total_tokens: 12 },
+              finish_reason: "stop",
+              citations: [],
+            });
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          };
+          if (current === 1) globalThis.setTimeout(finish, 6_000);
+          else finish();
+        },
+      });
+      return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
+    };
+  });
+
+  await openWorkspace(page, "/?view=chat", "Workbench");
+  await page.getByRole("button", { name: "New chat", exact: true }).click();
+  const composer = page.getByPlaceholder("Ask about this project…");
+  await expect(composer).toBeEnabled();
+  await composer.fill("Start the first response.");
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect(page.getByRole("button", { name: "Stop response" })).toBeVisible();
+
+  const queueComposer = page.getByPlaceholder("Queue the next message while this response finishes…");
+  await expect(queueComposer).toBeVisible();
+  await queueComposer.fill("First queued follow-up.");
+  await queueComposer.press("Enter");
+  await queueComposer.fill("Second queued follow-up.");
+  await queueComposer.press("Enter");
+  await expect(page.getByRole("region", { name: "Queued follow-up messages" })).toContainText("2 messages");
+  await expect(page.getByRole("region", { name: "Queued follow-up messages" })).toContainText("First queued follow-up.");
+  await expect(page.getByRole("region", { name: "Queued follow-up messages" })).toContainText("Second queued follow-up.");
+  const queue = page.getByRole("region", { name: "Queued follow-up messages" });
+  const queueGeometry = await queue.evaluate((element) => ({
+    scrollWidth: element.scrollWidth,
+    clientWidth: element.clientWidth,
+    viewportWidth: window.innerWidth,
+  }));
+  expect(queueGeometry.scrollWidth).toBeLessThanOrEqual(queueGeometry.clientWidth + 1);
+  expect(queueGeometry.clientWidth).toBeLessThanOrEqual(queueGeometry.viewportWidth + 1);
+  const queueAccessibility = await new AxeBuilder({ page }).include(".chat-follow-up-queue").analyze();
+  expect(queueAccessibility.violations).toEqual([]);
+
+  await expect.poll(() => page.evaluate(() => (globalThis as typeof globalThis & { __queueChatRequests?: Array<{ messages?: Array<{ content?: string }> }> }).__queueChatRequests?.length ?? 0), { timeout: 15_000 }).toBe(3);
+  const requests = await page.evaluate(() => (globalThis as typeof globalThis & { __queueChatRequests?: Array<{ messages?: Array<{ content?: string }> }> }).__queueChatRequests ?? []);
+  expect(requests.map((request) => request.messages?.at(-1)?.content)).toEqual([
+    "Start the first response.",
+    "First queued follow-up.",
+    "Second queued follow-up.",
+  ]);
+  await expect(page.getByText("The queued follow-up completed.").first()).toBeVisible();
+  await expect(page.getByRole("region", { name: "Queued follow-up messages" })).toHaveCount(0);
+});
+
 test("an idle resumed harness keeps routine telemetry quiet", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "desktop", "Harness status placement needs one desktop interaction run.");
   const harnessSessionId = "c9745e80-1111-4222-8333-444455556666";


### PR DESCRIPTION
## Summary

- Preserve steering for active harnesses that advertise steering.
- Queue plain-text follow-ups for providers and non-steerable harnesses, sending them in order after the active response.
- Persist the bounded queue per engagement/session in the current browser tab, with visible retry/review states after failures or reloads.
- Cover queue order, mobile layout, accessibility, and overflow behavior in the operator-facing tests.
- This pass intentionally does not add a server-side or cross-device provider queue.

## Verification

- npm run test -- --run — 63 files and 322 tests passed.
- npm run build — passed.
- Playwright queue workflow — passed on desktop, 320px Chromium, and Mobile WebKit; includes axe and horizontal-overflow checks.
- Existing completed-harness transcript test — passed.
- Python harness regression — passed.
- git diff --check — clean.
- Live service — port 8000 is active; served index.html exactly matches this production bundle and the served JavaScript contains the queue control.

## Gate note

The real-Core Playwright gate was attempted but is unavailable in this worktree because /home/agent/nebula-assistant-followups/.venv/bin/nebula-core is missing (ENOENT). The live Core process remained running while only the generated UI bundle was atomically swapped. The CSS audit also reports 20 violations that are identical on main and predate this change.