### PR TITLE
Keep native browser active with remote Core

### DIFF
--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -1396,7 +1396,6 @@ kbd { font-size: 11px; }
 .core-connection-actions { display: flex; flex-wrap: wrap; gap: 10px; }
 .core-connection-actions .button { min-height: 44px; }
 .core-connection-boundary { padding-top: 12px; border-top: 1px solid var(--border-soft); }
-.browser-remote-core-boundary { margin: 20px; }
 
 .diagnostics-unavailable {
   display: flex;

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -148,7 +148,7 @@ export function AppShell() {
       <WorkbenchEditorProvider>
         <WorkbenchDraftProvider>
           <ChromeProvider value={chrome}>
-            {runtime?.mode !== "desktop_remote" && <BrowserAutomationWorker />}
+            <BrowserAutomationWorker />
             <div className={`app-shell${zero ? " zero-layer-shell" : ""}${activityOpen ? " with-activity" : ""}${sidebarCollapsed ? " sidebar-collapsed" : ""}`}>
               <a className="skip-link" href="#main-content">Skip to main content</a>
               <SideNav collapsed={sidebarCollapsed} onNavigate={closeMobileSidebar} variant={zero ? "zero" : "standard"} />

--- a/ui/src/components/WorkbenchBrowser.tsx
+++ b/ui/src/components/WorkbenchBrowser.tsx
@@ -116,15 +116,16 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   const dialogOpen = useDialogOpen();
   const { activityOpen, paletteOpen, sidebarCollapsed } = useChrome();
   const desktop = isTauriRuntime();
-  const deviceIdRef = useRef(desktop ? "desktop" : "paired-browser");
-  useEffect(() => { if (desktop) void desktopDeviceId().then((value) => { deviceIdRef.current = value; }).catch((caught) => {
-    void logCaughtDiagnostic("interface.security_browser.device_identity_unavailable", "The desktop browser identity could not be loaded.", caught, "workbench_browser");
-  }); }, [desktop]);
+  const [deviceId, setDeviceId] = useState<string | undefined>(desktop ? undefined : "paired-browser");
   const [tabs, setTabs] = useState<BrowserTab[]>(() => [blankTab()]);
   const [activeId, setActiveId] = useState(() => tabs[0].id);
   const [capabilities, setCapabilities] = useState<BrowserCapabilities>();
   const [notice, setNotice] = useState<BrowserNotice>();
   const [error, setError] = useState<string>();
+  useEffect(() => { if (desktop) void desktopDeviceId().then(setDeviceId).catch((caught) => {
+    void logCaughtDiagnostic("interface.security_browser.device_identity_unavailable", "The desktop browser identity could not be loaded.", caught, "workbench_browser");
+    setError("This desktop's Browser identity is unavailable. Retry after restoring access to the protected app configuration.");
+  }); }, [desktop]);
   const [addingKnowledge, setAddingKnowledge] = useState(false);
   const addingScopeRef = useRef(false);
   const [capturingContext, setCapturingContext] = useState(false);
@@ -333,7 +334,8 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
           lastScopeRevision: decision.revision,
         };
       });
-      const persistedSession = await api.syncSecurityBrowserSession(activeSession, durableTabs, id, deviceIdRef.current);
+      if (!deviceId) throw new Error("The stable desktop Browser identity is still loading.");
+      const persistedSession = await api.syncSecurityBrowserSession(activeSession, durableTabs, id, deviceId);
       setWorkspace((current) => current ? {
         ...current,
         sessions: current.sessions.map((session) => session.id === persistedSession.id ? persistedSession : session),
@@ -364,7 +366,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
       updateTab(id, { loading: false, error: errorMessage(caught) });
       return false;
     }
-  }, [activeIdentity, activeSession, api, bounds, projectId, scope, updateTab]);
+  }, [activeIdentity, activeSession, api, bounds, deviceId, projectId, scope, updateTab]);
 
   const addTab = useCallback((url?: string) => {
     if (tabsRef.current.length >= MAX_TABS) {
@@ -449,7 +451,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   const startAutonomousRun = async (event: FormEvent) => {
     event.preventDefault();
     if (automationBusy || !activeSession || !activeIdentity || !activeTab?.created) return;
-    if (activeSession.deviceOwner !== deviceIdRef.current) {
+    if (!deviceId || activeSession.deviceOwner !== deviceId) {
       setWorkspaceError("This desktop browser is not paired to the selected session yet. Keep the session open, then retry after its device owner is saved.");
       return;
     }
@@ -541,7 +543,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   }, [refreshWorkspace]);
 
   useEffect(() => {
-    if (!desktop || !active || !activeSession) return;
+    if (!desktop || !active || !activeSession || !deviceId) return;
     let disposed = false;
     let handling = false;
     const process = async () => {
@@ -553,7 +555,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
         const queued = next.handoffs.find((handoff) => handoff.sessionId === activeSession.id && handoff.status === "queued");
         if (!queued) return;
         setWorkspace(next);
-        const claimed = await api.claimSecurityBrowserHandoff(queued, deviceIdRef.current);
+        const claimed = await api.claimSecurityBrowserHandoff(queued, deviceId);
         try {
           if (claimed.command === "focus_tab") {
             const target = tabsRef.current.find((tab) => tab.id === claimed.tabId);
@@ -569,11 +571,11 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
             setActiveId(target.id);
             if (!await openAddress(target.id, claimed.url)) throw new Error("The desktop browser could not complete the queued navigation.");
           }
-          await api.finishSecurityBrowserHandoff(claimed, "complete", undefined, deviceIdRef.current);
+          await api.finishSecurityBrowserHandoff(claimed, "complete", undefined, deviceId);
           setNotice({ kind: "info", message: "Paired-device browser handoff completed on this desktop." });
         } catch (caught) {
           void logCaughtDiagnostic("interface.security_browser.handoff_execution_failed", "A claimed browser handoff could not be completed.", caught, "workbench_browser");
-          await api.finishSecurityBrowserHandoff(claimed, "failed", errorMessage(caught), deviceIdRef.current).catch((receiptCaught) => {
+          await api.finishSecurityBrowserHandoff(claimed, "failed", errorMessage(caught), deviceId).catch((receiptCaught) => {
             void logCaughtDiagnostic("interface.security_browser.handoff_receipt_failed", "A failed browser handoff could not be recorded.", receiptCaught, "workbench_browser");
           });
           setWorkspaceError(errorMessage(caught));
@@ -588,7 +590,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
     void process();
     const timer = window.setInterval(() => void process(), 3000);
     return () => { disposed = true; window.clearInterval(timer); };
-  }, [active, activeSession, api, desktop, openAddress, projectId, refreshWorkspace]);
+  }, [active, activeSession, api, desktop, deviceId, openAddress, projectId, refreshWorkspace]);
 
   useEffect(() => {
     if (!activeSession || hydratedProjectRef.current === `${projectId}:${activeSession.id}`) return;
@@ -844,7 +846,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   }, [activeId, browserVisible, desktop, projectId, tabs]);
 
   useEffect(() => {
-    if (!activeSession || hydratedProjectRef.current !== `${projectId}:${activeSession.id}`) return;
+    if (!activeSession || !deviceId || hydratedProjectRef.current !== `${projectId}:${activeSession.id}`) return;
     const durableTabs = tabs.map((tab, position) => {
       const decision = evaluateBrowserScope(tab.url, scope);
       return {
@@ -860,7 +862,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
     const next = JSON.stringify({ tabs: durableTabs, active: activeId });
     if (previous === next) return;
     const timer = window.setTimeout(() => {
-      void api.syncSecurityBrowserSession(activeSession, durableTabs, activeId, desktop ? deviceIdRef.current : "paired-browser")
+      void api.syncSecurityBrowserSession(activeSession, durableTabs, activeId, deviceId)
         .then((updated) => setWorkspace((current) => current ? {
           ...current,
           sessions: current.sessions.map((session) => session.id === updated.id ? updated : session),
@@ -871,7 +873,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
         });
     }, 350);
     return () => window.clearTimeout(timer);
-  }, [activeId, activeSession, api, desktop, projectId, scope, tabs]);
+  }, [activeId, activeSession, api, deviceId, projectId, scope, tabs]);
 
   useEffect(() => {
     if (!desktop || !browserVisible || !activeTab?.created) return;
@@ -1491,7 +1493,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
         <button type="button" aria-label="Dismiss browser notice" onClick={() => setNotice(undefined)}><X size={14} /></button>
       </div>}
       <div className={`browser-surface${activeTab?.created ? " is-live" : ""}`} ref={surfaceRef}>
-        {!activeTab?.created && <div className="browser-start"><Globe2 size={34} /><strong>Browse from the Workbench</strong><p>Pages run in an isolated {capabilities?.engine ?? "system webview"} profile for the selected research identity. Nebula captures live page context only when you ask.</p><span className={`browser-start-scope ${scopeDecision.state}`}><ShieldCheck size={14} aria-hidden="true" /> {scopeDecision.label} · {scopeDecision.detail}</span><form onSubmit={submit}><Search size={16} /><input aria-label="Start browsing" autoFocus={active} value={activeTab?.address ?? ""} placeholder={!sessionHydrated ? "Loading isolated identity…" : "Search or enter an address"} disabled={!sessionHydrated || !activeIdentity} onChange={(event) => { if (activeTab) { addressDraftRef.current.set(activeTab.id, event.target.value); updateTab(activeTab.id, { address: event.target.value }); } }} /><button className="button primary" type="submit" disabled={!sessionHydrated || !activeIdentity}>Go</button></form>{activeTab?.error && <small role="alert">{activeTab.error}</small>}</div>}
+        {!activeTab?.created && <div className="browser-start"><Globe2 size={34} /><strong>Browse from the Workbench</strong><p>Pages run in an isolated {capabilities?.engine ?? "system webview"} profile for the selected research identity. Nebula captures live page context only when you ask.</p><span className={`browser-start-scope ${scopeDecision.state}`}><ShieldCheck size={14} aria-hidden="true" /> {scopeDecision.label} · {scopeDecision.detail}</span><form onSubmit={submit}><Search size={16} /><input aria-label="Start browsing" autoFocus={active} value={activeTab?.address ?? ""} placeholder={!sessionHydrated || !deviceId ? "Loading isolated identity…" : "Search or enter an address"} disabled={!sessionHydrated || !activeIdentity || !deviceId} onChange={(event) => { if (activeTab) { addressDraftRef.current.set(activeTab.id, event.target.value); updateTab(activeTab.id, { address: event.target.value }); } }} /><button className="button primary" type="submit" disabled={!sessionHydrated || !activeIdentity || !deviceId}>Go</button></form>{activeTab?.error && <small role="alert">{activeTab.error}</small>}</div>}
       </div>
       {researchPanel}
     </div>

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -503,7 +503,6 @@ export function SessionsPage() {
     refreshProvider,
     reverifyProvider,
     resolveApproval,
-    runtime,
     setupStatus,
     startMission,
     uploadEvidence,
@@ -2987,10 +2986,7 @@ export function SessionsPage() {
             <Suspense fallback={<div className="empty-state compact"><LoaderCircle className="spin" size={20} /><strong>Loading Code editor…</strong></div>}><CodeEditorPanel active={view === "code"} api={api} engagementId={engagement.id} workspacePath={engagement.workspacePath} providers={providers} harnesses={harnesses} onRun={setRunCandidate} onOpenTerminal={() => setView("terminal")} onCreateFindingDraft={requestFindingDraft} onUseWithAssistant={(context) => { requestNebulaDraft(context); setView("chat"); }} /></Suspense>
           </div>}
           {api && engagement && <div className="persistent-browser" hidden={view !== "browser"}>
-            {runtime?.mode === "desktop_remote" ? <div className="feature-unavailable browser-remote-core-boundary" role="status">
-              <Globe2 size={24} aria-hidden="true" />
-              <div><strong>Native Browser stays with the local desktop Core</strong><p>This UI shell is connected to a remote Core. Projects, terminals, chats, missions, and events use that remote Core, but this desktop does not claim or execute its Browser/proxy commands. Switch to Local Core in Settings to use the native Browser.</p></div>
-            </div> : <WorkbenchBrowser
+            <WorkbenchBrowser
               active={view === "browser"}
               api={api}
               operatorId={activeOperator?.id}
@@ -3002,7 +2998,7 @@ export function SessionsPage() {
               onOpenFiles={() => setView("workspace")}
               onScopeUpdated={setBrowserScope}
               onUploadEvidence={uploadEvidence}
-            />}
+            />
           </div>}
           {(view === "terminal" || view === "code") && (!api || !engagement) ? (
             <div className="empty-state"><FolderOpen size={24} /><strong>Preparing your project</strong><p>Terminal and Code become available as soon as Nebula finishes creating or loading a project.</p></div>

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -614,7 +614,7 @@ export function SettingsPage() {
             <label className="core-connection-insecure"><input type="checkbox" checked={insecureTransport} onChange={(event) => setInsecureTransport(event.target.checked)} /><span><strong>Allow HTTP for this connection</strong><small>Bearer tokens can be intercepted on an insecure network.</small></span></label>
             <div className="core-connection-actions"><button className="button primary" type="submit" disabled={coreConnectionBusy}>{coreConnectionBusy ? "Testing…" : "Connect UI shell to remote Core"}</button>{coreConnection?.mode === "remote" && <button className="button secondary" type="button" disabled={coreConnectionBusy} onClick={() => void invoke("use_local_backend").then(() => window.location.reload()).catch((error) => { void logCaughtDiagnostic("interface.settings_page.local_core_switch_failed", "The UI shell could not switch back to its local Core.", error, "settings_page"); setCoreConnectionError(error instanceof Error ? error.message : String(error)); })}>Use local Core</button>}</div>
           </form>
-          <p className="core-connection-boundary"><strong>Local-only capability:</strong> Native Browser/proxy automation is disabled while this shell uses a remote Core.</p>
+          <p className="core-connection-boundary"><strong>Native execution stays on this desktop:</strong> Browser tabs, identity storage, proxy traffic, and keyring credentials run locally. Their sessions, commands, rules, receipts, and evidence synchronize with the selected Core.</p>
           {coreConnectionError && <DiagnosticErrorNotice error={coreConnectionError} fallback="The Core connection could not be updated." compact />}
         </section>}
         <div className="setup-card-grid">

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -2807,7 +2807,7 @@ test("settings shows the live Kali preparation stage instead of a passive runtim
   await expect(page.getByRole("button", { name: "Preparing Kali…" })).toBeDisabled();
 });
 
-test("remote Core mode controls the UI shell and keeps native Browser local-only", async ({ browser }, testInfo) => {
+test("remote Core mode keeps the native Browser and command worker on this desktop", async ({ browser }, testInfo) => {
   test.skip(testInfo.project.name !== "desktop", "Desktop Core selection is a native-shell capability.");
   const context = await browser.newContext({ viewport: { width: 1024, height: 900 }, colorScheme: "dark" });
   const page = await context.newPage();
@@ -2822,6 +2822,23 @@ test("remote Core mode controls the UI shell and keeps native Browser local-only
           calls.push(command);
           if (command === "resolve_backend_connection") return { endpoint: `${location.origin}/api/v1`, token: "", protocol: "nebula-remote-core-v1", source: "remote" };
           if (command === "desktop_core_connection") return { mode: "remote", endpoint: `${location.origin}/api/v1`, tokenAvailable: true, deviceId: "desktop-remote-test" };
+          if (command === "desktop_device_id") return "desktop-remote-test";
+          if (command === "browser_capabilities") return {
+            engine: "Remote-Core local native mock",
+            projectStorage: "persistent",
+            identityPartitions: true,
+            devtools: true,
+            interceptionProxy: true,
+            http2Capture: true,
+            websocketCapture: true,
+            autonomousCommands: true,
+          };
+          if (command === "browser_proxy_ca_status") return {
+            certificatePath: "/protected/project-ca.pem",
+            fingerprint: "aa:bb:cc:dd",
+            state: "generated",
+            trustInstructions: "Trust this Project CA on the desktop before intercepting HTTPS.",
+          };
           return undefined;
         },
         transformCallback: () => 1,
@@ -2834,6 +2851,7 @@ test("remote Core mode controls the UI shell and keeps native Browser local-only
   await openWorkspace(page, "/settings", "Settings");
   const card = page.locator(".core-connection-settings");
   await expect(card.getByRole("heading", { name: "Remote Core selected" })).toBeVisible();
+  await expect(card.getByText(/Native execution stays on this desktop/)).toBeVisible();
   const geometry = await card.evaluate((element) => {
     const cardRect = element.getBoundingClientRect();
     const controls = [...element.querySelectorAll<HTMLElement>("input, button")].map((control) => control.getBoundingClientRect());
@@ -2854,12 +2872,17 @@ test("remote Core mode controls the UI shell and keeps native Browser local-only
     const current = geometry.controls[index];
     expect(current.top >= previous.bottom - 1 || current.left >= previous.right - 1).toBe(true);
   }
+  await expect.poll(() => page.evaluate(() => (window as Window & { __NEBULA_REMOTE_CORE_CALLS__?: string[] }).__NEBULA_REMOTE_CORE_CALLS__?.includes("desktop_device_id"))).toBe(true);
 
   await page.goto("/");
+  const ownershipRequest = page.waitForRequest((request) => request.method() === "PUT" && request.url().includes("/browser-sessions/browser-session-preview/tabs"));
   await page.getByRole("tab", { name: "Project browser", exact: true }).click();
-  await expect(page.getByText("Native Browser stays with the local desktop Core")).toBeVisible();
-  await expect(page.getByText(/Projects, terminals, chats, missions, and events use that remote Core/)).toBeVisible();
-  expect(await page.evaluate(() => (window as Window & { __NEBULA_REMOTE_CORE_CALLS__?: string[] }).__NEBULA_REMOTE_CORE_CALLS__?.some((command) => command.startsWith("browser_")))).toBe(false);
+  await expect(page.getByRole("tablist", { name: "Browser tabs" })).toBeVisible();
+  await expect(page.getByRole("textbox", { name: "Start browsing" })).toBeEnabled();
+  expect((await ownershipRequest).postDataJSON()).toMatchObject({ device_owner: "desktop-remote-test" });
+  const nativeCalls = await page.evaluate(() => (window as Window & { __NEBULA_REMOTE_CORE_CALLS__?: string[] }).__NEBULA_REMOTE_CORE_CALLS__ ?? []);
+  expect(nativeCalls).toContain("browser_capabilities");
+  expect(nativeCalls).toContain("desktop_device_id");
   await context.close();
 });
 


### PR DESCRIPTION
## Summary
- keep the desktop browser automation worker mounted when the UI shell uses a remote Core
- keep the native Browser and proxy visible and functional while durable state uses the selected Core API
- require the stable desktop device ID before browser ownership is persisted
- correct the Settings boundary copy and retain responsive connection-card geometry

## Verification
- npm run audit:diagnostics
- npm run build
- npm test (63 files, 323 tests)
- npx playwright test tests/interface.spec.ts --project=desktop --grep "remote Core mode keeps"

## Evidence boundary
The production web bundle and mocked native desktop workflow were exercised on Linux. A physical macOS remote-Core/native-webview run was not available on this host.