### PR TITLE
Validate remote Core connections natively

### DIFF
--- a/ui/src-tauri/Cargo.lock
+++ b/ui/src-tauri/Cargo.lock
@@ -576,6 +576,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,8 +1525,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1530,9 +1538,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2408,6 +2418,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,6 +2582,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -3261,6 +3278,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.5",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3435,6 +3508,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -3445,6 +3519,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -3549,6 +3624,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4634,6 +4710,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5272,6 +5363,16 @@ name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/ui/src-tauri/Cargo.toml
+++ b/ui/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ http-body-util = "0.1.3"
 ipnet = "2.12.0"
 minisign-verify = "0.2.5"
 regex = "1.12.2"
+reqwest = { version = "0.13.4", default-features = false, features = ["http2", "rustls"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.10.9"

--- a/ui/src-tauri/src/core_connection.rs
+++ b/ui/src-tauri/src/core_connection.rs
@@ -1,6 +1,6 @@
 //! Desktop-local Core selection. Remote credentials never enter the config file.
 
-use std::{fs, io::Write, path::PathBuf};
+use std::{fs, io::Write, path::PathBuf, time::Duration};
 
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde::{Deserialize, Serialize};
@@ -134,6 +134,44 @@ fn normalize_endpoint(value: &str, insecure_acknowledged: bool) -> Result<String
     Ok(format!("{endpoint}/api/v1"))
 }
 
+async fn validate_remote_core(endpoint: &str, token: &str) -> Result<(), String> {
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(8))
+        .timeout(Duration::from_secs(12))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|error| format!("cannot initialize the secure remote Core connection: {error}"))?;
+    let response = client
+        .get(format!("{endpoint}/health"))
+        .header(reqwest::header::ACCEPT, "application/json")
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(|error| {
+            if error.is_timeout() {
+                "the remote Core health check timed out; verify the LAN address and port"
+                    .to_string()
+            } else if endpoint.starts_with("https://") {
+                "the remote Core could not be reached or its TLS certificate could not be validated"
+                    .to_string()
+            } else {
+                "the remote Core could not be reached; verify the LAN address, port, and local firewall"
+                    .to_string()
+            }
+        })?;
+    remote_health_status_error(response.status().as_u16()).map_or(Ok(()), Err)
+}
+
+fn remote_health_status_error(status: u16) -> Option<String> {
+    match status {
+        200..=299 => None,
+        401 | 403 => Some("the remote Core rejected the bearer token".to_string()),
+        _ => Some(format!(
+            "the remote Core health check returned HTTP {status}"
+        )),
+    }
+}
+
 #[tauri::command]
 pub(crate) fn desktop_core_connection(app: AppHandle) -> Result<CoreConnectionStatus, String> {
     let stored = load(&app)?;
@@ -155,7 +193,7 @@ pub(crate) fn desktop_core_connection(app: AppHandle) -> Result<CoreConnectionSt
 }
 
 #[tauri::command]
-pub(crate) fn configure_remote_backend(
+pub(crate) async fn configure_remote_backend(
     app: AppHandle,
     endpoint: String,
     token: String,
@@ -165,6 +203,7 @@ pub(crate) fn configure_remote_backend(
     if token.trim().len() < 24 {
         return Err("Enter the remote Core bearer token.".to_string());
     }
+    validate_remote_core(&endpoint, token.trim()).await?;
     token_entry()?.set_password(token.trim()).map_err(|_| {
         "cannot save the remote Core token in the operating-system credential vault".to_string()
     })?;
@@ -227,7 +266,7 @@ pub(crate) fn resolve_backend_connection(
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_endpoint;
+    use super::{normalize_endpoint, remote_health_status_error};
 
     #[test]
     fn normalizes_remote_api_origin_without_userinfo() {
@@ -245,6 +284,19 @@ mod tests {
         assert_eq!(
             normalize_endpoint("http://192.0.2.10:8000", true).unwrap(),
             "http://192.0.2.10:8000/api/v1"
+        );
+    }
+
+    #[test]
+    fn remote_health_errors_do_not_hide_token_rejection() {
+        assert_eq!(remote_health_status_error(204), None);
+        assert_eq!(
+            remote_health_status_error(401).as_deref(),
+            Some("the remote Core rejected the bearer token")
+        );
+        assert_eq!(
+            remote_health_status_error(503).as_deref(),
+            Some("the remote Core health check returned HTTP 503")
         );
     }
 }

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -141,10 +141,8 @@ export function SettingsPage() {
     event.preventDefault();
     setCoreConnectionBusy(true); setCoreConnectionError(undefined);
     try {
-      // Validate the bearer token against the candidate before persisting it.
-      const normalized = remoteEndpoint.trim().replace(/\/$/, "").replace(/\/api\/v1$/, "");
-      const response = await fetch(`${normalized}/api/v1/health`, { headers: { Accept: "application/json", Authorization: `Bearer ${remoteToken.trim()}` } });
-      if (!response.ok) throw new Error("Remote Core rejected the endpoint or bearer token.");
+      // Native code validates the candidate before persisting it. This avoids a
+      // WebView-only HTTP policy obscuring a LAN Core or keychain failure.
       const saved = await invoke<{ mode: string; endpoint?: string; tokenAvailable: boolean }>("configure_remote_backend", { endpoint: remoteEndpoint, token: remoteToken, acknowledgeInsecureTransport: insecureTransport });
       setCoreConnection(saved); setRemoteToken("");
       window.location.reload();


### PR DESCRIPTION
## Summary
- validate authenticated remote Core health through native desktop networking before saving a connection
- preserve explicit HTTP acknowledgement and strict HTTPS certificate validation
- return actionable timeout, TLS, token-rejection, and HTTP-status errors instead of collapsing WebView setup failures

## Verification
- cargo fmt --check
- cargo test core_connection --lib
- npm run audit:diagnostics
- npm run build
- npm test (63 files, 323 tests)

## Evidence boundary
The production UI build and Linux native desktop tests ran locally. macOS packaging/runtime verification will run in CI; a physical Mac was not available.