### PR TITLE
Add AI browser research workbench

### DIFF
--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -89,6 +89,27 @@ from .browser_security import (
     BrowserWebSocketFrameRecordRequest,
     BrowserWorkspace,
 )
+from .browser_research import (
+    AttackCreateRequest,
+    AttackResultRequest,
+    AttackStateRequest,
+    BrowserResearchService,
+    BrowserResearchWorkspace,
+    CompareRequest,
+    CrawlCreateRequest,
+    CrawlStateRequest,
+    DecoderRequest,
+    FindingPromotionRequest,
+    HarImportRequest,
+    InterceptCreateRequest,
+    InterceptDecisionRequest,
+    RepeaterResultRequest,
+    RepeaterTabCreateRequest,
+    RepeaterTabUpdateRequest,
+    SiteEdgeRecordRequest,
+    SiteNodeRecordRequest,
+    TokenAnalysisRequest,
+)
 from .api_validation import ApiEntityValidator
 from .chat import (
     ChatCompletionRequest,
@@ -416,6 +437,14 @@ CUSTOM_RESOURCES = {
     "browser_sessions",
     "browser_traffic",
     "browser_websocket_frames",
+    "browser_site_nodes",
+    "browser_site_edges",
+    "browser_crawl_jobs",
+    "browser_intercepts",
+    "browser_repeater_tabs",
+    "browser_attacks",
+    "browser_attack_results",
+    "browser_token_analyses",
 }
 
 API_PREFIX = "/api/v1"
@@ -755,8 +784,6 @@ class MissionStartRequest(NebulaModel):
             raise ValueError(
                 "harness missions require harness_profile_id and no provider_id"
             )
-        if self.browser_autonomy is not None and self.backend != RunBackend.NATIVE:
-            raise ValueError("browser autonomy is available only to native missions")
         return self
 
 
@@ -1165,6 +1192,7 @@ def create_app(
         artifact_store=artifact_store,
         tool_platform=tool_platform,
         automation_tool_platform=automation_tool_platform,
+        browser_automation_platform=browser_automation_platform,
     )
     if harness_runtime.store is not store:
         raise ValueError("harness_runtime_service must use the API store")
@@ -1172,6 +1200,7 @@ def create_app(
         harness_runtime.bind_tool_platform(tool_platform)
     if automation_tool_platform is not None:
         harness_runtime.bind_automation_tool_platform(automation_tool_platform)
+    harness_runtime.bind_browser_automation_platform(browser_automation_platform)
     mcp_probes = McpProbeService(
         store,
         credential_store=credentials,
@@ -6125,6 +6154,7 @@ def create_app(
                 mcp_server_ids=request.mcp_server_ids,
                 actor_id=operator_id,
                 allow_remote_mcp=request.allow_cloud_tool_results,
+                browser_autonomy=request.browser_autonomy,
             )
         return await missions.start_mission(
             engagement_id=request.engagement_id,
@@ -6207,6 +6237,13 @@ def create_app(
                 mcp_server_ids=list(prior.runtime_snapshot.get("mcp_server_ids") or []),
                 actor_id=operator_id,
                 allow_remote_mcp=request.allow_cloud_tool_results,
+                browser_autonomy=(
+                    BrowserAutonomyRequestModel.model_validate(
+                        prior.metadata["browser_autonomy"]
+                    )
+                    if isinstance(prior.metadata.get("browser_autonomy"), dict)
+                    else None
+                ),
             )
         else:
             created = await missions.start_mission(
@@ -7952,6 +7989,7 @@ def create_app(
             )
 
     browser_security = BrowserSecurityService(store, artifact_store)
+    browser_research = BrowserResearchService(store, browser_security, artifact_store)
 
     @app.get(
         f"{API_PREFIX}/engagements/{{engagement_id}}/browser-automation",
@@ -8058,6 +8096,243 @@ def create_app(
     )
     async def browser_workspace(engagement_id: str) -> BrowserWorkspace:
         return browser_security.workspace(engagement_id)
+
+    @app.get(
+        f"{API_PREFIX}/engagements/{{engagement_id}}/browser-research",
+        response_model=BrowserResearchWorkspace,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def browser_research_workspace(
+        engagement_id: str,
+    ) -> BrowserResearchWorkspace:
+        browser_research.interrupt_stale_intercepts(engagement_id)
+        return browser_research.workspace(engagement_id)
+
+    @app.post(
+        f"{API_PREFIX}/engagements/{{engagement_id}}/browser-site-nodes",
+        status_code=201,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def record_browser_site_node(
+        engagement_id: str,
+        request: SiteNodeRecordRequest,
+        x_nebula_actor: str = Header(default="native-browser", alias="X-Nebula-Actor"),
+    ) -> Any:
+        session = store.get(BrowserSession, request.session_id)
+        if session.engagement_id != engagement_id:
+            raise HTTPException(status_code=404, detail="browser session not found")
+        return browser_research.record_site_node(request, x_nebula_actor)
+
+    @app.post(
+        f"{API_PREFIX}/engagements/{{engagement_id}}/browser-site-edges",
+        status_code=201,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def record_browser_site_edge(
+        engagement_id: str,
+        request: SiteEdgeRecordRequest,
+        x_nebula_actor: str = Header(default="native-browser", alias="X-Nebula-Actor"),
+    ) -> Any:
+        session = store.get(BrowserSession, request.session_id)
+        if session.engagement_id != engagement_id:
+            raise HTTPException(status_code=404, detail="browser session not found")
+        return browser_research.record_site_edge(request, x_nebula_actor)
+
+    @app.post(
+        f"{API_PREFIX}/engagements/{{engagement_id}}/browser-crawls",
+        status_code=201,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def create_browser_crawl(
+        engagement_id: str,
+        request: CrawlCreateRequest,
+        x_nebula_actor: str = Header(default="operator", alias="X-Nebula-Actor"),
+    ) -> Any:
+        session = store.get(BrowserSession, request.session_id)
+        if session.engagement_id != engagement_id:
+            raise HTTPException(status_code=404, detail="browser session not found")
+        return browser_research.create_crawl(request, x_nebula_actor)
+
+    @app.post(
+        f"{API_PREFIX}/browser-crawls/{{crawl_id}}/state",
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def transition_browser_crawl(
+        crawl_id: str, request: CrawlStateRequest
+    ) -> Any:
+        return browser_research.transition_crawl(crawl_id, request)
+
+    @app.post(
+        f"{API_PREFIX}/browser-sessions/{{session_id}}/intercepts",
+        status_code=201,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def pause_browser_intercept(
+        session_id: str,
+        request: InterceptCreateRequest,
+        x_nebula_actor: str = Header(default="native-browser", alias="X-Nebula-Actor"),
+    ) -> Any:
+        return browser_research.pause_intercept(session_id, request, x_nebula_actor)
+
+    @app.post(
+        f"{API_PREFIX}/browser-intercepts/{{intercept_id}}/decision",
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def decide_browser_intercept(
+        intercept_id: str, request: InterceptDecisionRequest
+    ) -> Any:
+        return browser_research.decide_intercept(intercept_id, request)
+
+    @app.post(
+        f"{API_PREFIX}/engagements/{{engagement_id}}/browser-repeater-tabs",
+        status_code=201,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def create_browser_repeater_tab(
+        engagement_id: str,
+        request: RepeaterTabCreateRequest,
+        x_nebula_actor: str = Header(default="operator", alias="X-Nebula-Actor"),
+    ) -> Any:
+        session = store.get(BrowserSession, request.session_id)
+        if session.engagement_id != engagement_id:
+            raise HTTPException(status_code=404, detail="browser session not found")
+        return browser_research.create_repeater_tab(request, x_nebula_actor)
+
+    @app.put(
+        f"{API_PREFIX}/browser-repeater-tabs/{{tab_id}}",
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def update_browser_repeater_tab(
+        tab_id: str,
+        request: RepeaterTabUpdateRequest,
+        x_nebula_actor: str = Header(default="operator", alias="X-Nebula-Actor"),
+    ) -> Any:
+        return browser_research.update_repeater_tab(tab_id, request, x_nebula_actor)
+
+    @app.post(
+        f"{API_PREFIX}/browser-repeater-tabs/{{tab_id}}/results",
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def record_browser_repeater_result(
+        tab_id: str, request: RepeaterResultRequest
+    ) -> Any:
+        return browser_research.record_repeater_result(tab_id, request)
+
+    @app.post(
+        f"{API_PREFIX}/engagements/{{engagement_id}}/browser-attacks",
+        status_code=201,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def create_browser_attack(
+        engagement_id: str,
+        request: AttackCreateRequest,
+        x_nebula_actor: str = Header(default="operator", alias="X-Nebula-Actor"),
+    ) -> Any:
+        session = store.get(BrowserSession, request.session_id)
+        if session.engagement_id != engagement_id:
+            raise HTTPException(status_code=404, detail="browser session not found")
+        return browser_research.create_attack(request, x_nebula_actor)
+
+    @app.post(
+        f"{API_PREFIX}/browser-attacks/{{attack_id}}/state",
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def transition_browser_attack(
+        attack_id: str, request: AttackStateRequest
+    ) -> Any:
+        return browser_research.transition_attack(attack_id, request)
+
+    @app.post(
+        f"{API_PREFIX}/browser-attacks/{{attack_id}}/results",
+        status_code=201,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def add_browser_attack_result(
+        attack_id: str,
+        request: AttackResultRequest,
+        x_nebula_actor: str = Header(default="native-browser", alias="X-Nebula-Actor"),
+    ) -> Any:
+        return browser_research.add_attack_result(attack_id, request, x_nebula_actor)
+
+    @app.post(
+        f"{API_PREFIX}/browser-utilities/decode",
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def browser_decode(request: DecoderRequest) -> dict[str, Any]:
+        return browser_research.decode(request)
+
+    @app.post(
+        f"{API_PREFIX}/browser-utilities/compare",
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def browser_compare(request: CompareRequest) -> dict[str, Any]:
+        return browser_research.compare(request)
+
+    @app.post(
+        f"{API_PREFIX}/engagements/{{engagement_id}}/browser-token-analyses",
+        status_code=201,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def create_browser_token_analysis(
+        engagement_id: str,
+        request: TokenAnalysisRequest,
+        x_nebula_actor: str = Header(default="operator", alias="X-Nebula-Actor"),
+    ) -> Any:
+        session = store.get(BrowserSession, request.session_id)
+        if session.engagement_id != engagement_id:
+            raise HTTPException(status_code=404, detail="browser session not found")
+        return browser_research.analyze_tokens(request, x_nebula_actor)
+
+    @app.post(
+        f"{API_PREFIX}/engagements/{{engagement_id}}/browser-findings",
+        status_code=201,
+        tags=["security-browser", "findings"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def promote_browser_finding(
+        engagement_id: str,
+        request: FindingPromotionRequest,
+        x_nebula_actor: str = Header(default="operator", alias="X-Nebula-Actor"),
+    ) -> Any:
+        return browser_research.promote_finding(engagement_id, request, x_nebula_actor)
+
+    @app.post(
+        f"{API_PREFIX}/engagements/{{engagement_id}}/browser-har/import",
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def import_browser_har(
+        engagement_id: str,
+        request: HarImportRequest,
+        x_nebula_actor: str = Header(default="operator", alias="X-Nebula-Actor"),
+    ) -> dict[str, Any]:
+        return browser_research.import_har(engagement_id, request, x_nebula_actor)
+
+    @app.get(
+        f"{API_PREFIX}/engagements/{{engagement_id}}/browser-har/export",
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def export_browser_har(
+        engagement_id: str, session_id: str = Query(min_length=1, max_length=200)
+    ) -> dict[str, Any]:
+        return browser_research.export_har(engagement_id, session_id)
 
     @app.post(
         f"{API_PREFIX}/engagements/{{engagement_id}}/browser-identities",

--- a/src/nebula/v3/browser_automation.py
+++ b/src/nebula/v3/browser_automation.py
@@ -72,6 +72,15 @@ COMMAND_RISK: dict[str, RiskClass] = {
     "proxy.remove_rule": RiskClass.ACTIVE_SCAN,
     "proxy.replay": RiskClass.ACTIVE_SCAN,
     "proxy.emergency_stop": RiskClass.ACTIVE_SCAN,
+    "target.observe": RiskClass.PASSIVE,
+    "target.crawl": RiskClass.ACTIVE_SCAN,
+    "repeater.create": RiskClass.ACTIVE_SCAN,
+    "intruder.create": RiskClass.ACTIVE_SCAN,
+    "intruder.control": RiskClass.ACTIVE_SCAN,
+    "analysis.decode": RiskClass.PASSIVE,
+    "analysis.compare": RiskClass.PASSIVE,
+    "analysis.tokens": RiskClass.PASSIVE,
+    "finding.propose": RiskClass.PASSIVE,
 }
 CREDENTIAL_CAPABLE_COMMANDS = frozenset(
     {"browser.interact", "browser.replay", "proxy.replay"}

--- a/src/nebula/v3/browser_research.py
+++ b/src/nebula/v3/browser_research.py
@@ -1,0 +1,1261 @@
+"""Durable Burp-class research primitives for the Nebula security browser.
+
+Live network transactions remain native-owned.  This service persists their
+reviewable state, enforces Project/session ownership, and provides bounded,
+deterministic utilities that are safe to expose to operators and AI runtimes.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import difflib
+import gzip
+import hashlib
+import html
+import json
+import math
+from collections import Counter
+from datetime import timedelta
+from typing import Any, Literal
+from urllib.parse import parse_qsl, unquote, quote, urlsplit, urlunsplit
+
+from pydantic import Field, field_validator, model_validator
+
+from .artifacts import ArtifactStore
+from .browser_security import (
+    BrowserSecurityService,
+    BrowserWorkflowError,
+    redact_browser_headers,
+)
+from .domain import (
+    BrowserAttack,
+    BrowserAttackResult,
+    BrowserCrawlJob,
+    BrowserInterceptItem,
+    BrowserRepeaterTab,
+    BrowserSession,
+    BrowserSiteEdge,
+    BrowserSiteNode,
+    BrowserTokenAnalysis,
+    BrowserTrafficExchange,
+    Evidence,
+    Finding,
+    FindingStatus,
+    NebulaModel,
+    Severity,
+    utc_now,
+)
+from .storage import NebulaStore
+
+
+MAX_UTILITY_INPUT = 1_048_576
+MAX_HAR_ENTRIES = 10_000
+INTERCEPT_LIFETIME = timedelta(minutes=5)
+ALLOWED_TRANSFORMS = {
+    "url_encode",
+    "url_decode",
+    "base64_encode",
+    "base64_decode",
+    "hex_encode",
+    "hex_decode",
+    "html_encode",
+    "html_decode",
+    "lowercase",
+    "uppercase",
+}
+CURATED_PAYLOADS: dict[str, tuple[str, ...]] = {
+    "booleans": ("true", "false", "1", "0", "null"),
+    "boundary_numbers": ("-1", "0", "1", "2147483647", "2147483648"),
+    "path_boundaries": (".", "..", "../", "%2e%2e%2f"),
+    "header_boundaries": ("", "0", "null", "undefined"),
+}
+
+
+class BrowserResearchWorkspace(NebulaModel):
+    site_nodes: list[BrowserSiteNode]
+    site_edges: list[BrowserSiteEdge]
+    crawl_jobs: list[BrowserCrawlJob]
+    intercepts: list[BrowserInterceptItem]
+    repeater_tabs: list[BrowserRepeaterTab]
+    attacks: list[BrowserAttack]
+    attack_results: list[BrowserAttackResult]
+    token_analyses: list[BrowserTokenAnalysis]
+
+
+class SiteNodeRecordRequest(NebulaModel):
+    session_id: str = Field(min_length=1, max_length=200)
+    url: str = Field(min_length=1, max_length=16_384)
+    method: str = Field(default="GET", pattern=r"^[A-Z][A-Z0-9_-]{0,31}$")
+    kind: Literal["page", "api", "form", "resource", "websocket"] = "page"
+    discovery_source: Literal[
+        "browser", "proxy", "crawl", "repeater", "intruder", "har", "automation"
+    ] = "browser"
+    status_code: int | None = Field(default=None, ge=100, le=999)
+    parameter_names: list[str] = Field(default_factory=list, max_length=256)
+    content_type: str | None = Field(default=None, max_length=500)
+    exchange_id: str | None = Field(default=None, max_length=200)
+    evidence_ids: list[str] = Field(default_factory=list, max_length=100)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class SiteEdgeRecordRequest(NebulaModel):
+    session_id: str = Field(min_length=1, max_length=200)
+    source_node_id: str = Field(min_length=1, max_length=200)
+    target_node_id: str = Field(min_length=1, max_length=200)
+    relation: Literal["navigation", "link", "form", "redirect", "request"]
+    discovered_by: Literal["browser", "crawl", "har", "automation"] = "browser"
+
+
+class CrawlCreateRequest(NebulaModel):
+    session_id: str = Field(min_length=1, max_length=200)
+    identity_id: str = Field(min_length=1, max_length=200)
+    start_url: str = Field(min_length=1, max_length=16_384)
+    max_depth: int = Field(default=2, ge=0, le=10)
+    max_requests: int = Field(default=100, ge=1, le=10_000)
+    max_concurrency: int = Field(default=2, ge=1, le=16)
+    max_duration_seconds: int = Field(default=300, ge=1, le=3_600)
+    max_body_bytes: int = Field(default=1_048_576, ge=0, le=16_777_216)
+
+
+class CrawlStateRequest(NebulaModel):
+    expected_revision: int = Field(ge=1)
+    action: Literal["queue", "start", "pause", "resume", "complete", "cancel", "fail"]
+    actor_id: str = Field(min_length=1, max_length=200)
+    requests_completed: int | None = Field(default=None, ge=0)
+    nodes_discovered: int | None = Field(default=None, ge=0)
+    checkpoint: int | None = Field(default=None, ge=0)
+    error: str | None = Field(default=None, max_length=4_000)
+
+
+class InterceptCreateRequest(NebulaModel):
+    tab_id: str = Field(min_length=1, max_length=200)
+    transaction_id: str = Field(min_length=1, max_length=300)
+    phase: Literal["request", "response"]
+    method: str = Field(pattern=r"^[A-Z][A-Z0-9_-]{0,31}$")
+    url: str = Field(min_length=1, max_length=16_384)
+    status_code: int | None = Field(default=None, ge=100, le=999)
+    headers: list[tuple[str, str]] = Field(default_factory=list, max_length=200)
+    body_artifact_id: str | None = Field(default=None, max_length=200)
+    timeout_seconds: int = Field(default=60, ge=5, le=300)
+
+
+class InterceptDecisionRequest(NebulaModel):
+    expected_revision: int = Field(ge=1)
+    decision: Literal["forward", "drop"]
+    operator_id: str = Field(min_length=1, max_length=200)
+    method: str | None = Field(default=None, pattern=r"^[A-Z][A-Z0-9_-]{0,31}$")
+    url: str | None = Field(default=None, max_length=16_384)
+    headers: list[tuple[str, str]] = Field(default_factory=list, max_length=200)
+    body_artifact_id: str | None = Field(default=None, max_length=200)
+
+
+class RepeaterTabCreateRequest(NebulaModel):
+    session_id: str = Field(min_length=1, max_length=200)
+    identity_id: str = Field(min_length=1, max_length=200)
+    name: str = Field(default="Repeater", min_length=1, max_length=200)
+    group: str = Field(default="Ungrouped", max_length=200)
+    notes: str = Field(default="", max_length=20_000)
+    protocol: Literal["http", "websocket"] = "http"
+    method: str = Field(default="GET", pattern=r"^[A-Z][A-Z0-9_-]{0,31}$")
+    url: str = Field(min_length=1, max_length=16_384)
+    headers: list[tuple[str, str]] = Field(default_factory=list, max_length=200)
+    body_artifact_id: str | None = Field(default=None, max_length=200)
+    source_exchange_id: str | None = Field(default=None, max_length=200)
+
+
+class RepeaterTabUpdateRequest(NebulaModel):
+    expected_revision: int = Field(ge=1)
+    name: str = Field(min_length=1, max_length=200)
+    group: str = Field(default="Ungrouped", max_length=200)
+    notes: str = Field(default="", max_length=20_000)
+    method: str = Field(pattern=r"^[A-Z][A-Z0-9_-]{0,31}$")
+    url: str = Field(min_length=1, max_length=16_384)
+    headers: list[tuple[str, str]] = Field(default_factory=list, max_length=200)
+    body_artifact_id: str | None = Field(default=None, max_length=200)
+
+
+class RepeaterResultRequest(NebulaModel):
+    expected_revision: int = Field(ge=1)
+    exchange_id: str = Field(min_length=1, max_length=200)
+    actor_id: str = Field(min_length=1, max_length=200)
+
+
+class AttackCreateRequest(NebulaModel):
+    session_id: str = Field(min_length=1, max_length=200)
+    identity_id: str = Field(min_length=1, max_length=200)
+    name: str = Field(default="Intruder attack", min_length=1, max_length=200)
+    strategy: Literal["sniper", "battering_ram", "pitchfork", "cluster_bomb"]
+    method: str = Field(pattern=r"^[A-Z][A-Z0-9_-]{0,31}$")
+    url_template: str = Field(min_length=1, max_length=16_384)
+    headers_template: list[tuple[str, str]] = Field(
+        default_factory=list, max_length=200
+    )
+    body_template: str = Field(default="", max_length=65_536)
+    positions: list[str] = Field(min_length=1, max_length=32)
+    payload_sets: list[dict[str, Any]] = Field(min_length=1, max_length=32)
+    transforms: list[str] = Field(default_factory=list, max_length=16)
+    max_requests: int = Field(default=100, ge=1, le=100_000)
+    max_concurrency: int = Field(default=1, ge=1, le=32)
+    requests_per_second: float = Field(default=2.0, gt=0, le=100.0)
+
+    @field_validator("transforms")
+    @classmethod
+    def transforms_are_declarative(cls, values: list[str]) -> list[str]:
+        unknown = set(values) - ALLOWED_TRANSFORMS
+        if unknown:
+            raise ValueError(f"unsupported Intruder transforms: {sorted(unknown)}")
+        return values
+
+    @model_validator(mode="after")
+    def payloads_are_inert_and_bounded(self) -> "AttackCreateRequest":
+        total = 0
+        for item in self.payload_sets:
+            kind = item.get("kind")
+            if kind == "curated":
+                if item.get("name") not in CURATED_PAYLOADS:
+                    raise ValueError("unknown curated payload set")
+                total += len(CURATED_PAYLOADS[str(item["name"])])
+            elif kind == "list":
+                values = item.get("values")
+                if not isinstance(values, list) or not values or len(values) > 10_000:
+                    raise ValueError("custom payload sets require 1-10000 inert values")
+                if not all(
+                    isinstance(value, str) and len(value) <= 16_384 for value in values
+                ):
+                    raise ValueError("custom payload values must be bounded strings")
+                total += len(values)
+            else:
+                raise ValueError("payload sets must be curated or inert lists")
+        if total > 50_000:
+            raise ValueError("combined payload sets exceed the 50000-value limit")
+        return self
+
+
+class AttackStateRequest(NebulaModel):
+    expected_revision: int = Field(ge=1)
+    action: Literal["queue", "start", "pause", "resume", "cancel", "complete", "fail"]
+    actor_id: str = Field(min_length=1, max_length=200)
+    error: str | None = Field(default=None, max_length=4_000)
+
+
+class AttackResultRequest(NebulaModel):
+    sequence: int = Field(ge=0)
+    payloads: list[str] = Field(default_factory=list, max_length=32)
+    exchange_id: str | None = Field(default=None, max_length=200)
+    status_code: int | None = Field(default=None, ge=100, le=999)
+    response_bytes: int | None = Field(default=None, ge=0)
+    duration_ms: int | None = Field(default=None, ge=0)
+    error: str | None = Field(default=None, max_length=4_000)
+    evidence_ids: list[str] = Field(default_factory=list, max_length=100)
+
+
+class DecoderRequest(NebulaModel):
+    operation: Literal[
+        "url_encode",
+        "url_decode",
+        "html_encode",
+        "html_decode",
+        "base64_encode",
+        "base64_decode",
+        "hex_encode",
+        "hex_decode",
+        "gzip_compress",
+        "gzip_decompress",
+        "jwt_inspect",
+        "sha256",
+        "sha1",
+        "md5",
+    ]
+    value: str = Field(max_length=MAX_UTILITY_INPUT)
+
+
+class CompareRequest(NebulaModel):
+    mode: Literal["text", "bytes", "json", "http"] = "text"
+    left: str = Field(max_length=MAX_UTILITY_INPUT)
+    right: str = Field(max_length=MAX_UTILITY_INPUT)
+
+
+class TokenAnalysisRequest(NebulaModel):
+    session_id: str = Field(min_length=1, max_length=200)
+    name: str = Field(default="Token analysis", min_length=1, max_length=200)
+    samples: list[str] = Field(min_length=1, max_length=100_000)
+    source_exchange_ids: list[str] = Field(default_factory=list, max_length=1_000)
+
+
+class FindingPromotionRequest(NebulaModel):
+    title: str = Field(min_length=1, max_length=500)
+    description: str = Field(default="", max_length=100_000)
+    severity: Severity = Severity.INFO
+    severity_rationale: str = Field(default="", max_length=20_000)
+    evidence_ids: list[str] = Field(min_length=1, max_length=100)
+    site_node_ids: list[str] = Field(default_factory=list, max_length=100)
+    source_exchange_ids: list[str] = Field(default_factory=list, max_length=100)
+    run_id: str | None = Field(default=None, max_length=200)
+
+
+class HarImportRequest(NebulaModel):
+    session_id: str = Field(min_length=1, max_length=200)
+    har: dict[str, Any]
+
+
+class BrowserResearchService:
+    def __init__(
+        self,
+        store: NebulaStore,
+        security: BrowserSecurityService,
+        artifact_store: ArtifactStore | None = None,
+    ) -> None:
+        self.store = store
+        self.security = security
+        self.artifact_store = artifact_store
+
+    def workspace(self, engagement_id: str) -> BrowserResearchWorkspace:
+        self.security.workspace(engagement_id)
+        return BrowserResearchWorkspace(
+            site_nodes=self.store.list_entities(
+                BrowserSiteNode, engagement_id=engagement_id, limit=1_000
+            ),
+            site_edges=self.store.list_entities(
+                BrowserSiteEdge, engagement_id=engagement_id, limit=1_000
+            ),
+            crawl_jobs=self.store.list_entities(
+                BrowserCrawlJob, engagement_id=engagement_id, limit=1_000
+            ),
+            intercepts=self.store.list_entities(
+                BrowserInterceptItem, engagement_id=engagement_id, limit=1_000
+            ),
+            repeater_tabs=self.store.list_entities(
+                BrowserRepeaterTab, engagement_id=engagement_id, limit=1_000
+            ),
+            attacks=self.store.list_entities(
+                BrowserAttack, engagement_id=engagement_id, limit=1_000
+            ),
+            attack_results=self.store.list_entities(
+                BrowserAttackResult, engagement_id=engagement_id, limit=1_000
+            ),
+            token_analyses=self.store.list_entities(
+                BrowserTokenAnalysis, engagement_id=engagement_id, limit=1_000
+            ),
+        )
+
+    def create_crawl(self, request: CrawlCreateRequest, actor_id: str) -> BrowserCrawlJob:
+        session = self.store.get(BrowserSession, request.session_id)
+        if session.identity_id != request.identity_id:
+            raise BrowserWorkflowError("crawl identity must match the selected session")
+        self.security._require_in_scope(
+            self.security._scope(session.engagement_id),
+            request.start_url,
+            "browser.crawl.create",
+            self._active_risk(),
+            native_scope_authority=True,
+        )
+        return self._create(
+            BrowserCrawlJob(engagement_id=session.engagement_id, **request.model_dump()),
+            "browser_crawl.created",
+            actor_id,
+        )
+
+    def transition_crawl(
+        self, crawl_id: str, request: CrawlStateRequest
+    ) -> BrowserCrawlJob:
+        crawl = self.store.get(BrowserCrawlJob, crawl_id)
+        transitions = {
+            "draft": {"queue": "queued", "cancel": "cancelled"},
+            "queued": {"start": "running", "cancel": "cancelled", "fail": "failed"},
+            "running": {"pause": "paused", "complete": "complete", "cancel": "cancelled", "fail": "failed"},
+            "paused": {"resume": "running", "cancel": "cancelled", "fail": "failed"},
+        }
+        next_state = transitions.get(crawl.state, {}).get(request.action)
+        if next_state is None:
+            raise BrowserWorkflowError(
+                f"cannot {request.action} a crawl in {crawl.state} state"
+            )
+        changes: dict[str, Any] = {"state": next_state, "error": request.error}
+        for field in ("requests_completed", "nodes_discovered", "checkpoint"):
+            value = getattr(request, field)
+            if value is not None:
+                changes[field] = value
+        if changes.get("requests_completed", crawl.requests_completed) > crawl.max_requests:
+            raise BrowserWorkflowError("crawl request budget is exhausted")
+        if next_state == "running" and crawl.started_at is None:
+            changes["started_at"] = utc_now()
+        if next_state in {"complete", "cancelled", "failed"}:
+            changes["completed_at"] = utc_now()
+        updated, _ = self.store.update_with_operation_event(
+            BrowserCrawlJob,
+            crawl.id,
+            changes,
+            expected_revision=request.expected_revision,
+            operation_id=crawl.id,
+            operation_kind="browser_crawl",
+            engagement_id=crawl.engagement_id,
+            event_type=f"browser_crawl.{next_state}",
+            event_payload={"checkpoint": changes.get("checkpoint", crawl.checkpoint)},
+            actor_id=request.actor_id,
+        )
+        return updated
+
+    def record_site_node(
+        self, request: SiteNodeRecordRequest, actor_id: str
+    ) -> BrowserSiteNode:
+        session = self.store.get(BrowserSession, request.session_id)
+        scope = self.security._scope(session.engagement_id)
+        self.security._require_in_scope(
+            scope, request.url, "browser.target.record", self._passive_risk()
+        )
+        normalized = self._normalized_site_url(request.url)
+        existing = next(
+            (
+                node
+                for node in self.store.list_entities(
+                    BrowserSiteNode, engagement_id=session.engagement_id, limit=1_000
+                )
+                if node.session_id == session.id
+                and node.method == request.method
+                and node.url == normalized
+            ),
+            None,
+        )
+        parameters = sorted(
+            set(request.parameter_names)
+            | {
+                name
+                for name, _ in parse_qsl(
+                    urlsplit(normalized).query, keep_blank_values=True
+                )
+            }
+        )[:256]
+        if existing is not None:
+            updated, _ = self.store.update_with_operation_event(
+                BrowserSiteNode,
+                existing.id,
+                {
+                    "status_code": request.status_code,
+                    "parameter_names": parameters,
+                    "content_type": request.content_type,
+                    "last_exchange_id": request.exchange_id,
+                    "last_seen_at": utc_now(),
+                    "evidence_ids": list(
+                        dict.fromkeys([*existing.evidence_ids, *request.evidence_ids])
+                    )[:100],
+                    "metadata": {**existing.metadata, **request.metadata},
+                },
+                expected_revision=existing.revision,
+                operation_id=existing.id,
+                operation_kind="browser_site_node",
+                engagement_id=existing.engagement_id,
+                event_type="browser_site_node.observed",
+                event_payload={"url": normalized, "source": request.discovery_source},
+                actor_id=actor_id,
+            )
+            return updated
+        node = BrowserSiteNode(
+            engagement_id=session.engagement_id,
+            session_id=session.id,
+            identity_id=session.identity_id,
+            url=normalized,
+            method=request.method,
+            kind=request.kind,
+            discovery_source=request.discovery_source,
+            status_code=request.status_code,
+            parameter_names=parameters,
+            content_type=request.content_type,
+            scope_policy_id=scope.id,
+            scope_policy_revision=scope.revision,
+            last_exchange_id=request.exchange_id,
+            evidence_ids=request.evidence_ids,
+            metadata=request.metadata,
+        )
+        return self._create(node, "browser_site_node.created", actor_id)
+
+    def record_exchange(
+        self, exchange: BrowserTrafficExchange, actor_id: str
+    ) -> BrowserSiteNode | None:
+        if exchange.scope_state != "in_scope":
+            return None
+        content_type = next(
+            (
+                value
+                for name, value in exchange.response_headers.items()
+                if name.lower() == "content-type"
+            ),
+            None,
+        )
+        kind: Literal["page", "api", "form", "resource", "websocket"] = (
+            "websocket"
+            if exchange.protocol == "websocket"
+            else (
+                "api"
+                if content_type
+                and ("json" in content_type or "graphql" in content_type)
+                else "page"
+            )
+        )
+        return self.record_site_node(
+            SiteNodeRecordRequest(
+                session_id=exchange.session_id,
+                url=exchange.url,
+                method=exchange.method,
+                kind=kind,
+                discovery_source="proxy",
+                status_code=exchange.status_code,
+                content_type=content_type,
+                exchange_id=exchange.id,
+            ),
+            actor_id,
+        )
+
+    def record_site_edge(
+        self, request: SiteEdgeRecordRequest, actor_id: str
+    ) -> BrowserSiteEdge:
+        session = self.store.get(BrowserSession, request.session_id)
+        source = self._owned(
+            BrowserSiteNode, request.source_node_id, session.engagement_id
+        )
+        target = self._owned(
+            BrowserSiteNode, request.target_node_id, session.engagement_id
+        )
+        if source.session_id != session.id or target.session_id != session.id:
+            raise BrowserWorkflowError(
+                "site-map edge endpoints must belong to the selected session"
+            )
+        existing = next(
+            (
+                edge
+                for edge in self.store.list_entities(
+                    BrowserSiteEdge, engagement_id=session.engagement_id, limit=1_000
+                )
+                if edge.session_id == session.id
+                and edge.source_node_id == source.id
+                and edge.target_node_id == target.id
+                and edge.relation == request.relation
+            ),
+            None,
+        )
+        if existing is not None:
+            return existing
+        return self._create(
+            BrowserSiteEdge(
+                engagement_id=session.engagement_id, **request.model_dump()
+            ),
+            "browser_site_edge.created",
+            actor_id,
+        )
+
+    def pause_intercept(
+        self, session_id: str, request: InterceptCreateRequest, actor_id: str
+    ) -> BrowserInterceptItem:
+        session = self.store.get(BrowserSession, session_id)
+        if not session.interception_enabled:
+            raise BrowserWorkflowError(
+                "interception must be explicitly enabled for the session"
+            )
+        if request.tab_id not in {tab.id for tab in session.tabs}:
+            raise BrowserWorkflowError(
+                "intercept tab does not belong to the browser session"
+            )
+        self.security._require_in_scope(
+            self.security._scope(session.engagement_id),
+            request.url,
+            "browser.intercept",
+            self._active_risk(),
+            native_scope_authority=True,
+        )
+        for item in self.store.list_entities(
+            BrowserInterceptItem, engagement_id=session.engagement_id, limit=1_000
+        ):
+            if item.transaction_id == request.transaction_id:
+                return item
+        item = BrowserInterceptItem(
+            engagement_id=session.engagement_id,
+            session_id=session.id,
+            identity_id=session.identity_id,
+            headers=self._redact_pairs(request.headers),
+            expires_at=utc_now() + timedelta(seconds=request.timeout_seconds),
+            **request.model_dump(exclude={"headers", "timeout_seconds"}),
+        )
+        return self._create(item, "browser_intercept.paused", actor_id)
+
+    def decide_intercept(
+        self, intercept_id: str, request: InterceptDecisionRequest
+    ) -> BrowserInterceptItem:
+        item = self.store.get(BrowserInterceptItem, intercept_id)
+        if item.state != "paused":
+            raise BrowserWorkflowError("only paused intercepts can be decided")
+        if utc_now() >= item.expires_at:
+            return self._transition_intercept(
+                item,
+                request.expected_revision,
+                "expired",
+                request.operator_id,
+                "intercept expired before decision",
+            )
+        target = request.url or item.url
+        self.security._require_in_scope(
+            self.security._scope(item.engagement_id),
+            target,
+            "browser.intercept.forward",
+            self._active_risk(),
+            native_scope_authority=True,
+        )
+        changes: dict[str, Any] = {
+            "state": "forwarded" if request.decision == "forward" else "dropped",
+            "decision": request.decision,
+            "decided_by": request.operator_id,
+            "decided_at": utc_now(),
+        }
+        if request.decision == "forward":
+            changes.update(
+                {
+                    "edited_method": request.method,
+                    "edited_url": request.url,
+                    "edited_headers": self._redact_pairs(request.headers),
+                    "edited_body_artifact_id": request.body_artifact_id,
+                }
+            )
+        updated, _ = self.store.update_with_operation_event(
+            BrowserInterceptItem,
+            item.id,
+            changes,
+            expected_revision=request.expected_revision,
+            operation_id=item.id,
+            operation_kind="browser_intercept",
+            engagement_id=item.engagement_id,
+            event_type=f"browser_intercept.{changes['state']}",
+            event_payload={"decision": request.decision},
+            actor_id=request.operator_id,
+        )
+        return updated
+
+    def interrupt_stale_intercepts(
+        self, engagement_id: str, actor_id: str = "system"
+    ) -> int:
+        changed = 0
+        for item in self.store.list_entities(
+            BrowserInterceptItem, engagement_id=engagement_id, limit=1_000
+        ):
+            if item.state == "paused" and utc_now() >= item.expires_at:
+                self._transition_intercept(
+                    item,
+                    item.revision,
+                    "interrupted",
+                    actor_id,
+                    "native transaction expired or disconnected",
+                )
+                changed += 1
+        return changed
+
+    def create_repeater_tab(
+        self, request: RepeaterTabCreateRequest, actor_id: str
+    ) -> BrowserRepeaterTab:
+        session = self.store.get(BrowserSession, request.session_id)
+        if session.identity_id != request.identity_id:
+            raise BrowserWorkflowError(
+                "Repeater identity must match the selected session"
+            )
+        self.security._require_in_scope(
+            self.security._scope(session.engagement_id),
+            request.url,
+            "browser.repeater.create",
+            self._active_risk(),
+            native_scope_authority=True,
+        )
+        if request.source_exchange_id:
+            self._owned(
+                BrowserTrafficExchange,
+                request.source_exchange_id,
+                session.engagement_id,
+            )
+        tab = BrowserRepeaterTab(
+            engagement_id=session.engagement_id,
+            headers=self._redact_pairs(request.headers),
+            **request.model_dump(exclude={"headers"}),
+        )
+        return self._create(tab, "browser_repeater_tab.created", actor_id)
+
+    def update_repeater_tab(
+        self, tab_id: str, request: RepeaterTabUpdateRequest, actor_id: str
+    ) -> BrowserRepeaterTab:
+        tab = self.store.get(BrowserRepeaterTab, tab_id)
+        self.security._require_in_scope(
+            self.security._scope(tab.engagement_id),
+            request.url,
+            "browser.repeater.edit",
+            self._active_risk(),
+            native_scope_authority=True,
+        )
+        changes = request.model_dump(exclude={"expected_revision", "headers"})
+        changes["headers"] = self._redact_pairs(request.headers)
+        updated, _ = self.store.update_with_operation_event(
+            BrowserRepeaterTab,
+            tab.id,
+            changes,
+            expected_revision=request.expected_revision,
+            operation_id=tab.id,
+            operation_kind="browser_repeater_tab",
+            engagement_id=tab.engagement_id,
+            event_type="browser_repeater_tab.updated",
+            event_payload={"url": request.url},
+            actor_id=actor_id,
+        )
+        return updated
+
+    def record_repeater_result(
+        self, tab_id: str, request: RepeaterResultRequest
+    ) -> BrowserRepeaterTab:
+        tab = self.store.get(BrowserRepeaterTab, tab_id)
+        exchange = self._owned(
+            BrowserTrafficExchange, request.exchange_id, tab.engagement_id
+        )
+        if exchange.session_id != tab.session_id:
+            raise BrowserWorkflowError(
+                "Repeater result belongs to another browser session"
+            )
+        history = list(dict.fromkeys([*tab.history_exchange_ids, exchange.id]))[-500:]
+        updated, _ = self.store.update_with_operation_event(
+            BrowserRepeaterTab,
+            tab.id,
+            {"history_exchange_ids": history},
+            expected_revision=request.expected_revision,
+            operation_id=tab.id,
+            operation_kind="browser_repeater_tab",
+            engagement_id=tab.engagement_id,
+            event_type="browser_repeater_tab.result_recorded",
+            event_payload={"exchange_id": exchange.id},
+            actor_id=request.actor_id,
+        )
+        return updated
+
+    def create_attack(
+        self, request: AttackCreateRequest, actor_id: str
+    ) -> BrowserAttack:
+        session = self.store.get(BrowserSession, request.session_id)
+        if session.identity_id != request.identity_id:
+            raise BrowserWorkflowError(
+                "attack identity must match the selected session"
+            )
+        sample_url = request.url_template
+        for position in request.positions:
+            sample_url = sample_url.replace(f"§{position}§", "sample")
+        self.security._require_in_scope(
+            self.security._scope(session.engagement_id),
+            sample_url,
+            "browser.intruder.create",
+            self._active_risk(),
+            native_scope_authority=True,
+        )
+        attack = BrowserAttack(
+            engagement_id=session.engagement_id, **request.model_dump()
+        )
+        return self._create(attack, "browser_attack.created", actor_id)
+
+    def transition_attack(
+        self, attack_id: str, request: AttackStateRequest
+    ) -> BrowserAttack:
+        attack = self.store.get(BrowserAttack, attack_id)
+        transitions = {
+            "draft": {"queue": "queued", "cancel": "cancelled"},
+            "queued": {"start": "running", "cancel": "cancelled", "fail": "failed"},
+            "running": {
+                "pause": "paused",
+                "cancel": "cancelled",
+                "complete": "complete",
+                "fail": "failed",
+            },
+            "paused": {"resume": "running", "cancel": "cancelled", "fail": "failed"},
+        }
+        next_state = transitions.get(attack.state, {}).get(request.action)
+        if next_state is None:
+            raise BrowserWorkflowError(
+                f"cannot {request.action} an attack in {attack.state} state"
+            )
+        changes: dict[str, Any] = {"state": next_state, "error": request.error}
+        if next_state == "running" and attack.started_at is None:
+            changes["started_at"] = utc_now()
+        if next_state in {"complete", "cancelled", "failed"}:
+            changes["completed_at"] = utc_now()
+        updated, _ = self.store.update_with_operation_event(
+            BrowserAttack,
+            attack.id,
+            changes,
+            expected_revision=request.expected_revision,
+            operation_id=attack.id,
+            operation_kind="browser_attack",
+            engagement_id=attack.engagement_id,
+            event_type=f"browser_attack.{next_state}",
+            event_payload={},
+            actor_id=request.actor_id,
+        )
+        return updated
+
+    def add_attack_result(
+        self, attack_id: str, request: AttackResultRequest, actor_id: str
+    ) -> BrowserAttackResult:
+        attack = self.store.get(BrowserAttack, attack_id)
+        if attack.state != "running":
+            raise BrowserWorkflowError("attack results require a running attack")
+        if attack.request_count >= attack.max_requests:
+            raise BrowserWorkflowError("attack request budget is exhausted")
+        existing = next(
+            (
+                result
+                for result in self.store.list_entities(
+                    BrowserAttackResult,
+                    engagement_id=attack.engagement_id,
+                    limit=1_000,
+                )
+                if result.attack_id == attack.id and result.sequence == request.sequence
+            ),
+            None,
+        )
+        if existing is not None:
+            return existing
+        if request.exchange_id:
+            self._owned(
+                BrowserTrafficExchange, request.exchange_id, attack.engagement_id
+            )
+        result = BrowserAttackResult(
+            engagement_id=attack.engagement_id,
+            attack_id=attack.id,
+            **request.model_dump(),
+        )
+        created = self._create(result, "browser_attack_result.created", actor_id)
+        latest = self.store.get(BrowserAttack, attack.id)
+        self.store.update_with_operation_event(
+            BrowserAttack,
+            latest.id,
+            {
+                "request_count": latest.request_count + 1,
+                "error_count": latest.error_count + (1 if request.error else 0),
+            },
+            expected_revision=latest.revision,
+            operation_id=latest.id,
+            operation_kind="browser_attack",
+            engagement_id=latest.engagement_id,
+            event_type="browser_attack.progress",
+            event_payload={"request_count": latest.request_count + 1},
+            actor_id=actor_id,
+        )
+        return created
+
+    def decode(self, request: DecoderRequest) -> dict[str, Any]:
+        value = request.value
+        operation = request.operation
+        try:
+            result: Any
+            if operation == "url_encode":
+                result = quote(value, safe="")
+            elif operation == "url_decode":
+                result = unquote(value)
+            elif operation == "html_encode":
+                result = html.escape(value, quote=True)
+            elif operation == "html_decode":
+                result = html.unescape(value)
+            elif operation == "base64_encode":
+                result = base64.b64encode(value.encode()).decode()
+            elif operation == "base64_decode":
+                result = base64.b64decode(value, validate=True).decode(
+                    "utf-8", errors="replace"
+                )
+            elif operation == "hex_encode":
+                result = value.encode().hex()
+            elif operation == "hex_decode":
+                result = bytes.fromhex(value).decode("utf-8", errors="replace")
+            elif operation == "gzip_compress":
+                result = base64.b64encode(gzip.compress(value.encode())).decode()
+            elif operation == "gzip_decompress":
+                result = gzip.decompress(base64.b64decode(value, validate=True)).decode(
+                    "utf-8", errors="replace"
+                )
+            elif operation == "jwt_inspect":
+                parts = value.split(".")
+                if len(parts) != 3:
+                    raise ValueError("JWTs require three dot-separated segments")
+                result = {
+                    "header": self._jwt_segment(parts[0]),
+                    "payload": self._jwt_segment(parts[1]),
+                    "signature_sha256": hashlib.sha256(parts[2].encode()).hexdigest(),
+                    "verified": False,
+                }
+            else:
+                result = hashlib.new(operation, value.encode()).hexdigest()
+        except (ValueError, binascii.Error, OSError) as exc:
+            raise BrowserWorkflowError(f"decoder operation failed: {exc}") from exc
+        encoded = (
+            json.dumps(result, ensure_ascii=False)
+            if not isinstance(result, str)
+            else result
+        )
+        if len(encoded.encode()) > MAX_UTILITY_INPUT:
+            raise BrowserWorkflowError("decoder output exceeds the 1 MiB limit")
+        return {
+            "operation": operation,
+            "result": result,
+            "bytes": len(encoded.encode()),
+        }
+
+    def compare(self, request: CompareRequest) -> dict[str, Any]:
+        left, right = request.left, request.right
+        if request.mode == "json":
+            try:
+                left = json.dumps(
+                    json.loads(left), indent=2, sort_keys=True, ensure_ascii=False
+                )
+                right = json.dumps(
+                    json.loads(right), indent=2, sort_keys=True, ensure_ascii=False
+                )
+            except json.JSONDecodeError as exc:
+                raise BrowserWorkflowError(
+                    "JSON comparison requires valid JSON on both sides"
+                ) from exc
+        if request.mode == "bytes":
+            try:
+                left_bytes, right_bytes = (
+                    base64.b64decode(left, validate=True),
+                    base64.b64decode(right, validate=True),
+                )
+            except binascii.Error as exc:
+                raise BrowserWorkflowError(
+                    "byte comparison expects base64 input"
+                ) from exc
+            first_difference = next(
+                (
+                    index
+                    for index, pair in enumerate(zip(left_bytes, right_bytes))
+                    if pair[0] != pair[1]
+                ),
+                min(len(left_bytes), len(right_bytes))
+                if len(left_bytes) != len(right_bytes)
+                else None,
+            )
+            return {
+                "mode": request.mode,
+                "equal": left_bytes == right_bytes,
+                "left_bytes": len(left_bytes),
+                "right_bytes": len(right_bytes),
+                "first_difference": first_difference,
+            }
+        diff = list(
+            difflib.unified_diff(
+                left.splitlines(),
+                right.splitlines(),
+                fromfile="left",
+                tofile="right",
+                lineterm="",
+            )
+        )[:10_000]
+        return {
+            "mode": request.mode,
+            "equal": left == right,
+            "similarity": difflib.SequenceMatcher(a=left, b=right).ratio(),
+            "diff": diff,
+            "truncated": len(diff) == 10_000,
+        }
+
+    def analyze_tokens(
+        self, request: TokenAnalysisRequest, actor_id: str
+    ) -> BrowserTokenAnalysis:
+        session = self.store.get(BrowserSession, request.session_id)
+        encoded_size = sum(len(sample.encode()) for sample in request.samples)
+        if encoded_size > 8 * MAX_UTILITY_INPUT:
+            raise BrowserWorkflowError("token samples exceed the 8 MiB analysis limit")
+        for exchange_id in request.source_exchange_ids:
+            self._owned(BrowserTrafficExchange, exchange_id, session.engagement_id)
+        frequencies = Counter("".join(request.samples))
+        total = sum(frequencies.values())
+        entropy = (
+            -sum(
+                (count / total) * math.log2(count / total)
+                for count in frequencies.values()
+            )
+            if total
+            else 0.0
+        )
+        unique = len(set(request.samples))
+        analysis = BrowserTokenAnalysis(
+            engagement_id=session.engagement_id,
+            session_id=session.id,
+            name=request.name,
+            sample_count=len(request.samples),
+            token_length_min=min(map(len, request.samples)),
+            token_length_max=max(map(len, request.samples)),
+            unique_count=unique,
+            collision_count=len(request.samples) - unique,
+            shannon_bits_per_character=entropy,
+            character_frequencies=dict(frequencies.most_common(256)),
+            source_exchange_ids=request.source_exchange_ids,
+            metadata={
+                "analysis_version": "browser-sequencer-v1",
+                "interpretation": "descriptive only; not a cryptographic certification",
+            },
+        )
+        return self._create(analysis, "browser_token_analysis.created", actor_id)
+
+    def promote_finding(
+        self, engagement_id: str, request: FindingPromotionRequest, actor_id: str
+    ) -> Finding:
+        for evidence_id in request.evidence_ids:
+            self._owned(Evidence, evidence_id, engagement_id)
+        for node_id in request.site_node_ids:
+            self._owned(BrowserSiteNode, node_id, engagement_id)
+        for exchange_id in request.source_exchange_ids:
+            self._owned(BrowserTrafficExchange, exchange_id, engagement_id)
+        finding = Finding(
+            engagement_id=engagement_id,
+            title=request.title,
+            description=request.description,
+            status=FindingStatus.CANDIDATE,
+            severity=request.severity,
+            severity_rationale=request.severity_rationale,
+            evidence_ids=request.evidence_ids,
+            metadata={
+                "source": "security-browser",
+                "browser_site_node_ids": request.site_node_ids,
+                "browser_exchange_ids": request.source_exchange_ids,
+                "run_id": request.run_id,
+            },
+        )
+        return self._create(finding, "browser_finding.candidate_created", actor_id)
+
+    def import_har(
+        self, engagement_id: str, request: HarImportRequest, actor_id: str
+    ) -> dict[str, Any]:
+        session = self._owned(BrowserSession, request.session_id, engagement_id)
+        entries = (
+            request.har.get("log", {}).get("entries")
+            if isinstance(request.har.get("log"), dict)
+            else None
+        )
+        if not isinstance(entries, list):
+            raise BrowserWorkflowError("HAR import requires log.entries")
+        if len(entries) > MAX_HAR_ENTRIES:
+            raise BrowserWorkflowError("HAR import exceeds the 10000-entry limit")
+        imported = 0
+        skipped = 0
+        for raw in entries:
+            try:
+                request_data = raw["request"]
+                response_data = raw.get("response", {})
+                url = str(request_data["url"])
+                method = str(request_data.get("method") or "GET").upper()
+                self.security._require_in_scope(
+                    self.security._scope(engagement_id),
+                    url,
+                    "browser.har.import",
+                    self._passive_risk(),
+                )
+                header_map = {
+                    str(item.get("name", "")): str(item.get("value", ""))
+                    for item in response_data.get("headers", [])[:200]
+                }
+                self.record_site_node(
+                    SiteNodeRecordRequest(
+                        session_id=session.id,
+                        url=url,
+                        method=method,
+                        discovery_source="har",
+                        status_code=response_data.get("status"),
+                        content_type=next(
+                            (
+                                value
+                                for name, value in header_map.items()
+                                if name.lower() == "content-type"
+                            ),
+                            None,
+                        ),
+                        metadata={"har_imported": True, "bodies_omitted": True},
+                    ),
+                    actor_id,
+                )
+                imported += 1
+            except (KeyError, TypeError, ValueError, BrowserWorkflowError):
+                skipped += 1
+        return {
+            "session_id": session.id,
+            "entries": len(entries),
+            "imported": imported,
+            "skipped": skipped,
+            "bodies_imported": 0,
+            "redaction": "headers and bodies containing reusable secrets are not imported",
+        }
+
+    def export_har(self, engagement_id: str, session_id: str) -> dict[str, Any]:
+        session = self._owned(BrowserSession, session_id, engagement_id)
+        exchanges = [
+            exchange
+            for exchange in self.store.list_entities(
+                BrowserTrafficExchange, engagement_id=engagement_id, limit=1_000
+            )
+            if exchange.session_id == session.id
+        ]
+        entries = []
+        for exchange in exchanges:
+            entries.append(
+                {
+                    "startedDateTime": exchange.started_at.isoformat(),
+                    "time": exchange.duration_ms or 0,
+                    "request": {
+                        "method": exchange.method,
+                        "url": exchange.url,
+                        "httpVersion": exchange.protocol,
+                        "headers": [
+                            {"name": name, "value": value}
+                            for name, value in exchange.request_headers.items()
+                        ],
+                        "queryString": [
+                            {"name": name, "value": value}
+                            for name, value in parse_qsl(
+                                urlsplit(exchange.url).query, keep_blank_values=True
+                            )
+                        ],
+                        "headersSize": -1,
+                        "bodySize": exchange.request_bytes
+                        if exchange.request_bytes is not None
+                        else -1,
+                    },
+                    "response": {
+                        "status": exchange.status_code or 0,
+                        "statusText": "",
+                        "httpVersion": exchange.protocol,
+                        "headers": [
+                            {"name": name, "value": value}
+                            for name, value in exchange.response_headers.items()
+                        ],
+                        "content": {
+                            "size": exchange.response_bytes or 0,
+                            "mimeType": exchange.response_headers.get(
+                                "content-type", "application/octet-stream"
+                            ),
+                            "comment": "Body omitted; see Nebula evidence artifacts when authorized.",
+                        },
+                        "redirectURL": "",
+                        "headersSize": -1,
+                        "bodySize": exchange.response_bytes
+                        if exchange.response_bytes is not None
+                        else -1,
+                    },
+                    "cache": {},
+                    "timings": {
+                        "send": 0,
+                        "wait": exchange.duration_ms or 0,
+                        "receive": 0,
+                    },
+                    "comment": f"Nebula exchange {exchange.id}; scope revision {exchange.scope_policy_revision}; redacted",
+                }
+            )
+        return {
+            "log": {
+                "version": "1.2",
+                "creator": {"name": "Nebula", "version": "3"},
+                "comment": "Redacted HAR export; reusable secrets and bodies are omitted.",
+                "entries": entries,
+            }
+        }
+
+    @staticmethod
+    def _normalized_site_url(value: str) -> str:
+        parsed = urlsplit(value)
+        return urlunsplit(
+            (
+                parsed.scheme.lower(),
+                parsed.netloc.lower(),
+                parsed.path or "/",
+                parsed.query,
+                "",
+            )
+        )
+
+    @staticmethod
+    def _redact_pairs(headers: list[tuple[str, str]]) -> list[tuple[str, str]]:
+        # Preserve order and duplicate names while redacting each reusable value.
+        return [
+            (name, redact_browser_headers({name: value})[name])
+            for name, value in headers
+        ]
+
+    @staticmethod
+    def _jwt_segment(value: str) -> Any:
+        padded = value + "=" * (-len(value) % 4)
+        return json.loads(base64.urlsafe_b64decode(padded).decode("utf-8"))
+
+    @staticmethod
+    def _passive_risk():
+        from .domain import RiskClass
+
+        return RiskClass.PASSIVE
+
+    @staticmethod
+    def _active_risk():
+        from .domain import RiskClass
+
+        return RiskClass.ACTIVE_SCAN
+
+    def _owned(self, model: type[Any], entity_id: str, engagement_id: str) -> Any:
+        entity = self.store.get(model, entity_id)
+        if getattr(entity, "engagement_id", None) != engagement_id:
+            raise BrowserWorkflowError(
+                "browser research object belongs to another Project"
+            )
+        return entity
+
+    def _create(self, entity: Any, event_type: str, actor_id: str) -> Any:
+        created, _ = self.store.create_with_operation_event(
+            entity,
+            operation_id=entity.id,
+            operation_kind=entity.entity_kind,
+            engagement_id=entity.engagement_id,
+            event_type=event_type,
+            event_payload={"entity_id": entity.id},
+            actor_id=actor_id,
+            idempotency_key=f"create:{entity.id}",
+        )
+        return created
+
+    def _transition_intercept(
+        self,
+        item: BrowserInterceptItem,
+        revision: int,
+        state: Literal["interrupted", "expired"],
+        actor_id: str,
+        error: str,
+    ) -> BrowserInterceptItem:
+        updated, _ = self.store.update_with_operation_event(
+            BrowserInterceptItem,
+            item.id,
+            {
+                "state": state,
+                "error": error,
+                "decided_at": utc_now(),
+                "decided_by": actor_id,
+            },
+            expected_revision=revision,
+            operation_id=item.id,
+            operation_kind="browser_intercept",
+            engagement_id=item.engagement_id,
+            event_type=f"browser_intercept.{state}",
+            event_payload={"error": error},
+            actor_id=actor_id,
+        )
+        return updated
+
+
+__all__ = [
+    "AttackCreateRequest",
+    "AttackResultRequest",
+    "AttackStateRequest",
+    "BrowserResearchService",
+    "BrowserResearchWorkspace",
+    "CompareRequest",
+    "DecoderRequest",
+    "FindingPromotionRequest",
+    "HarImportRequest",
+    "InterceptCreateRequest",
+    "InterceptDecisionRequest",
+    "RepeaterResultRequest",
+    "RepeaterTabCreateRequest",
+    "RepeaterTabUpdateRequest",
+    "SiteEdgeRecordRequest",
+    "SiteNodeRecordRequest",
+    "TokenAnalysisRequest",
+]

--- a/src/nebula/v3/browser_research.py
+++ b/src/nebula/v3/browser_research.py
@@ -339,7 +339,9 @@ class BrowserResearchService:
             ),
         )
 
-    def create_crawl(self, request: CrawlCreateRequest, actor_id: str) -> BrowserCrawlJob:
+    def create_crawl(
+        self, request: CrawlCreateRequest, actor_id: str
+    ) -> BrowserCrawlJob:
         session = self.store.get(BrowserSession, request.session_id)
         if session.identity_id != request.identity_id:
             raise BrowserWorkflowError("crawl identity must match the selected session")
@@ -351,7 +353,9 @@ class BrowserResearchService:
             native_scope_authority=True,
         )
         return self._create(
-            BrowserCrawlJob(engagement_id=session.engagement_id, **request.model_dump()),
+            BrowserCrawlJob(
+                engagement_id=session.engagement_id, **request.model_dump()
+            ),
             "browser_crawl.created",
             actor_id,
         )
@@ -363,7 +367,12 @@ class BrowserResearchService:
         transitions = {
             "draft": {"queue": "queued", "cancel": "cancelled"},
             "queued": {"start": "running", "cancel": "cancelled", "fail": "failed"},
-            "running": {"pause": "paused", "complete": "complete", "cancel": "cancelled", "fail": "failed"},
+            "running": {
+                "pause": "paused",
+                "complete": "complete",
+                "cancel": "cancelled",
+                "fail": "failed",
+            },
             "paused": {"resume": "running", "cancel": "cancelled", "fail": "failed"},
         }
         next_state = transitions.get(crawl.state, {}).get(request.action)
@@ -376,7 +385,10 @@ class BrowserResearchService:
             value = getattr(request, field)
             if value is not None:
                 changes[field] = value
-        if changes.get("requests_completed", crawl.requests_completed) > crawl.max_requests:
+        if (
+            changes.get("requests_completed", crawl.requests_completed)
+            > crawl.max_requests
+        ):
             raise BrowserWorkflowError("crawl request budget is exhausted")
         if next_state == "running" and crawl.started_at is None:
             changes["started_at"] = utc_now()

--- a/src/nebula/v3/browser_research.py
+++ b/src/nebula/v3/browser_research.py
@@ -1081,7 +1081,12 @@ class BrowserResearchService:
                     actor_id,
                 )
                 imported += 1
-            except (KeyError, TypeError, ValueError, BrowserWorkflowError):
+            except (
+                KeyError,
+                TypeError,
+                ValueError,
+                BrowserWorkflowError,
+            ):  # diagnostic-expected: malformed HAR entries are counted and skipped.
                 skipped += 1
         return {
             "session_id": session.id,

--- a/src/nebula/v3/browser_security.py
+++ b/src/nebula/v3/browser_security.py
@@ -704,13 +704,15 @@ class BrowserSecurityService:
             request_header_lines=[
                 (name, redact_browser_headers({name: value})[name])
                 for name, value in (
-                    request.request_header_lines or list(request.request_headers.items())
+                    request.request_header_lines
+                    or list(request.request_headers.items())
                 )
             ],
             response_header_lines=[
                 (name, redact_browser_headers({name: value})[name])
                 for name, value in (
-                    request.response_header_lines or list(request.response_headers.items())
+                    request.response_header_lines
+                    or list(request.response_headers.items())
                 )
             ],
             http2_pseudo_headers=[

--- a/src/nebula/v3/browser_security.py
+++ b/src/nebula/v3/browser_security.py
@@ -149,11 +149,22 @@ class BrowserTrafficRecordRequest(NebulaModel):
     status_code: int | None = Field(default=None, ge=100, le=999)
     request_headers: dict[str, str] = Field(default_factory=dict)
     response_headers: dict[str, str] = Field(default_factory=dict)
+    request_header_lines: list[tuple[str, str]] = Field(
+        default_factory=list, max_length=MAX_HEADERS
+    )
+    response_header_lines: list[tuple[str, str]] = Field(
+        default_factory=list, max_length=MAX_HEADERS
+    )
+    http2_pseudo_headers: list[tuple[str, str]] = Field(
+        default_factory=list, max_length=16
+    )
     request_body_artifact_id: str | None = Field(default=None, max_length=200)
     response_body_artifact_id: str | None = Field(default=None, max_length=200)
     request_bytes: int | None = Field(default=None, ge=0)
     response_bytes: int | None = Field(default=None, ge=0)
     duration_ms: int | None = Field(default=None, ge=0)
+    timing: dict[str, int] = Field(default_factory=dict)
+    rule_effect_ids: list[str] = Field(default_factory=list, max_length=200)
     replay_of_exchange_id: str | None = Field(default=None, max_length=200)
     error: str | None = Field(default=None, max_length=4_000)
     blocked: bool = False
@@ -170,6 +181,28 @@ class BrowserTrafficRecordRequest(NebulaModel):
             for name, item in value.items()
         ):
             raise ValueError("browser traffic header name or value is too large")
+        return value
+
+    @field_validator(
+        "request_header_lines", "response_header_lines", "http2_pseudo_headers"
+    )
+    @classmethod
+    def ordered_headers_are_bounded(
+        cls, value: list[tuple[str, str]]
+    ) -> list[tuple[str, str]]:
+        if any(
+            len(name) > MAX_HEADER_NAME or len(item) > MAX_HEADER_VALUE
+            for name, item in value
+        ):
+            raise ValueError("browser traffic header name or value is too large")
+        return value
+
+    @field_validator("timing")
+    @classmethod
+    def timing_is_bounded(cls, value: dict[str, int]) -> dict[str, int]:
+        allowed = {"dns_ms", "connect_ms", "tls_ms", "send_ms", "wait_ms", "receive_ms"}
+        if set(value) - allowed or any(item < 0 for item in value.values()):
+            raise ValueError("browser traffic timing contains an invalid phase")
         return value
 
 
@@ -668,11 +701,43 @@ class BrowserSecurityService:
             scope_policy_revision=scope.revision,
             request_headers=redact_browser_headers(request.request_headers),
             response_headers=redact_browser_headers(request.response_headers),
+            request_header_lines=[
+                (name, redact_browser_headers({name: value})[name])
+                for name, value in (
+                    request.request_header_lines or list(request.request_headers.items())
+                )
+            ],
+            response_header_lines=[
+                (name, redact_browser_headers({name: value})[name])
+                for name, value in (
+                    request.response_header_lines or list(request.response_headers.items())
+                )
+            ],
+            http2_pseudo_headers=[
+                (name, redact_browser_headers({name: value})[name])
+                for name, value in request.http2_pseudo_headers
+            ],
             **request.model_dump(
-                exclude={"tab_id", "request_headers", "response_headers"}
+                exclude={
+                    "tab_id",
+                    "request_headers",
+                    "response_headers",
+                    "request_header_lines",
+                    "response_header_lines",
+                    "http2_pseudo_headers",
+                }
             ),
         )
-        return self._create(exchange, "browser_traffic.recorded", actor_id)
+        created = self._create(exchange, "browser_traffic.recorded", actor_id)
+        # Keep Target authoritative without making the native worker duplicate
+        # site-map writes. A blocked/out-of-scope exchange remains traffic
+        # evidence but is deliberately excluded from the in-scope map.
+        from .browser_research import BrowserResearchService
+
+        BrowserResearchService(self.store, self, self.artifact_store).record_exchange(
+            created, actor_id
+        )
+        return created
 
     def record_websocket_frame(
         self,
@@ -1017,7 +1082,13 @@ class BrowserSecurityService:
         return scope
 
     def _require_in_scope(
-        self, scope: ScopePolicy, target: str, action: str, risk: RiskClass
+        self,
+        scope: ScopePolicy,
+        target: str,
+        action: str,
+        risk: RiskClass,
+        *,
+        native_scope_authority: bool = False,
     ) -> None:
         decision = self.policy.evaluate(
             scope,
@@ -1026,6 +1097,7 @@ class BrowserSecurityService:
                 risk_class=risk,
                 target=target,
                 action=action,
+                native_scope_authority=native_scope_authority,
             ),
         )
         if decision.effect == PolicyEffect.DENY:

--- a/src/nebula/v3/browser_tools.py
+++ b/src/nebula/v3/browser_tools.py
@@ -569,6 +569,7 @@ class BrowserAutomationBroker(ToolBroker):
             )
         running = await self.ledger.transition(call, ToolCallStatus.RUNNING)
         evidence_ids: list[str] = []
+        output: dict[str, Any]
         try:
             lease = self.automation.active_lease_for_run(invocation.run_id)
             lease_id = lease.id

--- a/src/nebula/v3/browser_tools.py
+++ b/src/nebula/v3/browser_tools.py
@@ -18,6 +18,17 @@ from .browser_automation import (
     BrowserCommandCreateRequest,
     BrowserProxyRuleRequest,
 )
+from .browser_research import (
+    AttackCreateRequest,
+    AttackStateRequest,
+    BrowserResearchService,
+    CompareRequest,
+    CrawlCreateRequest,
+    DecoderRequest,
+    FindingPromotionRequest,
+    RepeaterTabCreateRequest,
+    TokenAnalysisRequest,
+)
 from .domain import (
     Approval,
     BrowserActionKind,
@@ -316,8 +327,16 @@ def autonomous_browser_specs() -> dict[str, ToolSpec]:
                     "max_depth": {"type": "integer", "minimum": 0, "maximum": 10},
                     "max_requests": {"type": "integer", "minimum": 1, "maximum": 10000},
                     "max_concurrency": {"type": "integer", "minimum": 1, "maximum": 16},
-                    "max_duration_seconds": {"type": "integer", "minimum": 1, "maximum": 3600},
-                    "max_body_bytes": {"type": "integer", "minimum": 0, "maximum": 16777216},
+                    "max_duration_seconds": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 3600,
+                    },
+                    "max_body_bytes": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 16777216,
+                    },
                 },
                 "required": ["start_url"],
             },
@@ -328,7 +347,8 @@ def autonomous_browser_specs() -> dict[str, ToolSpec]:
             "repeater.create",
             "Create a durable Repeater tab without copying identity secrets.",
             {
-                "type": "object", "additionalProperties": False,
+                "type": "object",
+                "additionalProperties": False,
                 "properties": {
                     "name": {"type": "string", "minLength": 1, "maxLength": 200},
                     "method": {"type": "string", "pattern": "^[A-Za-z]{1,16}$"},
@@ -344,17 +364,51 @@ def autonomous_browser_specs() -> dict[str, ToolSpec]:
             "intruder.create",
             "Create a bounded Intruder draft using inert payload values.",
             {
-                "type": "object", "additionalProperties": False,
+                "type": "object",
+                "additionalProperties": False,
                 "properties": {
                     "name": {"type": "string", "minLength": 1, "maxLength": 200},
-                    "strategy": {"type": "string", "enum": ["sniper", "battering_ram", "pitchfork", "cluster_bomb"]},
+                    "strategy": {
+                        "type": "string",
+                        "enum": [
+                            "sniper",
+                            "battering_ram",
+                            "pitchfork",
+                            "cluster_bomb",
+                        ],
+                    },
                     "method": {"type": "string", "pattern": "^[A-Za-z]{1,16}$"},
-                    "url_template": {"type": "string", "minLength": 1, "maxLength": 16384},
-                    "positions": {"type": "array", "minItems": 1, "maxItems": 32, "items": {"type": "string", "maxLength": 200}},
-                    "payload_values": {"type": "array", "minItems": 1, "maxItems": 10000, "items": {"type": "string", "maxLength": 4000}},
-                    "max_requests": {"type": "integer", "minimum": 1, "maximum": 100000},
+                    "url_template": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 16384,
+                    },
+                    "positions": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 32,
+                        "items": {"type": "string", "maxLength": 200},
+                    },
+                    "payload_values": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 10000,
+                        "items": {"type": "string", "maxLength": 4000},
+                    },
+                    "max_requests": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100000,
+                    },
                 },
-                "required": ["name", "strategy", "method", "url_template", "positions", "payload_values"],
+                "required": [
+                    "name",
+                    "strategy",
+                    "method",
+                    "url_template",
+                    "positions",
+                    "payload_values",
+                ],
             },
             risk=RiskClass.ACTIVE_SCAN,
         ),
@@ -362,44 +416,108 @@ def autonomous_browser_specs() -> dict[str, ToolSpec]:
             "intruder.control",
             "Queue, pause, resume, cancel, or complete a lease-session attack.",
             {
-                "type": "object", "additionalProperties": False,
+                "type": "object",
+                "additionalProperties": False,
                 "properties": {
                     "attack_id": {"type": "string", "minLength": 1, "maxLength": 200},
                     "expected_revision": {"type": "integer", "minimum": 1},
-                    "action": {"type": "string", "enum": ["queue", "start", "pause", "resume", "cancel", "complete"]},
+                    "action": {
+                        "type": "string",
+                        "enum": [
+                            "queue",
+                            "start",
+                            "pause",
+                            "resume",
+                            "cancel",
+                            "complete",
+                        ],
+                    },
                 },
                 "required": ["attack_id", "expected_revision", "action"],
             },
             risk=RiskClass.ACTIVE_SCAN,
         ),
         "analysis.decode": spec(
-            "analysis.decode", "Apply one deterministic Decoder transformation.",
-            {"type": "object", "additionalProperties": False, "properties": {"operation": {"type": "string"}, "value": {"type": "string", "maxLength": 1048576}}, "required": ["operation", "value"]},
+            "analysis.decode",
+            "Apply one deterministic Decoder transformation.",
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "operation": {"type": "string"},
+                    "value": {"type": "string", "maxLength": 1048576},
+                },
+                "required": ["operation", "value"],
+            },
             risk=RiskClass.PASSIVE,
         ),
         "analysis.compare": spec(
-            "analysis.compare", "Compare bounded text, JSON, bytes, or HTTP messages.",
-            {"type": "object", "additionalProperties": False, "properties": {"mode": {"type": "string", "enum": ["text", "json", "bytes", "http"]}, "left": {"type": "string", "maxLength": 1048576}, "right": {"type": "string", "maxLength": 1048576}}, "required": ["mode", "left", "right"]},
+            "analysis.compare",
+            "Compare bounded text, JSON, bytes, or HTTP messages.",
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "mode": {
+                        "type": "string",
+                        "enum": ["text", "json", "bytes", "http"],
+                    },
+                    "left": {"type": "string", "maxLength": 1048576},
+                    "right": {"type": "string", "maxLength": 1048576},
+                },
+                "required": ["mode", "left", "right"],
+            },
             risk=RiskClass.PASSIVE,
         ),
         "analysis.tokens": spec(
-            "analysis.tokens", "Persist a descriptive Sequencer-style token analysis.",
-            {"type": "object", "additionalProperties": False, "properties": {"name": {"type": "string", "minLength": 1, "maxLength": 200}, "samples": {"type": "array", "minItems": 1, "maxItems": 100000, "items": {"type": "string", "maxLength": 10000}}}, "required": ["name", "samples"]},
+            "analysis.tokens",
+            "Persist a descriptive Sequencer-style token analysis.",
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "name": {"type": "string", "minLength": 1, "maxLength": 200},
+                    "samples": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 100000,
+                        "items": {"type": "string", "maxLength": 10000},
+                    },
+                },
+                "required": ["name", "samples"],
+            },
             risk=RiskClass.PASSIVE,
         ),
         "finding.propose": spec(
             "finding.propose",
             "Create an evidence-linked candidate finding; confirmation remains operator-owned.",
             {
-                "type": "object", "additionalProperties": False,
+                "type": "object",
+                "additionalProperties": False,
                 "properties": {
                     "title": {"type": "string", "minLength": 1, "maxLength": 500},
                     "description": {"type": "string", "maxLength": 100000},
-                    "severity": {"type": "string", "enum": ["info", "low", "medium", "high", "critical"]},
+                    "severity": {
+                        "type": "string",
+                        "enum": ["info", "low", "medium", "high", "critical"],
+                    },
                     "severity_rationale": {"type": "string", "maxLength": 20000},
-                    "evidence_ids": {"type": "array", "minItems": 1, "maxItems": 100, "items": {"type": "string", "maxLength": 200}},
-                    "site_node_ids": {"type": "array", "maxItems": 100, "items": {"type": "string", "maxLength": 200}},
-                    "source_exchange_ids": {"type": "array", "maxItems": 100, "items": {"type": "string", "maxLength": 200}},
+                    "evidence_ids": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 100,
+                        "items": {"type": "string", "maxLength": 200},
+                    },
+                    "site_node_ids": {
+                        "type": "array",
+                        "maxItems": 100,
+                        "items": {"type": "string", "maxLength": 200},
+                    },
+                    "source_exchange_ids": {
+                        "type": "array",
+                        "maxItems": 100,
+                        "items": {"type": "string", "maxLength": 200},
+                    },
                 },
                 "required": ["title", "evidence_ids"],
             },
@@ -454,19 +572,9 @@ class BrowserAutomationBroker(ToolBroker):
         try:
             lease = self.automation.active_lease_for_run(invocation.run_id)
             lease_id = lease.id
-            if invocation.tool_name.startswith(("target.", "repeater.", "intruder.", "analysis.", "finding.")):
-                from .browser_research import (
-                    AttackCreateRequest,
-                    AttackStateRequest,
-                    BrowserResearchService,
-                    CompareRequest,
-                    CrawlCreateRequest,
-                    DecoderRequest,
-                    FindingPromotionRequest,
-                    RepeaterTabCreateRequest,
-                    TokenAnalysisRequest,
-                )
-
+            if invocation.tool_name.startswith(
+                ("target.", "repeater.", "intruder.", "analysis.", "finding.")
+            ):
                 research = BrowserResearchService(
                     self.store, BrowserSecurityService(self.store)
                 )
@@ -520,7 +628,10 @@ class BrowserAutomationBroker(ToolBroker):
                         ),
                         invocation.requested_by,
                     )
-                    output = {"status": "draft", "attack": attack.model_dump(mode="json")}
+                    output = {
+                        "status": "draft",
+                        "attack": attack.model_dump(mode="json"),
+                    }
                 elif invocation.tool_name == "intruder.control":
                     attack_id = str(arguments.pop("attack_id"))
                     current_attack = self.store.get(BrowserAttack, attack_id)
@@ -534,19 +645,23 @@ class BrowserAutomationBroker(ToolBroker):
                             actor_id=invocation.requested_by, **arguments
                         ),
                     )
-                    output = {"status": attack.state, "attack": attack.model_dump(mode="json")}
+                    output = {
+                        "status": attack.state,
+                        "attack": attack.model_dump(mode="json"),
+                    }
                 elif invocation.tool_name == "analysis.decode":
                     output = research.decode(DecoderRequest.model_validate(arguments))
                 elif invocation.tool_name == "analysis.compare":
                     output = research.compare(CompareRequest.model_validate(arguments))
                 elif invocation.tool_name == "analysis.tokens":
                     analysis = research.analyze_tokens(
-                        TokenAnalysisRequest(
-                            session_id=session.id, **arguments
-                        ),
+                        TokenAnalysisRequest(session_id=session.id, **arguments),
                         invocation.requested_by,
                     )
-                    output = {"status": "complete", "analysis": analysis.model_dump(mode="json")}
+                    output = {
+                        "status": "complete",
+                        "analysis": analysis.model_dump(mode="json"),
+                    }
                 else:
                     finding = research.promote_finding(
                         lease.engagement_id,

--- a/src/nebula/v3/browser_tools.py
+++ b/src/nebula/v3/browser_tools.py
@@ -21,6 +21,7 @@ from .browser_automation import (
 from .domain import (
     Approval,
     BrowserActionKind,
+    BrowserAttack,
     BrowserCaptureMode,
     BrowserCommandStatus,
     BrowserSession,
@@ -298,6 +299,112 @@ def autonomous_browser_specs() -> dict[str, ToolSpec]:
             },
             risk=RiskClass.ACTIVE_SCAN,
         ),
+        "target.observe": spec(
+            "target.observe",
+            "Read the durable in-scope site map, crawl progress, and evidence links for this lease session.",
+            {"type": "object", "additionalProperties": False, "properties": {}},
+            risk=RiskClass.PASSIVE,
+        ),
+        "target.crawl": spec(
+            "target.crawl",
+            "Create a bounded in-scope crawl draft for native execution.",
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "start_url": {"type": "string", "minLength": 1, "maxLength": 16384},
+                    "max_depth": {"type": "integer", "minimum": 0, "maximum": 10},
+                    "max_requests": {"type": "integer", "minimum": 1, "maximum": 10000},
+                    "max_concurrency": {"type": "integer", "minimum": 1, "maximum": 16},
+                    "max_duration_seconds": {"type": "integer", "minimum": 1, "maximum": 3600},
+                    "max_body_bytes": {"type": "integer", "minimum": 0, "maximum": 16777216},
+                },
+                "required": ["start_url"],
+            },
+            risk=RiskClass.ACTIVE_SCAN,
+            target="start_url",
+        ),
+        "repeater.create": spec(
+            "repeater.create",
+            "Create a durable Repeater tab without copying identity secrets.",
+            {
+                "type": "object", "additionalProperties": False,
+                "properties": {
+                    "name": {"type": "string", "minLength": 1, "maxLength": 200},
+                    "method": {"type": "string", "pattern": "^[A-Za-z]{1,16}$"},
+                    "url": {"type": "string", "minLength": 1, "maxLength": 16384},
+                    "notes": {"type": "string", "maxLength": 20000},
+                },
+                "required": ["name", "method", "url"],
+            },
+            risk=RiskClass.ACTIVE_SCAN,
+            target="url",
+        ),
+        "intruder.create": spec(
+            "intruder.create",
+            "Create a bounded Intruder draft using inert payload values.",
+            {
+                "type": "object", "additionalProperties": False,
+                "properties": {
+                    "name": {"type": "string", "minLength": 1, "maxLength": 200},
+                    "strategy": {"type": "string", "enum": ["sniper", "battering_ram", "pitchfork", "cluster_bomb"]},
+                    "method": {"type": "string", "pattern": "^[A-Za-z]{1,16}$"},
+                    "url_template": {"type": "string", "minLength": 1, "maxLength": 16384},
+                    "positions": {"type": "array", "minItems": 1, "maxItems": 32, "items": {"type": "string", "maxLength": 200}},
+                    "payload_values": {"type": "array", "minItems": 1, "maxItems": 10000, "items": {"type": "string", "maxLength": 4000}},
+                    "max_requests": {"type": "integer", "minimum": 1, "maximum": 100000},
+                },
+                "required": ["name", "strategy", "method", "url_template", "positions", "payload_values"],
+            },
+            risk=RiskClass.ACTIVE_SCAN,
+        ),
+        "intruder.control": spec(
+            "intruder.control",
+            "Queue, pause, resume, cancel, or complete a lease-session attack.",
+            {
+                "type": "object", "additionalProperties": False,
+                "properties": {
+                    "attack_id": {"type": "string", "minLength": 1, "maxLength": 200},
+                    "expected_revision": {"type": "integer", "minimum": 1},
+                    "action": {"type": "string", "enum": ["queue", "start", "pause", "resume", "cancel", "complete"]},
+                },
+                "required": ["attack_id", "expected_revision", "action"],
+            },
+            risk=RiskClass.ACTIVE_SCAN,
+        ),
+        "analysis.decode": spec(
+            "analysis.decode", "Apply one deterministic Decoder transformation.",
+            {"type": "object", "additionalProperties": False, "properties": {"operation": {"type": "string"}, "value": {"type": "string", "maxLength": 1048576}}, "required": ["operation", "value"]},
+            risk=RiskClass.PASSIVE,
+        ),
+        "analysis.compare": spec(
+            "analysis.compare", "Compare bounded text, JSON, bytes, or HTTP messages.",
+            {"type": "object", "additionalProperties": False, "properties": {"mode": {"type": "string", "enum": ["text", "json", "bytes", "http"]}, "left": {"type": "string", "maxLength": 1048576}, "right": {"type": "string", "maxLength": 1048576}}, "required": ["mode", "left", "right"]},
+            risk=RiskClass.PASSIVE,
+        ),
+        "analysis.tokens": spec(
+            "analysis.tokens", "Persist a descriptive Sequencer-style token analysis.",
+            {"type": "object", "additionalProperties": False, "properties": {"name": {"type": "string", "minLength": 1, "maxLength": 200}, "samples": {"type": "array", "minItems": 1, "maxItems": 100000, "items": {"type": "string", "maxLength": 10000}}}, "required": ["name", "samples"]},
+            risk=RiskClass.PASSIVE,
+        ),
+        "finding.propose": spec(
+            "finding.propose",
+            "Create an evidence-linked candidate finding; confirmation remains operator-owned.",
+            {
+                "type": "object", "additionalProperties": False,
+                "properties": {
+                    "title": {"type": "string", "minLength": 1, "maxLength": 500},
+                    "description": {"type": "string", "maxLength": 100000},
+                    "severity": {"type": "string", "enum": ["info", "low", "medium", "high", "critical"]},
+                    "severity_rationale": {"type": "string", "maxLength": 20000},
+                    "evidence_ids": {"type": "array", "minItems": 1, "maxItems": 100, "items": {"type": "string", "maxLength": 200}},
+                    "site_node_ids": {"type": "array", "maxItems": 100, "items": {"type": "string", "maxLength": 200}},
+                    "source_exchange_ids": {"type": "array", "maxItems": 100, "items": {"type": "string", "maxLength": 200}},
+                },
+                "required": ["title", "evidence_ids"],
+            },
+            risk=RiskClass.PASSIVE,
+        ),
     }
 
 
@@ -347,7 +454,110 @@ class BrowserAutomationBroker(ToolBroker):
         try:
             lease = self.automation.active_lease_for_run(invocation.run_id)
             lease_id = lease.id
-            if invocation.tool_name == "proxy.observe":
+            if invocation.tool_name.startswith(("target.", "repeater.", "intruder.", "analysis.", "finding.")):
+                from .browser_research import (
+                    AttackCreateRequest,
+                    AttackStateRequest,
+                    BrowserResearchService,
+                    CompareRequest,
+                    CrawlCreateRequest,
+                    DecoderRequest,
+                    FindingPromotionRequest,
+                    RepeaterTabCreateRequest,
+                    TokenAnalysisRequest,
+                )
+
+                research = BrowserResearchService(
+                    self.store, BrowserSecurityService(self.store)
+                )
+                session = self.store.get(BrowserSession, lease.session_id)
+                arguments = dict(invocation.arguments)
+                if invocation.tool_name == "target.observe":
+                    workspace = research.workspace(lease.engagement_id)
+                    output = {
+                        "status": "complete",
+                        "site_nodes": [
+                            item.model_dump(mode="json")
+                            for item in workspace.site_nodes
+                            if item.session_id == lease.session_id
+                        ][:500],
+                        "crawl_jobs": [
+                            item.model_dump(mode="json")
+                            for item in workspace.crawl_jobs
+                            if item.session_id == lease.session_id
+                        ][:100],
+                    }
+                elif invocation.tool_name == "target.crawl":
+                    crawl = research.create_crawl(
+                        CrawlCreateRequest(
+                            session_id=session.id,
+                            identity_id=session.identity_id,
+                            **arguments,
+                        ),
+                        invocation.requested_by,
+                    )
+                    output = {"status": "draft", "crawl": crawl.model_dump(mode="json")}
+                elif invocation.tool_name == "repeater.create":
+                    arguments["method"] = str(arguments["method"]).upper()
+                    tab = research.create_repeater_tab(
+                        RepeaterTabCreateRequest(
+                            session_id=session.id,
+                            identity_id=session.identity_id,
+                            **arguments,
+                        ),
+                        invocation.requested_by,
+                    )
+                    output = {"status": "complete", "tab": tab.model_dump(mode="json")}
+                elif invocation.tool_name == "intruder.create":
+                    values = arguments.pop("payload_values")
+                    arguments["method"] = str(arguments["method"]).upper()
+                    attack = research.create_attack(
+                        AttackCreateRequest(
+                            session_id=session.id,
+                            identity_id=session.identity_id,
+                            payload_sets=[{"kind": "list", "values": values}],
+                            **arguments,
+                        ),
+                        invocation.requested_by,
+                    )
+                    output = {"status": "draft", "attack": attack.model_dump(mode="json")}
+                elif invocation.tool_name == "intruder.control":
+                    attack_id = str(arguments.pop("attack_id"))
+                    current_attack = self.store.get(BrowserAttack, attack_id)
+                    if current_attack.session_id != session.id:
+                        raise InvalidToolArguments(
+                            "attack belongs to another browser lease session"
+                        )
+                    attack = research.transition_attack(
+                        attack_id,
+                        AttackStateRequest(
+                            actor_id=invocation.requested_by, **arguments
+                        ),
+                    )
+                    output = {"status": attack.state, "attack": attack.model_dump(mode="json")}
+                elif invocation.tool_name == "analysis.decode":
+                    output = research.decode(DecoderRequest.model_validate(arguments))
+                elif invocation.tool_name == "analysis.compare":
+                    output = research.compare(CompareRequest.model_validate(arguments))
+                elif invocation.tool_name == "analysis.tokens":
+                    analysis = research.analyze_tokens(
+                        TokenAnalysisRequest(
+                            session_id=session.id, **arguments
+                        ),
+                        invocation.requested_by,
+                    )
+                    output = {"status": "complete", "analysis": analysis.model_dump(mode="json")}
+                else:
+                    finding = research.promote_finding(
+                        lease.engagement_id,
+                        FindingPromotionRequest(run_id=lease.run_id, **arguments),
+                        invocation.requested_by,
+                    )
+                    output = {
+                        "status": "candidate",
+                        "finding": finding.model_dump(mode="json"),
+                    }
+            elif invocation.tool_name == "proxy.observe":
                 session = self.store.get(BrowserSession, lease.session_id)
                 status = self.automation.status(
                     lease.engagement_id, run_id=lease.run_id
@@ -513,6 +723,20 @@ class BrowserAutomationToolPlatform:
     ) -> None:
         self.store = store
         self.automation = automation
+
+    def runtime_components(self, engagement_id: str) -> RuntimeToolComponents:
+        """Return the backend-neutral tool surface used by harness gateways."""
+
+        engagement = self.store.get(Engagement, engagement_id)
+        scope = self.store.get(ScopePolicy, engagement.scope_policy_id or "")
+        specs = autonomous_browser_specs()
+        return RuntimeToolComponents(
+            broker=BrowserAutomationBroker(self.store, self.automation),
+            scope=scope,
+            workspace=Path(engagement.workspace_path or ".").resolve(),
+            specs=specs,
+            runtime_digest="browser-investigation-v2",
+        )
 
     def mission_components(
         self, run: Any, provider: ModelProvider

--- a/src/nebula/v3/domain.py
+++ b/src/nebula/v3/domain.py
@@ -932,11 +932,24 @@ class BrowserTrafficExchange(Entity):
     status_code: int | None = Field(default=None, ge=100, le=999)
     request_headers: dict[str, str] = Field(default_factory=dict)
     response_headers: dict[str, str] = Field(default_factory=dict)
+    # Ordered lines preserve duplicate headers for protocol-aware replay while
+    # the maps above remain the backwards-compatible summary representation.
+    request_header_lines: list[tuple[str, str]] = Field(
+        default_factory=list, max_length=200
+    )
+    response_header_lines: list[tuple[str, str]] = Field(
+        default_factory=list, max_length=200
+    )
+    http2_pseudo_headers: list[tuple[str, str]] = Field(
+        default_factory=list, max_length=16
+    )
     request_body_artifact_id: str | None = Field(default=None, max_length=200)
     response_body_artifact_id: str | None = Field(default=None, max_length=200)
     request_bytes: int | None = Field(default=None, ge=0)
     response_bytes: int | None = Field(default=None, ge=0)
     duration_ms: int | None = Field(default=None, ge=0)
+    timing: dict[str, int] = Field(default_factory=dict)
+    rule_effect_ids: list[str] = Field(default_factory=list, max_length=200)
     scope_state: Literal["in_scope", "out_of_scope", "inactive", "unconfigured"]
     scope_policy_id: str = Field(min_length=1, max_length=200)
     scope_policy_revision: int = Field(ge=1)
@@ -1208,6 +1221,224 @@ class BrowserProxyRule(Entity):
         if self.expires_at <= self.created_at:
             raise ValueError("browser proxy rule expiry must follow creation")
         return self
+
+
+class BrowserSiteNode(Entity):
+    """One normalized target-map location discovered by browser research."""
+
+    entity_kind: ClassVar[str] = "browser_site_nodes"
+    engagement_id: str
+    session_id: str = Field(min_length=1, max_length=200)
+    identity_id: str = Field(min_length=1, max_length=200)
+    url: str = Field(min_length=1, max_length=16_384)
+    method: str = Field(default="GET", pattern=r"^[A-Z][A-Z0-9_-]{0,31}$")
+    kind: Literal["page", "api", "form", "resource", "websocket"] = "page"
+    discovery_source: Literal[
+        "browser", "proxy", "crawl", "repeater", "intruder", "har", "automation"
+    ] = "proxy"
+    status_code: int | None = Field(default=None, ge=100, le=999)
+    parameter_names: list[str] = Field(default_factory=list, max_length=256)
+    content_type: str | None = Field(default=None, max_length=500)
+    scope_policy_id: str = Field(min_length=1, max_length=200)
+    scope_policy_revision: int = Field(ge=1)
+    last_exchange_id: str | None = Field(default=None, max_length=200)
+    evidence_ids: list[str] = Field(default_factory=list, max_length=100)
+    first_seen_at: datetime = Field(default_factory=utc_now)
+    last_seen_at: datetime = Field(default_factory=utc_now)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("url")
+    @classmethod
+    def browser_site_url_is_network_only(cls, value: str) -> str:
+        parsed = urlsplit(value)
+        if (
+            parsed.scheme.lower() not in {"http", "https", "ws", "wss"}
+            or not parsed.hostname
+        ):
+            raise ValueError("browser site-map URLs must use HTTP(S) or WebSocket")
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("browser site-map URLs cannot contain credentials")
+        return value
+
+
+class BrowserSiteEdge(Entity):
+    entity_kind: ClassVar[str] = "browser_site_edges"
+    engagement_id: str
+    session_id: str = Field(min_length=1, max_length=200)
+    source_node_id: str = Field(min_length=1, max_length=200)
+    target_node_id: str = Field(min_length=1, max_length=200)
+    relation: Literal["navigation", "link", "form", "redirect", "request"]
+    discovered_by: Literal["browser", "crawl", "har", "automation"] = "browser"
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class BrowserCrawlJob(Entity):
+    """Bounded crawl intent and acknowledged native-worker progress."""
+
+    entity_kind: ClassVar[str] = "browser_crawl_jobs"
+    engagement_id: str
+    session_id: str = Field(min_length=1, max_length=200)
+    identity_id: str = Field(min_length=1, max_length=200)
+    start_url: str = Field(min_length=1, max_length=16_384)
+    state: Literal[
+        "draft", "queued", "running", "paused", "complete", "cancelled", "failed"
+    ] = "draft"
+    max_depth: int = Field(default=2, ge=0, le=10)
+    max_requests: int = Field(default=100, ge=1, le=10_000)
+    max_concurrency: int = Field(default=2, ge=1, le=16)
+    max_duration_seconds: int = Field(default=300, ge=1, le=3_600)
+    max_body_bytes: int = Field(default=1_048_576, ge=0, le=16_777_216)
+    requests_completed: int = Field(default=0, ge=0)
+    nodes_discovered: int = Field(default=0, ge=0)
+    checkpoint: int = Field(default=0, ge=0)
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    error: str | None = Field(default=None, max_length=4_000)
+
+    @field_validator("start_url")
+    @classmethod
+    def browser_crawl_url_is_network_only(cls, value: str) -> str:
+        parsed = urlsplit(value)
+        if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+            raise ValueError("crawl URLs must use HTTP(S)")
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("crawl URLs cannot contain credentials")
+        return value
+
+    @field_validator("started_at", "completed_at")
+    @classmethod
+    def browser_crawl_time_is_aware(cls, value: datetime | None) -> datetime | None:
+        if value is not None and (value.tzinfo is None or value.utcoffset() is None):
+            raise ValueError("browser crawl timestamps must include a timezone")
+        return value.astimezone(timezone.utc) if value is not None else None
+
+
+class BrowserInterceptItem(Entity):
+    """Durable receipt for a native request/response paused at a breakpoint."""
+
+    entity_kind: ClassVar[str] = "browser_intercepts"
+    engagement_id: str
+    session_id: str = Field(min_length=1, max_length=200)
+    tab_id: str = Field(min_length=1, max_length=200)
+    identity_id: str = Field(min_length=1, max_length=200)
+    transaction_id: str = Field(min_length=1, max_length=300)
+    phase: Literal["request", "response"]
+    method: str = Field(pattern=r"^[A-Z][A-Z0-9_-]{0,31}$")
+    url: str = Field(min_length=1, max_length=16_384)
+    status_code: int | None = Field(default=None, ge=100, le=999)
+    headers: list[tuple[str, str]] = Field(default_factory=list, max_length=200)
+    body_artifact_id: str | None = Field(default=None, max_length=200)
+    state: Literal["paused", "forwarded", "dropped", "interrupted", "expired"] = (
+        "paused"
+    )
+    decision: Literal["forward", "drop"] | None = None
+    decided_by: str | None = Field(default=None, max_length=200)
+    decided_at: datetime | None = None
+    expires_at: datetime
+    edited_method: str | None = Field(default=None, pattern=r"^[A-Z][A-Z0-9_-]{0,31}$")
+    edited_url: str | None = Field(default=None, max_length=16_384)
+    edited_headers: list[tuple[str, str]] = Field(default_factory=list, max_length=200)
+    edited_body_artifact_id: str | None = Field(default=None, max_length=200)
+    error: str | None = Field(default=None, max_length=4_000)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("expires_at", "decided_at")
+    @classmethod
+    def browser_intercept_time_is_aware(cls, value: datetime | None) -> datetime | None:
+        if value is not None and (value.tzinfo is None or value.utcoffset() is None):
+            raise ValueError("browser intercept timestamps must include a timezone")
+        return value.astimezone(timezone.utc) if value is not None else None
+
+
+class BrowserRepeaterTab(Entity):
+    entity_kind: ClassVar[str] = "browser_repeater_tabs"
+    engagement_id: str
+    session_id: str = Field(min_length=1, max_length=200)
+    identity_id: str = Field(min_length=1, max_length=200)
+    name: str = Field(min_length=1, max_length=200)
+    group: str = Field(default="Ungrouped", max_length=200)
+    notes: str = Field(default="", max_length=20_000)
+    protocol: Literal["http", "websocket"] = "http"
+    method: str = Field(default="GET", pattern=r"^[A-Z][A-Z0-9_-]{0,31}$")
+    url: str = Field(min_length=1, max_length=16_384)
+    headers: list[tuple[str, str]] = Field(default_factory=list, max_length=200)
+    body_artifact_id: str | None = Field(default=None, max_length=200)
+    source_exchange_id: str | None = Field(default=None, max_length=200)
+    history_exchange_ids: list[str] = Field(default_factory=list, max_length=500)
+    evidence_ids: list[str] = Field(default_factory=list, max_length=100)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class BrowserAttack(Entity):
+    """Durable, resumable Intruder-style attack definition and progress."""
+
+    entity_kind: ClassVar[str] = "browser_attacks"
+    engagement_id: str
+    session_id: str = Field(min_length=1, max_length=200)
+    identity_id: str = Field(min_length=1, max_length=200)
+    name: str = Field(min_length=1, max_length=200)
+    strategy: Literal["sniper", "battering_ram", "pitchfork", "cluster_bomb"]
+    method: str = Field(pattern=r"^[A-Z][A-Z0-9_-]{0,31}$")
+    url_template: str = Field(min_length=1, max_length=16_384)
+    headers_template: list[tuple[str, str]] = Field(
+        default_factory=list, max_length=200
+    )
+    body_template: str = Field(default="", max_length=65_536)
+    positions: list[str] = Field(min_length=1, max_length=32)
+    payload_sets: list[dict[str, Any]] = Field(min_length=1, max_length=32)
+    transforms: list[str] = Field(default_factory=list, max_length=16)
+    state: Literal[
+        "draft", "queued", "running", "paused", "complete", "cancelled", "failed"
+    ] = "draft"
+    max_requests: int = Field(default=100, ge=1, le=100_000)
+    max_concurrency: int = Field(default=1, ge=1, le=32)
+    requests_per_second: float = Field(default=2.0, gt=0, le=100.0)
+    request_count: int = Field(default=0, ge=0)
+    error_count: int = Field(default=0, ge=0)
+    baseline_exchange_id: str | None = Field(default=None, max_length=200)
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    error: str | None = Field(default=None, max_length=4_000)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("started_at", "completed_at")
+    @classmethod
+    def browser_attack_time_is_aware(cls, value: datetime | None) -> datetime | None:
+        if value is not None and (value.tzinfo is None or value.utcoffset() is None):
+            raise ValueError("browser attack timestamps must include a timezone")
+        return value.astimezone(timezone.utc) if value is not None else None
+
+
+class BrowserAttackResult(Entity):
+    entity_kind: ClassVar[str] = "browser_attack_results"
+    engagement_id: str
+    attack_id: str = Field(min_length=1, max_length=200)
+    sequence: int = Field(ge=0)
+    payloads: list[str] = Field(default_factory=list, max_length=32)
+    exchange_id: str | None = Field(default=None, max_length=200)
+    status_code: int | None = Field(default=None, ge=100, le=999)
+    response_bytes: int | None = Field(default=None, ge=0)
+    duration_ms: int | None = Field(default=None, ge=0)
+    error: str | None = Field(default=None, max_length=4_000)
+    evidence_ids: list[str] = Field(default_factory=list, max_length=100)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class BrowserTokenAnalysis(Entity):
+    entity_kind: ClassVar[str] = "browser_token_analyses"
+    engagement_id: str
+    session_id: str = Field(min_length=1, max_length=200)
+    name: str = Field(min_length=1, max_length=200)
+    sample_count: int = Field(ge=1, le=100_000)
+    token_length_min: int = Field(ge=0)
+    token_length_max: int = Field(ge=0)
+    unique_count: int = Field(ge=0)
+    collision_count: int = Field(ge=0)
+    shannon_bits_per_character: float = Field(ge=0)
+    character_frequencies: dict[str, int] = Field(default_factory=dict)
+    source_exchange_ids: list[str] = Field(default_factory=list, max_length=1_000)
+    evidence_ids: list[str] = Field(default_factory=list, max_length=100)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 class BrowserHandoff(Entity):
@@ -2912,6 +3143,14 @@ ENTITY_MODELS: tuple[type[Entity], ...] = (
     BrowserAutomationLease,
     BrowserCommand,
     BrowserProxyRule,
+    BrowserCrawlJob,
+    BrowserSiteNode,
+    BrowserSiteEdge,
+    BrowserInterceptItem,
+    BrowserRepeaterTab,
+    BrowserAttack,
+    BrowserAttackResult,
+    BrowserTokenAnalysis,
     BrowserHandoff,
     SoftwareComponent,
     Observation,

--- a/src/nebula/v3/harnesses.py
+++ b/src/nebula/v3/harnesses.py
@@ -99,7 +99,7 @@ from .domain import (
     utc_now,
 )
 from .model_pricing import CATALOG_VERIFIED_ON, codex_model_pricing
-from .browser_tools import AUTONOMOUS_BROWSER_TOOLS
+from .browser_tools import AUTONOMOUS_BROWSER_TOOLS, combine_tool_components
 from .redaction import redact_text, sanitize_display_text
 from .storage import NebulaStore, NotFoundError
 from .mcp import (
@@ -5293,8 +5293,6 @@ class HarnessRuntimeService:
                 if components is None:
                     components = browser_components
                 else:
-                    from .browser_tools import combine_tool_components
-
                     components = combine_tool_components(components, browser_components)
         except AutomationRuntimeUnavailable as exc:
             if snapshot is None:

--- a/src/nebula/v3/harnesses.py
+++ b/src/nebula/v3/harnesses.py
@@ -99,6 +99,7 @@ from .domain import (
     utc_now,
 )
 from .model_pricing import CATALOG_VERIFIED_ON, codex_model_pricing
+from .browser_tools import AUTONOMOUS_BROWSER_TOOLS
 from .redaction import redact_text, sanitize_display_text
 from .storage import NebulaStore, NotFoundError
 from .mcp import (
@@ -124,6 +125,8 @@ from .tools import (
 
 if TYPE_CHECKING:
     from .automation_tools import AutomationToolComponents, AutomationToolPlatform
+    from .browser_automation import BrowserAutonomyRequestModel
+    from .browser_tools import BrowserAutomationToolPlatform
     from .runtime_platform import RuntimePlatform, RuntimeToolComponents
 
 MAX_NORMALIZED_TEXT = 200_000
@@ -4807,6 +4810,7 @@ class HarnessRuntimeService:
         artifact_store: ArtifactStore | None = None,
         tool_platform: RuntimePlatform | None = None,
         automation_tool_platform: AutomationToolPlatform | None = None,
+        browser_automation_platform: BrowserAutomationToolPlatform | None = None,
         knowledge_retriever: KnowledgeRetriever | None = None,
         adapter_factory: AdapterFactory | None = None,
         shutdown_timeout_seconds: float = 5.0,
@@ -4825,6 +4829,7 @@ class HarnessRuntimeService:
         self.evidence_recorder = StoreToolEvidenceRecorder(store, self.artifact_store)
         self.tool_platform = tool_platform
         self.automation_tool_platform = automation_tool_platform
+        self.browser_automation_platform = browser_automation_platform
         self.knowledge_retriever = knowledge_retriever
         if tool_platform is not None and tool_platform.store is not store:
             raise ValueError("tool platform must use the harness runtime store")
@@ -4885,6 +4890,22 @@ class HarnessRuntimeService:
                 "harness runtime is already bound to an automation platform"
             )
         self.automation_tool_platform = platform
+
+    def bind_browser_automation_platform(
+        self, platform: BrowserAutomationToolPlatform
+    ) -> None:
+        if platform.store is not self.store:
+            raise ValueError(
+                "browser automation platform must use the harness runtime store"
+            )
+        if (
+            self.browser_automation_platform is not None
+            and self.browser_automation_platform is not platform
+        ):
+            raise ValueError(
+                "harness runtime is already bound to a browser automation platform"
+            )
+        self.browser_automation_platform = platform
 
     @staticmethod
     def _default_adapter(kind: HarnessKind) -> HarnessAdapter:
@@ -5231,11 +5252,15 @@ class HarnessRuntimeService:
         engagement_id: str,
         model: str,
         snapshot: dict[str, Any] | None = None,
+        include_browser: bool = False,
     ) -> tuple[
         RuntimeToolComponents | AutomationToolComponents | None,
         dict[str, Any] | None,
     ]:
-        if self.automation_tool_platform is None:
+        include_browser = include_browser or bool(
+            snapshot and snapshot.get("browser_runtime_enabled") is True
+        )
+        if self.automation_tool_platform is None and not include_browser:
             return None, None
         if snapshot is not None:
             if snapshot.get("schema") != "nebula.harness-command-runtime/v1":
@@ -5250,9 +5275,27 @@ class HarnessRuntimeService:
                     "harness command-runtime snapshot has invalid tool names"
                 )
         try:
-            components = self.automation_tool_platform.chat_components(
-                engagement_id=engagement_id,
+            components = (
+                self.automation_tool_platform.chat_components(
+                    engagement_id=engagement_id,
+                )
+                if self.automation_tool_platform is not None
+                else None
             )
+            if include_browser:
+                if self.browser_automation_platform is None:
+                    raise HarnessConfigurationError(
+                        "browser automation runtime is unavailable"
+                    )
+                browser_components = (
+                    self.browser_automation_platform.runtime_components(engagement_id)
+                )
+                if components is None:
+                    components = browser_components
+                else:
+                    from .browser_tools import combine_tool_components
+
+                    components = combine_tool_components(components, browser_components)
         except AutomationRuntimeUnavailable as exc:
             if snapshot is None:
                 return None, None
@@ -5267,6 +5310,8 @@ class HarnessRuntimeService:
                 "could not resolve the harness command runtime: " + _safe_error(exc)
             ) from exc
         resolved = self._oci_snapshot(components)
+        if include_browser:
+            resolved["browser_runtime_enabled"] = True
         if snapshot is not None and resolved != snapshot:
             raise HarnessConfigurationError(
                 "the immutable harness command-runtime snapshot no longer matches"
@@ -5287,6 +5332,7 @@ class HarnessRuntimeService:
             engagement_id=session.engagement_id,
             model=session.model,
             snapshot=snapshot,
+            include_browser=session.metadata.get("browser_runtime_enabled") is True,
         )
         if components is None:
             return None
@@ -6420,6 +6466,7 @@ class HarnessRuntimeService:
         mcp_server_ids: list[str] | None = None,
         actor_id: str = "system",
         allow_remote_mcp: bool = False,
+        browser_autonomy: BrowserAutonomyRequestModel | None = None,
     ) -> AgentRun:
         profile = self.store.get(HarnessProfile, profile_id)
         if harness_session_id:
@@ -6448,6 +6495,13 @@ class HarnessRuntimeService:
                 raise HarnessConfigurationError(
                     "MCP selection is frozen for an existing harness session"
                 )
+            if (
+                browser_autonomy is not None
+                and session.metadata.get("browser_runtime_enabled") is not True
+            ):
+                raise HarnessConfigurationError(
+                    "browser investigations require a new dedicated harness session"
+                )
         else:
             self._validate_harness_privacy(
                 engagement_id,
@@ -6463,11 +6517,28 @@ class HarnessRuntimeService:
                 reasoning_effort=reasoning_effort,
                 service_tier=service_tier,
             )
+            if browser_autonomy is not None:
+                session = self.store.update(
+                    HarnessSession,
+                    session.id,
+                    {
+                        "metadata": {
+                            **session.metadata,
+                            "browser_runtime_enabled": True,
+                            "command_runtime_enabled": True,
+                        }
+                    },
+                    expected_revision=session.revision,
+                )
         forked_from_session_id: str | None = None
         if self.session_activity(session.id).busy:
             forked_from_session_id = session.id
             session = self._fork_session(session, reason="parallel mission requested")
         oci_components = self._ensure_oci_components(session)
+        # _ensure_oci_components persists the first immutable browser gateway
+        # snapshot. Reload so this run freezes that authoritative value rather
+        # than the pre-gateway session metadata held by the caller.
+        session = self.store.get(HarnessSession, session.id)
         oci_snapshot = session.metadata.get("command_runtime_snapshot")
         if not isinstance(oci_snapshot, dict) and oci_components is not None:
             oci_snapshot = self._oci_snapshot(oci_components)
@@ -6540,6 +6611,14 @@ class HarnessRuntimeService:
                 **({"series_id": series_id} if series_id else {}),
                 "total_tasks": len(stage_prompts),
                 "completed_tasks": 0,
+                **(
+                    {
+                        "browser_autonomy": browser_autonomy.model_dump(mode="json"),
+                        "tool_names": list(AUTONOMOUS_BROWSER_TOOLS),
+                    }
+                    if browser_autonomy is not None
+                    else {}
+                ),
             },
         )
         turns = [
@@ -6577,6 +6656,36 @@ class HarnessRuntimeService:
             transaction.add(run)
             for turn in turns:
                 transaction.add(turn)
+        if browser_autonomy is not None:
+            if self.browser_automation_platform is None:
+                latest = self.store.get(AgentRun, run.id)
+                self.store.update(
+                    AgentRun,
+                    latest.id,
+                    {"status": RunStatus.FAILED, "completed_at": utc_now()},
+                    expected_revision=latest.revision,
+                )
+                raise HarnessConfigurationError(
+                    "browser automation runtime is unavailable"
+                )
+            try:
+                self.browser_automation_platform.automation.create_lease(
+                    run.id,
+                    engagement_id,
+                    browser_autonomy,
+                    actor_id,
+                )
+            except Exception as exc:
+                latest = self.store.get(AgentRun, run.id)
+                self.store.update(
+                    AgentRun,
+                    latest.id,
+                    {"status": RunStatus.FAILED, "completed_at": utc_now()},
+                    expected_revision=latest.revision,
+                )
+                raise HarnessConfigurationError(
+                    f"browser automation lease could not be created: {_safe_error(exc)}"
+                ) from exc
         for chat in self._attached_chats(session.id):
             self._append_chat_handoff(
                 chat,

--- a/src/nebula/v3/harnesses.py
+++ b/src/nebula/v3/harnesses.py
@@ -5275,7 +5275,7 @@ class HarnessRuntimeService:
                     "harness command-runtime snapshot has invalid tool names"
                 )
         try:
-            components = (
+            components: RuntimeToolComponents | AutomationToolComponents | None = (
                 self.automation_tool_platform.chat_components(
                     engagement_id=engagement_id,
                 )
@@ -5307,6 +5307,8 @@ class HarnessRuntimeService:
             raise HarnessConfigurationError(
                 "could not resolve the harness command runtime: " + _safe_error(exc)
             ) from exc
+        if components is None:
+            raise HarnessConfigurationError("harness command runtime is unavailable")
         resolved = self._oci_snapshot(components)
         if include_browser:
             resolved["browser_runtime_enabled"] = True

--- a/tests/v3/test_browser_automation.py
+++ b/tests/v3/test_browser_automation.py
@@ -1,3 +1,6 @@
+import asyncio
+from pathlib import Path
+
 import pytest
 
 from nebula.v3.browser_automation import (
@@ -9,8 +12,10 @@ from nebula.v3.browser_automation import (
     BrowserCommandResultRequest,
     BrowserProxyRuleRequest,
 )
+from nebula.v3.browser_tools import BrowserAutomationBroker, autonomous_browser_specs
 from nebula.v3.domain import AgentRun, BrowserCommandStatus, Engagement, ScopePolicy
 from nebula.v3.storage import NebulaStore
+from nebula.v3.tools import ToolInvocation
 
 
 def _project(store: NebulaStore) -> tuple[Engagement, str]:
@@ -92,6 +97,73 @@ def test_browser_automation_lease_claim_and_finish_are_durable(tmp_path):
     )
     assert finished.status == BrowserCommandStatus.COMPLETE
     assert service.status(project.id, run.id).commands[0].result["page"] == "untrusted"
+
+
+def test_browser_runtime_exposes_backend_neutral_research_tools(tmp_path):
+    async def scenario() -> None:
+        store = NebulaStore(tmp_path / "nebula.db")
+        project, scope_id = _project(store)
+        run = _run(store, project)
+        service = BrowserAutomationService(store)
+        from nebula.v3.domain import BrowserCrawlJob, BrowserIdentity, BrowserSession
+
+        identity = store.create(
+            BrowserIdentity(engagement_id=project.id, name="Test identity")
+        )
+        session = store.create(
+            BrowserSession(
+                engagement_id=project.id,
+                name="Test session",
+                identity_id=identity.id,
+                device_owner="desktop-1",
+            )
+        )
+        service.create_lease(
+            run.id,
+            project.id,
+            BrowserAutonomyRequestModel(
+                session_id=session.id,
+                targets=["https://app.example.test/"],
+            ),
+            "operator",
+        )
+        broker = BrowserAutomationBroker(store, service)
+        scope = store.get(ScopePolicy, scope_id)
+        assert {"target.crawl", "repeater.create", "intruder.create", "analysis.tokens"} <= set(
+            autonomous_browser_specs()
+        )
+
+        result = await broker.execute(
+            ToolInvocation(
+                engagement_id=project.id,
+                run_id=run.id,
+                tool_name="target.crawl",
+                arguments={
+                    "start_url": "https://app.example.test/docs",
+                    "max_requests": 10,
+                },
+                workspace=Path(tmp_path),
+                idempotency_key="crawl-1",
+            ),
+            scope,
+        )
+        assert result.output["status"] == "draft"
+        assert store.count(BrowserCrawlJob) == 1
+
+        decoded = await broker.execute(
+            ToolInvocation(
+                engagement_id=project.id,
+                run_id=run.id,
+                tool_name="analysis.decode",
+                arguments={"operation": "url_decode", "value": "a%2Fb"},
+                workspace=Path(tmp_path),
+                idempotency_key="decode-1",
+            ),
+            scope,
+        )
+        assert decoded.output["result"] == "a/b"
+
+    asyncio.run(scenario())
 
 
 def test_browser_automation_rejects_scope_expansion_and_secret_values(tmp_path):

--- a/tests/v3/test_browser_automation.py
+++ b/tests/v3/test_browser_automation.py
@@ -129,9 +129,12 @@ def test_browser_runtime_exposes_backend_neutral_research_tools(tmp_path):
         )
         broker = BrowserAutomationBroker(store, service)
         scope = store.get(ScopePolicy, scope_id)
-        assert {"target.crawl", "repeater.create", "intruder.create", "analysis.tokens"} <= set(
-            autonomous_browser_specs()
-        )
+        assert {
+            "target.crawl",
+            "repeater.create",
+            "intruder.create",
+            "analysis.tokens",
+        } <= set(autonomous_browser_specs())
 
         result = await broker.execute(
             ToolInvocation(

--- a/tests/v3/test_browser_research.py
+++ b/tests/v3/test_browser_research.py
@@ -1,0 +1,414 @@
+import base64
+
+from fastapi.testclient import TestClient
+
+from nebula.v3.api import create_app
+from nebula.v3.artifacts import ArtifactStore
+from nebula.v3.domain import (
+    BrowserAttack,
+    BrowserAttackResult,
+    BrowserCrawlJob,
+    BrowserInterceptItem,
+    BrowserRepeaterTab,
+    BrowserSiteNode,
+    BrowserTokenAnalysis,
+    Engagement,
+    Evidence,
+    Finding,
+    ScopePolicy,
+)
+from nebula.v3.storage import NebulaStore
+
+
+def _auth() -> dict[str, str]:
+    return {"Authorization": "Bearer test-token"}
+
+
+def _setup(tmp_path):
+    store = NebulaStore(tmp_path / "nebula.db")
+    client = TestClient(
+        create_app(
+            store,
+            artifact_store=ArtifactStore(tmp_path / "artifacts"),
+            auth_token="test-token",
+        )
+    )
+    created = client.post(
+        "/api/v1/engagements", headers=_auth(), json={"name": "Burp parity lab"}
+    )
+    assert created.status_code == 201, created.text
+    project = store.get(Engagement, created.json()["id"])
+    scope = store.get(ScopePolicy, project.scope_policy_id)
+    store.update(
+        ScopePolicy,
+        scope.id,
+        {
+            "allowed_domains": ["app.example.test"],
+            "allowed_ports": [443],
+        },
+        expected_revision=scope.revision,
+    )
+    workspace = client.get(
+        f"/api/v1/engagements/{project.id}/browser-workspace", headers=_auth()
+    ).json()
+    identity = workspace["identities"][0]
+    session = workspace["sessions"][0]
+    synced = client.put(
+        f"/api/v1/browser-sessions/{session['id']}/tabs",
+        headers=_auth(),
+        json={
+            "expected_revision": session["revision"],
+            "tabs": [
+                {
+                    "id": "tab-1",
+                    "url": "https://app.example.test/",
+                    "title": "App",
+                    "position": 0,
+                    "last_scope_state": "in_scope",
+                    "last_scope_revision": 2,
+                }
+            ],
+            "active_tab_id": "tab-1",
+            "device_owner": "desktop-1",
+        },
+    )
+    assert synced.status_code == 200, synced.text
+    return store, client, project, identity, synced.json()
+
+
+def test_proxy_capture_populates_durable_target_map_without_secrets(tmp_path):
+    store, client, project, _, session = _setup(tmp_path)
+    capture = client.post(
+        f"/api/v1/browser-sessions/{session['id']}/traffic",
+        headers=_auth(),
+        json={
+            "tab_id": "tab-1",
+            "method": "GET",
+            "url": "https://app.example.test/api/users?page=1",
+            "protocol": "h2",
+            "status_code": 200,
+            "request_headers": {"Authorization": "Bearer secret"},
+            "response_headers": {"Content-Type": "application/json"},
+            "request_header_lines": [
+                ["X-Trace", "first"],
+                ["X-Trace", "second"],
+                ["Cookie", "session=secret"],
+            ],
+            "http2_pseudo_headers": [[":method", "GET"], [":path", "/api/users?page=1"]],
+            "timing": {"connect_ms": 4, "wait_ms": 8},
+            "rule_effect_ids": ["rule-1"],
+        },
+    )
+    assert capture.status_code == 201, capture.text
+    assert capture.json()["request_header_lines"][:2] == [
+        ["X-Trace", "first"],
+        ["X-Trace", "second"],
+    ]
+    assert capture.json()["request_header_lines"][2][1].startswith("<redacted:sha256:")
+    assert capture.json()["http2_pseudo_headers"][1] == [
+        ":path",
+        "/api/users?page=1",
+    ]
+
+    research = client.get(
+        f"/api/v1/engagements/{project.id}/browser-research", headers=_auth()
+    )
+    assert research.status_code == 200, research.text
+    node = research.json()["site_nodes"][0]
+    assert node["kind"] == "api"
+    assert node["parameter_names"] == ["page"]
+    assert node["last_exchange_id"] == capture.json()["id"]
+    assert "secret" not in research.text
+    assert store.count(BrowserSiteNode) == 1
+
+
+def test_interception_requires_opt_in_and_is_single_decision(tmp_path):
+    store, client, _, _, session = _setup(tmp_path)
+    disabled = client.post(
+        f"/api/v1/browser-sessions/{session['id']}/intercepts",
+        headers=_auth(),
+        json={
+            "tab_id": "tab-1",
+            "transaction_id": "tx-1",
+            "phase": "request",
+            "method": "POST",
+            "url": "https://app.example.test/profile",
+            "headers": [["Authorization", "Bearer secret"]],
+        },
+    )
+    assert disabled.status_code == 422
+
+    enabled = client.put(
+        f"/api/v1/browser-sessions/{session['id']}/capture-settings",
+        headers=_auth(),
+        json={
+            "expected_revision": session["revision"],
+            "capture_mode": "headers",
+            "proxy_enabled": True,
+            "trust_acknowledged": True,
+            "interception_enabled": True,
+            "upstream_proxy_enabled": False,
+        },
+    )
+    assert enabled.status_code == 200, enabled.text
+    paused = client.post(
+        f"/api/v1/browser-sessions/{session['id']}/intercepts",
+        headers=_auth(),
+        json={
+            "tab_id": "tab-1",
+            "transaction_id": "tx-1",
+            "phase": "request",
+            "method": "POST",
+            "url": "https://app.example.test/profile",
+            "headers": [["Authorization", "Bearer secret"], ["X-Test", "one"]],
+        },
+    )
+    assert paused.status_code == 201, paused.text
+    assert paused.json()["headers"][0][1].startswith("<redacted:sha256:")
+    assert "Bearer secret" not in paused.text
+
+    forwarded = client.post(
+        f"/api/v1/browser-intercepts/{paused.json()['id']}/decision",
+        headers=_auth(),
+        json={
+            "expected_revision": paused.json()["revision"],
+            "decision": "forward",
+            "operator_id": "operator-1",
+            "headers": [["X-Test", "two"]],
+        },
+    )
+    assert forwarded.status_code == 200, forwarded.text
+    assert forwarded.json()["state"] == "forwarded"
+    repeated = client.post(
+        f"/api/v1/browser-intercepts/{paused.json()['id']}/decision",
+        headers=_auth(),
+        json={
+            "expected_revision": forwarded.json()["revision"],
+            "decision": "drop",
+            "operator_id": "operator-1",
+        },
+    )
+    assert repeated.status_code == 422
+    assert store.count(BrowserInterceptItem) == 1
+
+
+def test_bounded_crawl_lifecycle_enforces_scope_and_request_budget(tmp_path):
+    store, client, project, identity, session = _setup(tmp_path)
+    created = client.post(
+        f"/api/v1/engagements/{project.id}/browser-crawls",
+        headers=_auth(),
+        json={
+            "session_id": session["id"],
+            "identity_id": identity["id"],
+            "start_url": "https://app.example.test/docs",
+            "max_depth": 2,
+            "max_requests": 3,
+            "max_concurrency": 1,
+            "max_duration_seconds": 30,
+            "max_body_bytes": 4096,
+        },
+    )
+    assert created.status_code == 201, created.text
+    crawl = created.json()
+    assert crawl["state"] == "draft"
+    assert store.count(BrowserCrawlJob) == 1
+
+    for action, expected in (("queue", "queued"), ("start", "running")):
+        response = client.post(
+            f"/api/v1/browser-crawls/{crawl['id']}/state",
+            headers=_auth(),
+            json={
+                "expected_revision": crawl["revision"],
+                "action": action,
+                "actor_id": "operator",
+            },
+        )
+        assert response.status_code == 200, response.text
+        crawl = response.json()
+        assert crawl["state"] == expected
+
+    exhausted = client.post(
+        f"/api/v1/browser-crawls/{crawl['id']}/state",
+        headers=_auth(),
+        json={
+            "expected_revision": crawl["revision"],
+            "action": "complete",
+            "actor_id": "native-browser",
+            "requests_completed": 4,
+            "checkpoint": 4,
+        },
+    )
+    assert exhausted.status_code == 422
+
+    outside = client.post(
+        f"/api/v1/engagements/{project.id}/browser-crawls",
+        headers=_auth(),
+        json={
+            "session_id": session["id"],
+            "identity_id": identity["id"],
+            "start_url": "https://outside.example.invalid/",
+        },
+    )
+    assert outside.status_code == 422
+
+
+def test_repeater_and_intruder_lifecycles_are_durable_and_budgeted(tmp_path):
+    store, client, project, identity, session = _setup(tmp_path)
+    repeater = client.post(
+        f"/api/v1/engagements/{project.id}/browser-repeater-tabs",
+        headers=_auth(),
+        json={
+            "session_id": session["id"],
+            "identity_id": identity["id"],
+            "name": "Authorization check",
+            "method": "GET",
+            "url": "https://app.example.test/api/profile",
+            "headers": [["Accept", "application/json"]],
+        },
+    )
+    assert repeater.status_code == 201, repeater.text
+    assert store.count(BrowserRepeaterTab) == 1
+
+    attack = client.post(
+        f"/api/v1/engagements/{project.id}/browser-attacks",
+        headers=_auth(),
+        json={
+            "session_id": session["id"],
+            "identity_id": identity["id"],
+            "name": "Identifier boundaries",
+            "strategy": "sniper",
+            "method": "GET",
+            "url_template": "https://app.example.test/api/users/§id§",
+            "positions": ["id"],
+            "payload_sets": [{"kind": "curated", "name": "boundary_numbers"}],
+            "transforms": ["url_encode"],
+            "max_requests": 2,
+        },
+    )
+    assert attack.status_code == 201, attack.text
+    current = attack.json()
+    for action in ("queue", "start", "pause", "resume"):
+        moved = client.post(
+            f"/api/v1/browser-attacks/{current['id']}/state",
+            headers=_auth(),
+            json={
+                "expected_revision": current["revision"],
+                "action": action,
+                "actor_id": "operator-1",
+            },
+        )
+        assert moved.status_code == 200, moved.text
+        current = moved.json()
+    assert current["state"] == "running"
+    for sequence in range(2):
+        result = client.post(
+            f"/api/v1/browser-attacks/{current['id']}/results",
+            headers=_auth(),
+            json={"sequence": sequence, "payloads": [str(sequence)], "status_code": 200},
+        )
+        assert result.status_code == 201, result.text
+    exhausted = client.post(
+        f"/api/v1/browser-attacks/{current['id']}/results",
+        headers=_auth(),
+        json={"sequence": 2, "payloads": ["2"], "status_code": 200},
+    )
+    assert exhausted.status_code == 422
+    assert store.count(BrowserAttack) == 1
+    assert store.count(BrowserAttackResult) == 2
+
+
+def test_decoder_comparer_sequencer_har_and_finding_promotion(tmp_path):
+    store, client, project, _, session = _setup(tmp_path)
+    encoded = client.post(
+        "/api/v1/browser-utilities/decode",
+        headers=_auth(),
+        json={"operation": "base64_encode", "value": "nebula"},
+    )
+    assert encoded.status_code == 200
+    assert encoded.json()["result"] == base64.b64encode(b"nebula").decode()
+    compared = client.post(
+        "/api/v1/browser-utilities/compare",
+        headers=_auth(),
+        json={"mode": "json", "left": '{"b":2,"a":1}', "right": '{"a":1,"b":3}'},
+    )
+    assert compared.status_code == 200
+    assert compared.json()["equal"] is False
+    assert compared.json()["diff"]
+
+    sequencer = client.post(
+        f"/api/v1/engagements/{project.id}/browser-token-analyses",
+        headers=_auth(),
+        json={
+            "session_id": session["id"],
+            "name": "Session tokens",
+            "samples": ["abc1", "abc2", "abc2"],
+        },
+    )
+    assert sequencer.status_code == 201, sequencer.text
+    assert sequencer.json()["collision_count"] == 1
+    assert store.count(BrowserTokenAnalysis) == 1
+
+    imported = client.post(
+        f"/api/v1/engagements/{project.id}/browser-har/import",
+        headers=_auth(),
+        json={
+            "session_id": session["id"],
+            "har": {
+                "log": {
+                    "entries": [
+                        {
+                            "request": {
+                                "method": "GET",
+                                "url": "https://app.example.test/har",
+                                "headers": [{"name": "Cookie", "value": "secret"}],
+                            },
+                            "response": {
+                                "status": 200,
+                                "headers": [{"name": "Content-Type", "value": "text/html"}],
+                            },
+                        }
+                    ]
+                }
+            },
+        },
+    )
+    assert imported.status_code == 200, imported.text
+    assert imported.json() == {
+        "session_id": session["id"],
+        "entries": 1,
+        "imported": 1,
+        "skipped": 0,
+        "bodies_imported": 0,
+        "redaction": "headers and bodies containing reusable secrets are not imported",
+    }
+    exported = client.get(
+        f"/api/v1/engagements/{project.id}/browser-har/export",
+        headers=_auth(),
+        params={"session_id": session["id"]},
+    )
+    assert exported.status_code == 200
+    assert '"value":"secret"' not in exported.text
+
+    evidence = store.create(
+        Evidence(
+            engagement_id=project.id,
+            evidence_type="browser-response",
+            title="Authorization variance",
+            sha256="a" * 64,
+        )
+    )
+    node = store.list_entities(BrowserSiteNode, engagement_id=project.id, limit=100)[0]
+    finding = client.post(
+        f"/api/v1/engagements/{project.id}/browser-findings",
+        headers=_auth(),
+        json={
+            "title": "Possible authorization variance",
+            "severity": "medium",
+            "evidence_ids": [evidence.id],
+            "site_node_ids": [node.id],
+        },
+    )
+    assert finding.status_code == 201, finding.text
+    assert finding.json()["status"] == "candidate"
+    assert finding.json()["metadata"]["browser_site_node_ids"] == [node.id]
+    assert store.count(Finding) == 1

--- a/tests/v3/test_browser_research.py
+++ b/tests/v3/test_browser_research.py
@@ -94,7 +94,10 @@ def test_proxy_capture_populates_durable_target_map_without_secrets(tmp_path):
                 ["X-Trace", "second"],
                 ["Cookie", "session=secret"],
             ],
-            "http2_pseudo_headers": [[":method", "GET"], [":path", "/api/users?page=1"]],
+            "http2_pseudo_headers": [
+                [":method", "GET"],
+                [":path", "/api/users?page=1"],
+            ],
             "timing": {"connect_ms": 4, "wait_ms": 8},
             "rule_effect_ids": ["rule-1"],
         },
@@ -304,7 +307,11 @@ def test_repeater_and_intruder_lifecycles_are_durable_and_budgeted(tmp_path):
         result = client.post(
             f"/api/v1/browser-attacks/{current['id']}/results",
             headers=_auth(),
-            json={"sequence": sequence, "payloads": [str(sequence)], "status_code": 200},
+            json={
+                "sequence": sequence,
+                "payloads": [str(sequence)],
+                "status_code": 200,
+            },
         )
         assert result.status_code == 201, result.text
     exhausted = client.post(
@@ -364,7 +371,9 @@ def test_decoder_comparer_sequencer_har_and_finding_promotion(tmp_path):
                             },
                             "response": {
                                 "status": 200,
-                                "headers": [{"name": "Content-Type", "value": "text/html"}],
+                                "headers": [
+                                    {"name": "Content-Type", "value": "text/html"}
+                                ],
                             },
                         }
                     ]

--- a/tests/v3/test_harnesses.py
+++ b/tests/v3/test_harnesses.py
@@ -19,6 +19,8 @@ from pydantic import SecretStr
 from nebula.v3.api import create_app
 from nebula.v3.automation_runtime import AutomationRuntimeUnavailable
 from nebula.v3.artifacts import ArtifactStore
+from nebula.v3.browser_automation import BrowserAutomationService, BrowserAutonomyRequestModel
+from nebula.v3.browser_tools import AUTONOMOUS_BROWSER_TOOLS, BrowserAutomationToolPlatform
 from nebula.v3.chat import ChatService
 from nebula.v3.credentials import CredentialCreateRequest, CredentialStore
 from nebula.v3.diagnostics import DiagnosticManager
@@ -31,6 +33,8 @@ from nebula.v3.domain import (
     ChatSession,
     ChatTokenUsage,
     ChatTurn,
+    BrowserIdentity,
+    BrowserSession,
     Engagement,
     HarnessCapabilities,
     HarnessDetailedUsage,
@@ -58,6 +62,7 @@ from nebula.v3.domain import (
     RiskClass,
     RunBudget,
     RunStatus,
+    ScopePolicy,
     ToolCall,
     ToolCallStatus,
     utc_now,
@@ -665,6 +670,67 @@ def test_shared_session_handoff_streaming_and_frozen_mcp_snapshot(tmp_path):
         ]
         await runtime.shutdown()
         assert adapter.connections[0].closed is True
+
+    asyncio.run(scenario())
+
+
+def test_harness_mission_freezes_browser_gateway_and_lease(tmp_path):
+    async def scenario() -> None:
+        store, engagement, profile, _mcp, _adapter, runtime = _runtime(tmp_path)
+        scope = store.create(
+            ScopePolicy(
+                engagement_id=engagement.id,
+                allowed_domains=["app.example.test"],
+                allowed_ports=[443],
+            )
+        )
+        engagement = store.update(
+            Engagement,
+            engagement.id,
+            {"scope_policy_id": scope.id},
+            expected_revision=engagement.revision,
+        )
+        identity = store.create(
+            BrowserIdentity(engagement_id=engagement.id, name="Harness identity")
+        )
+        session = store.create(
+            BrowserSession(
+                engagement_id=engagement.id,
+                identity_id=identity.id,
+                name="Harness browser",
+                device_owner="desktop-1",
+            )
+        )
+        platform = BrowserAutomationToolPlatform(
+            store, BrowserAutomationService(store)
+        )
+        runtime.bind_browser_automation_platform(platform)
+
+        run = await runtime.start_mission(
+            engagement_id=engagement.id,
+            objective="Inspect the bounded browser target",
+            profile_id=profile.id,
+            model="test-model",
+            budget=RunBudget(max_duration_seconds=5),
+            actor_id="operator",
+            browser_autonomy=BrowserAutonomyRequestModel(
+                session_id=session.id,
+                targets=["https://app.example.test/"],
+                max_commands=20,
+                max_requests=50,
+            ),
+        )
+        assert run.backend.value == "harness"
+        assert run.metadata["browser_autonomy"]["session_id"] == session.id
+        assert set(run.metadata["tool_names"]) == set(AUTONOMOUS_BROWSER_TOOLS)
+        frozen = run.runtime_snapshot["command_runtime_snapshot"]
+        assert frozen["browser_runtime_enabled"] is True
+        assert set(frozen["tool_names"]) == set(AUTONOMOUS_BROWSER_TOOLS)
+        status = platform.automation.status(engagement.id, run_id=run.id)
+        assert status.leases[0].session_id == session.id
+        assert status.leases[0].scope_policy_revision == scope.revision
+        await runtime._mission_tasks[run.id]
+        await runtime.shutdown()
 
     asyncio.run(scenario())
 

--- a/tests/v3/test_harnesses.py
+++ b/tests/v3/test_harnesses.py
@@ -19,8 +19,14 @@ from pydantic import SecretStr
 from nebula.v3.api import create_app
 from nebula.v3.automation_runtime import AutomationRuntimeUnavailable
 from nebula.v3.artifacts import ArtifactStore
-from nebula.v3.browser_automation import BrowserAutomationService, BrowserAutonomyRequestModel
-from nebula.v3.browser_tools import AUTONOMOUS_BROWSER_TOOLS, BrowserAutomationToolPlatform
+from nebula.v3.browser_automation import (
+    BrowserAutomationService,
+    BrowserAutonomyRequestModel,
+)
+from nebula.v3.browser_tools import (
+    AUTONOMOUS_BROWSER_TOOLS,
+    BrowserAutomationToolPlatform,
+)
 from nebula.v3.chat import ChatService
 from nebula.v3.credentials import CredentialCreateRequest, CredentialStore
 from nebula.v3.diagnostics import DiagnosticManager
@@ -701,9 +707,7 @@ def test_harness_mission_freezes_browser_gateway_and_lease(tmp_path):
                 device_owner="desktop-1",
             )
         )
-        platform = BrowserAutomationToolPlatform(
-            store, BrowserAutomationService(store)
-        )
+        platform = BrowserAutomationToolPlatform(store, BrowserAutomationService(store))
         runtime.bind_browser_automation_platform(platform)
 
         run = await runtime.start_mission(

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -51,6 +51,13 @@ import type {
   SecurityBrowserHandoff,
   SecurityBrowserIdentity,
   SecurityBrowserSession,
+  SecurityBrowserResearchWorkspace,
+  SecurityBrowserSiteNode,
+  SecurityBrowserIntercept,
+  SecurityBrowserRepeaterTab,
+  SecurityBrowserAttack,
+  SecurityBrowserCrawlJob,
+  SecurityBrowserTokenAnalysis,
   SecurityBrowserWorkspace,
   SecurityBrowserWebSocketFrame,
   FindingCreateRequest,
@@ -389,6 +396,120 @@ interface WireBrowserAutomationStatus {
   leases: WireBrowserAutomationLease[];
   commands: WireBrowserCommand[];
   rules: WireBrowserProxyRule[];
+}
+
+interface WireBrowserSiteNode extends WireEntity {
+  session_id: string;
+  identity_id: string;
+  url: string;
+  method: string;
+  kind: SecurityBrowserSiteNode["kind"];
+  discovery_source: SecurityBrowserSiteNode["discoverySource"];
+  status_code?: number | null;
+  parameter_names: string[];
+  content_type?: string | null;
+  last_exchange_id?: string | null;
+  evidence_ids: string[];
+  first_seen_at: string;
+  last_seen_at: string;
+}
+
+interface WireBrowserIntercept extends WireEntity {
+  session_id: string;
+  tab_id: string;
+  transaction_id: string;
+  phase: SecurityBrowserIntercept["phase"];
+  method: string;
+  url: string;
+  status_code?: number | null;
+  headers: Array<[string, string]>;
+  state: SecurityBrowserIntercept["state"];
+  expires_at: string;
+  error?: string | null;
+}
+
+interface WireBrowserRepeaterTab extends WireEntity {
+  session_id: string;
+  identity_id: string;
+  name: string;
+  group: string;
+  notes: string;
+  protocol: SecurityBrowserRepeaterTab["protocol"];
+  method: string;
+  url: string;
+  headers: Array<[string, string]>;
+  source_exchange_id?: string | null;
+  history_exchange_ids: string[];
+  evidence_ids: string[];
+}
+
+interface WireBrowserCrawlJob extends WireEntity {
+  session_id: string;
+  identity_id: string;
+  start_url: string;
+  state: SecurityBrowserCrawlJob["state"];
+  max_depth: number;
+  max_requests: number;
+  max_concurrency: number;
+  max_duration_seconds: number;
+  max_body_bytes: number;
+  requests_completed: number;
+  nodes_discovered: number;
+  checkpoint: number;
+  error?: string | null;
+}
+
+interface WireBrowserAttack extends WireEntity {
+  session_id: string;
+  identity_id: string;
+  name: string;
+  strategy: SecurityBrowserAttack["strategy"];
+  method: string;
+  url_template: string;
+  positions: string[];
+  payload_sets: Array<Record<string, unknown>>;
+  transforms: string[];
+  state: SecurityBrowserAttack["state"];
+  max_requests: number;
+  max_concurrency: number;
+  requests_per_second: number;
+  request_count: number;
+  error_count: number;
+  error?: string | null;
+}
+
+interface WireBrowserAttackResult extends WireEntity {
+  attack_id: string;
+  sequence: number;
+  payloads: string[];
+  exchange_id?: string | null;
+  status_code?: number | null;
+  response_bytes?: number | null;
+  duration_ms?: number | null;
+  error?: string | null;
+  evidence_ids: string[];
+}
+
+interface WireBrowserTokenAnalysis extends WireEntity {
+  session_id: string;
+  name: string;
+  sample_count: number;
+  token_length_min: number;
+  token_length_max: number;
+  unique_count: number;
+  collision_count: number;
+  shannon_bits_per_character: number;
+  character_frequencies: Record<string, number>;
+}
+
+interface WireBrowserResearchWorkspace {
+  site_nodes: WireBrowserSiteNode[];
+  crawl_jobs?: WireBrowserCrawlJob[];
+  intercepts: WireBrowserIntercept[];
+  repeater_tabs: WireBrowserRepeaterTab[];
+  attacks: WireBrowserAttack[];
+  attack_results: WireBrowserAttackResult[];
+  token_analyses: WireBrowserTokenAnalysis[];
 }
 
 interface WireBrowserWorkspace {
@@ -3286,6 +3407,120 @@ function mapBrowserWorkspace(value: WireBrowserWorkspace): SecurityBrowserWorksp
     frames: value.frames.map(mapBrowserWebSocketFrame),
     actions: value.actions.map(mapBrowserAction),
     handoffs: value.handoffs.map(mapBrowserHandoff),
+  };
+}
+
+function mapBrowserResearchWorkspace(value: WireBrowserResearchWorkspace): SecurityBrowserResearchWorkspace {
+  return {
+    siteNodes: value.site_nodes.map((item) => ({
+      id: item.id,
+      revision: item.revision,
+      sessionId: item.session_id,
+      identityId: item.identity_id,
+      url: item.url,
+      method: item.method,
+      kind: item.kind,
+      discoverySource: item.discovery_source,
+      statusCode: item.status_code ?? undefined,
+      parameterNames: item.parameter_names,
+      contentType: item.content_type ?? undefined,
+      lastExchangeId: item.last_exchange_id ?? undefined,
+      evidenceIds: item.evidence_ids,
+      firstSeenAt: item.first_seen_at,
+      lastSeenAt: item.last_seen_at,
+    })),
+    crawlJobs: (value.crawl_jobs ?? []).map((item) => ({
+      id: item.id,
+      revision: item.revision,
+      sessionId: item.session_id,
+      identityId: item.identity_id,
+      startUrl: item.start_url,
+      state: item.state,
+      maxDepth: item.max_depth,
+      maxRequests: item.max_requests,
+      maxConcurrency: item.max_concurrency,
+      maxDurationSeconds: item.max_duration_seconds,
+      maxBodyBytes: item.max_body_bytes,
+      requestsCompleted: item.requests_completed,
+      nodesDiscovered: item.nodes_discovered,
+      checkpoint: item.checkpoint,
+      error: item.error ?? undefined,
+    })),
+    intercepts: value.intercepts.map((item) => ({
+      id: item.id,
+      revision: item.revision,
+      sessionId: item.session_id,
+      tabId: item.tab_id,
+      transactionId: item.transaction_id,
+      phase: item.phase,
+      method: item.method,
+      url: item.url,
+      statusCode: item.status_code ?? undefined,
+      headers: item.headers,
+      state: item.state,
+      expiresAt: item.expires_at,
+      error: item.error ?? undefined,
+    })),
+    repeaterTabs: value.repeater_tabs.map((item) => ({
+      id: item.id,
+      revision: item.revision,
+      sessionId: item.session_id,
+      identityId: item.identity_id,
+      name: item.name,
+      group: item.group,
+      notes: item.notes,
+      protocol: item.protocol,
+      method: item.method,
+      url: item.url,
+      headers: item.headers,
+      sourceExchangeId: item.source_exchange_id ?? undefined,
+      historyExchangeIds: item.history_exchange_ids,
+      evidenceIds: item.evidence_ids,
+    })),
+    attacks: value.attacks.map((item) => ({
+      id: item.id,
+      revision: item.revision,
+      sessionId: item.session_id,
+      identityId: item.identity_id,
+      name: item.name,
+      strategy: item.strategy,
+      method: item.method,
+      urlTemplate: item.url_template,
+      positions: item.positions,
+      payloadSets: item.payload_sets,
+      transforms: item.transforms,
+      state: item.state,
+      maxRequests: item.max_requests,
+      maxConcurrency: item.max_concurrency,
+      requestsPerSecond: item.requests_per_second,
+      requestCount: item.request_count,
+      errorCount: item.error_count,
+      error: item.error ?? undefined,
+    })),
+    attackResults: value.attack_results.map((item) => ({
+      id: item.id,
+      attackId: item.attack_id,
+      sequence: item.sequence,
+      payloads: item.payloads,
+      exchangeId: item.exchange_id ?? undefined,
+      statusCode: item.status_code ?? undefined,
+      responseBytes: item.response_bytes ?? undefined,
+      durationMs: item.duration_ms ?? undefined,
+      error: item.error ?? undefined,
+      evidenceIds: item.evidence_ids,
+    })),
+    tokenAnalyses: value.token_analyses.map((item) => ({
+      id: item.id,
+      sessionId: item.session_id,
+      name: item.name,
+      sampleCount: item.sample_count,
+      tokenLengthMin: item.token_length_min,
+      tokenLengthMax: item.token_length_max,
+      uniqueCount: item.unique_count,
+      collisionCount: item.collision_count,
+      shannonBitsPerCharacter: item.shannon_bits_per_character,
+      characterFrequencies: item.character_frequencies,
+    })),
   };
 }
 
@@ -6665,6 +6900,199 @@ export class ApiClient {
       `engagements/${encodeURIComponent(engagementId)}/browser-workspace`,
       { signal },
     ).then(mapBrowserWorkspace);
+  }
+
+  getSecurityBrowserResearch(
+    engagementId: string,
+    signal?: AbortSignal,
+  ): Promise<SecurityBrowserResearchWorkspace> {
+    return this.request<WireBrowserResearchWorkspace>(
+      `engagements/${encodeURIComponent(engagementId)}/browser-research`,
+      { signal },
+    ).then(mapBrowserResearchWorkspace);
+  }
+
+  createSecurityBrowserCrawl(
+    engagementId: string,
+    body: {
+      sessionId: string;
+      identityId: string;
+      startUrl: string;
+      maxDepth: number;
+      maxRequests: number;
+      maxConcurrency: number;
+      maxDurationSeconds: number;
+      maxBodyBytes: number;
+    },
+  ): Promise<SecurityBrowserCrawlJob> {
+    return this.request<WireBrowserCrawlJob>(
+      `engagements/${encodeURIComponent(engagementId)}/browser-crawls`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          session_id: body.sessionId,
+          identity_id: body.identityId,
+          start_url: body.startUrl,
+          max_depth: body.maxDepth,
+          max_requests: body.maxRequests,
+          max_concurrency: body.maxConcurrency,
+          max_duration_seconds: body.maxDurationSeconds,
+          max_body_bytes: body.maxBodyBytes,
+        }),
+      },
+    ).then((value) => mapBrowserResearchWorkspace({
+      site_nodes: [], crawl_jobs: [value], intercepts: [], repeater_tabs: [], attacks: [], attack_results: [], token_analyses: [],
+    }).crawlJobs[0]);
+  }
+
+  transitionSecurityBrowserCrawl(
+    crawl: SecurityBrowserCrawlJob,
+    action: "queue" | "start" | "pause" | "resume" | "cancel" | "complete" | "fail",
+    operatorId = "operator",
+  ): Promise<SecurityBrowserCrawlJob> {
+    return this.request<WireBrowserCrawlJob>(
+      `browser-crawls/${encodeURIComponent(crawl.id)}/state`,
+      {
+        method: "POST",
+        body: JSON.stringify({ expected_revision: crawl.revision, action, actor_id: operatorId }),
+      },
+    ).then((value) => mapBrowserResearchWorkspace({
+      site_nodes: [], crawl_jobs: [value], intercepts: [], repeater_tabs: [], attacks: [], attack_results: [], token_analyses: [],
+    }).crawlJobs[0]);
+  }
+
+  decideSecurityBrowserIntercept(
+    intercept: SecurityBrowserIntercept,
+    decision: "forward" | "drop",
+    operatorId = "operator",
+  ): Promise<SecurityBrowserIntercept> {
+    return this.request<WireBrowserIntercept>(
+      `browser-intercepts/${encodeURIComponent(intercept.id)}/decision`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          expected_revision: intercept.revision,
+          decision,
+          operator_id: operatorId,
+        }),
+      },
+    ).then((value) => mapBrowserResearchWorkspace({
+      site_nodes: [], intercepts: [value], repeater_tabs: [], attacks: [], attack_results: [], token_analyses: [],
+    }).intercepts[0]);
+  }
+
+  createSecurityBrowserRepeaterTab(
+    engagementId: string,
+    body: {
+      sessionId: string;
+      identityId: string;
+      name: string;
+      method: string;
+      url: string;
+      headers?: Array<[string, string]>;
+      sourceExchangeId?: string;
+    },
+  ): Promise<SecurityBrowserRepeaterTab> {
+    return this.request<WireBrowserRepeaterTab>(
+      `engagements/${encodeURIComponent(engagementId)}/browser-repeater-tabs`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          session_id: body.sessionId,
+          identity_id: body.identityId,
+          name: body.name,
+          method: body.method,
+          url: body.url,
+          headers: body.headers ?? [],
+          source_exchange_id: body.sourceExchangeId,
+        }),
+      },
+    ).then((value) => mapBrowserResearchWorkspace({
+      site_nodes: [], intercepts: [], repeater_tabs: [value], attacks: [], attack_results: [], token_analyses: [],
+    }).repeaterTabs[0]);
+  }
+
+  createSecurityBrowserAttack(
+    engagementId: string,
+    body: {
+      sessionId: string;
+      identityId: string;
+      name: string;
+      strategy: SecurityBrowserAttack["strategy"];
+      method: string;
+      urlTemplate: string;
+      positions: string[];
+      payloadValues: string[];
+      transforms?: string[];
+      maxRequests: number;
+      maxConcurrency: number;
+      requestsPerSecond: number;
+    },
+  ): Promise<SecurityBrowserAttack> {
+    return this.request<WireBrowserAttack>(
+      `engagements/${encodeURIComponent(engagementId)}/browser-attacks`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          session_id: body.sessionId,
+          identity_id: body.identityId,
+          name: body.name,
+          strategy: body.strategy,
+          method: body.method,
+          url_template: body.urlTemplate,
+          positions: body.positions,
+          payload_sets: [{ kind: "list", values: body.payloadValues }],
+          transforms: body.transforms ?? [],
+          max_requests: body.maxRequests,
+          max_concurrency: body.maxConcurrency,
+          requests_per_second: body.requestsPerSecond,
+        }),
+      },
+    ).then((value) => mapBrowserResearchWorkspace({
+      site_nodes: [], intercepts: [], repeater_tabs: [], attacks: [value], attack_results: [], token_analyses: [],
+    }).attacks[0]);
+  }
+
+  transitionSecurityBrowserAttack(
+    attack: SecurityBrowserAttack,
+    action: "queue" | "start" | "pause" | "resume" | "cancel" | "complete" | "fail",
+    operatorId = "operator",
+  ): Promise<SecurityBrowserAttack> {
+    return this.request<WireBrowserAttack>(
+      `browser-attacks/${encodeURIComponent(attack.id)}/state`,
+      {
+        method: "POST",
+        body: JSON.stringify({ expected_revision: attack.revision, action, actor_id: operatorId }),
+      },
+    ).then((value) => mapBrowserResearchWorkspace({
+      site_nodes: [], intercepts: [], repeater_tabs: [], attacks: [value], attack_results: [], token_analyses: [],
+    }).attacks[0]);
+  }
+
+  securityBrowserDecode(operation: string, value: string): Promise<{ operation: string; result: unknown; bytes: number }> {
+    return this.request("browser-utilities/decode", {
+      method: "POST",
+      body: JSON.stringify({ operation, value }),
+    });
+  }
+
+  securityBrowserCompare(mode: string, left: string, right: string): Promise<{ mode: string; equal: boolean; similarity?: number; diff?: string[] }> {
+    return this.request("browser-utilities/compare", {
+      method: "POST",
+      body: JSON.stringify({ mode, left, right }),
+    });
+  }
+
+  createSecurityBrowserTokenAnalysis(
+    engagementId: string,
+    body: { sessionId: string; name: string; samples: string[] },
+  ): Promise<SecurityBrowserTokenAnalysis> {
+    return this.request<WireBrowserTokenAnalysis>(
+      `engagements/${encodeURIComponent(engagementId)}/browser-token-analyses`,
+      { method: "POST", body: JSON.stringify({ session_id: body.sessionId, name: body.name, samples: body.samples }) },
+    ).then((value) => mapBrowserResearchWorkspace({
+      site_nodes: [], intercepts: [], repeater_tabs: [], attacks: [], attack_results: [], token_analyses: [value],
+    }).tokenAnalyses[0]);
   }
 
   getSecurityBrowserAutomation(

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -422,6 +422,132 @@ export interface SecurityBrowserWorkspace {
   handoffs: SecurityBrowserHandoff[];
 }
 
+export interface SecurityBrowserSiteNode {
+  id: Identifier;
+  revision: number;
+  sessionId: Identifier;
+  identityId: Identifier;
+  url: string;
+  method: string;
+  kind: "page" | "api" | "form" | "resource" | "websocket";
+  discoverySource: "browser" | "proxy" | "crawl" | "repeater" | "intruder" | "har" | "automation";
+  statusCode?: number;
+  parameterNames: string[];
+  contentType?: string;
+  lastExchangeId?: Identifier;
+  evidenceIds: Identifier[];
+  firstSeenAt: string;
+  lastSeenAt: string;
+}
+
+export interface SecurityBrowserIntercept {
+  id: Identifier;
+  revision: number;
+  sessionId: Identifier;
+  tabId: Identifier;
+  transactionId: string;
+  phase: "request" | "response";
+  method: string;
+  url: string;
+  statusCode?: number;
+  headers: Array<[string, string]>;
+  state: "paused" | "forwarded" | "dropped" | "interrupted" | "expired";
+  expiresAt: string;
+  error?: string;
+}
+
+export interface SecurityBrowserCrawlJob {
+  id: Identifier;
+  revision: number;
+  sessionId: Identifier;
+  identityId: Identifier;
+  startUrl: string;
+  state: "draft" | "queued" | "running" | "paused" | "complete" | "cancelled" | "failed";
+  maxDepth: number;
+  maxRequests: number;
+  maxConcurrency: number;
+  maxDurationSeconds: number;
+  maxBodyBytes: number;
+  requestsCompleted: number;
+  nodesDiscovered: number;
+  checkpoint: number;
+  error?: string;
+}
+
+export interface SecurityBrowserRepeaterTab {
+  id: Identifier;
+  revision: number;
+  sessionId: Identifier;
+  identityId: Identifier;
+  name: string;
+  group: string;
+  notes: string;
+  protocol: "http" | "websocket";
+  method: string;
+  url: string;
+  headers: Array<[string, string]>;
+  sourceExchangeId?: Identifier;
+  historyExchangeIds: Identifier[];
+  evidenceIds: Identifier[];
+}
+
+export interface SecurityBrowserAttack {
+  id: Identifier;
+  revision: number;
+  sessionId: Identifier;
+  identityId: Identifier;
+  name: string;
+  strategy: "sniper" | "battering_ram" | "pitchfork" | "cluster_bomb";
+  method: string;
+  urlTemplate: string;
+  positions: string[];
+  payloadSets: Array<Record<string, unknown>>;
+  transforms: string[];
+  state: "draft" | "queued" | "running" | "paused" | "complete" | "cancelled" | "failed";
+  maxRequests: number;
+  maxConcurrency: number;
+  requestsPerSecond: number;
+  requestCount: number;
+  errorCount: number;
+  error?: string;
+}
+
+export interface SecurityBrowserAttackResult {
+  id: Identifier;
+  attackId: Identifier;
+  sequence: number;
+  payloads: string[];
+  exchangeId?: Identifier;
+  statusCode?: number;
+  responseBytes?: number;
+  durationMs?: number;
+  error?: string;
+  evidenceIds: Identifier[];
+}
+
+export interface SecurityBrowserTokenAnalysis {
+  id: Identifier;
+  sessionId: Identifier;
+  name: string;
+  sampleCount: number;
+  tokenLengthMin: number;
+  tokenLengthMax: number;
+  uniqueCount: number;
+  collisionCount: number;
+  shannonBitsPerCharacter: number;
+  characterFrequencies: Record<string, number>;
+}
+
+export interface SecurityBrowserResearchWorkspace {
+  siteNodes: SecurityBrowserSiteNode[];
+  crawlJobs: SecurityBrowserCrawlJob[];
+  intercepts: SecurityBrowserIntercept[];
+  repeaterTabs: SecurityBrowserRepeaterTab[];
+  attacks: SecurityBrowserAttack[];
+  attackResults: SecurityBrowserAttackResult[];
+  tokenAnalyses: SecurityBrowserTokenAnalysis[];
+}
+
 export interface ScopeImportCandidate {
   id: Identifier;
   targetType: "cidr" | "domain" | "url";

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -649,11 +649,37 @@ kbd { font-size: 11px; }
 .browser-research-panel > header strong { font-size: 13px; }
 .browser-research-panel > header small { overflow: hidden; color: var(--muted); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
 .browser-research-panel > header > button { display: inline-grid; width: 36px; height: 36px; place-items: center; border: 0; border-radius: var(--radius-control); color: var(--muted); background: transparent; cursor: pointer; }
-.browser-research-panel > nav { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); border-bottom: 1px solid var(--border-soft); }
-.browser-research-panel > nav button { display: flex; min-width: 0; min-height: 42px; align-items: center; justify-content: center; gap: 4px; padding: 0 5px; border: 0; border-bottom: 2px solid transparent; color: var(--muted); background: transparent; font-size: 11px; cursor: pointer; }
+.browser-research-panel > nav { display: flex; flex: 0 0 auto; overflow-x: auto; border-bottom: 1px solid var(--border-soft); scrollbar-width: thin; }
+.browser-research-panel > nav button { display: flex; min-width: max-content; min-height: 42px; flex: 0 0 auto; align-items: center; justify-content: center; gap: 4px; padding: 0 9px; border: 0; border-bottom: 2px solid transparent; color: var(--muted); background: transparent; font-size: 11px; cursor: pointer; }
 .browser-research-panel > nav button.active { border-bottom-color: var(--blue); color: var(--text); background: var(--surface-muted); }
 .browser-research-panel > nav span { display: inline-grid; min-width: 17px; height: 17px; place-items: center; border-radius: 999px; background: var(--canvas); font: 11px var(--font-mono); }
-.browser-traffic-workbench, .browser-action-list, .browser-identity-workbench, .browser-session-workbench { min-height: 0; flex: 1; overflow: auto; }
+.browser-traffic-workbench, .browser-action-list, .browser-identity-workbench, .browser-session-workbench, .browser-suite { min-height: 0; flex: 1; overflow: auto; }
+.browser-suite { display: grid; align-content: start; }
+.browser-suite > section { display: grid; align-content: start; gap: 10px; padding: 12px; }
+.browser-suite-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; }
+.browser-suite-heading > div { display: flex; min-width: 0; align-items: flex-start; gap: 7px; }
+.browser-suite-heading span { display: grid; min-width: 0; gap: 3px; }
+.browser-suite-heading h3 { margin: 0; font-size: 13px; }
+.browser-suite-heading small { color: var(--muted); font-size: 11px; line-height: 1.4; }
+.browser-suite-list { display: grid; gap: 5px; margin: 0; padding: 0; list-style: none; }
+.browser-suite-list > li { display: flex; min-width: 0; align-items: flex-start; gap: 8px; padding: 9px; border: 1px solid var(--border-soft); border-radius: var(--radius-control); background: var(--surface); }
+.browser-suite-list > li > div { display: grid; min-width: 0; flex: 1; gap: 4px; }
+.browser-suite-list strong, .browser-suite-list small { overflow-wrap: anywhere; }
+.browser-suite-list small { color: var(--muted); font-size: 11px; line-height: 1.4; }
+.browser-suite-actions { display: flex; flex-wrap: wrap; gap: 6px; padding-top: 4px; }
+.browser-suite-form { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; padding: 10px; border: 1px solid var(--border-soft); border-radius: var(--radius-panel); background: var(--surface-muted); }
+.browser-suite-form label, .browser-utility-grid label { display: grid; gap: 5px; color: var(--muted); font-size: 11px; }
+.browser-suite-form :where(input, select, textarea), .browser-utility-grid :where(input, select, textarea) { width: 100%; min-width: 0; padding: 7px 8px; border: 1px solid var(--border); border-radius: var(--radius-control); color: var(--text); background: var(--canvas); font: 11px/1.45 var(--font-mono); resize: vertical; }
+.browser-suite-wide, .browser-suite-form > button { grid-column: 1 / -1; }
+.browser-utility-grid { display: grid; gap: 9px; }
+.browser-utility-grid form { display: grid; gap: 7px; padding: 10px; border: 1px solid var(--border-soft); border-radius: var(--radius-panel); background: var(--surface); }
+.browser-utility-grid h4 { display: flex; align-items: center; gap: 5px; margin: 0; }
+.browser-utility-grid pre { max-height: 200px; margin: 0; overflow: auto; padding: 8px; border-radius: var(--radius-control); background: var(--canvas); font-size: 11px; white-space: pre-wrap; overflow-wrap: anywhere; }
+.browser-utility-grid dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 5px; margin: 0; }
+.browser-utility-grid dl div { padding: 6px; border: 1px solid var(--border-soft); border-radius: var(--radius-control); }
+.browser-utility-grid dt { color: var(--muted); font-size: 11px; }
+.browser-utility-grid dd { margin: 2px 0 0; font: 11px var(--font-mono); }
+.browser-suite-footer { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding-top: 3px; color: var(--muted); font-size: 11px; }
 .browser-research-toolbar { display: flex; min-height: 40px; align-items: center; justify-content: space-between; gap: 8px; padding: 7px 10px; border-bottom: 1px solid var(--border-soft); color: var(--muted); font-size: 11px; }
 .browser-research-toolbar button { display: inline-flex; min-height: 28px; align-items: center; gap: 4px; border: 0; border-radius: var(--radius-control); color: var(--blue); background: transparent; font-size: 11px; cursor: pointer; }
 .browser-research-toolbar button:disabled { color: var(--muted); cursor: default; }
@@ -725,7 +751,7 @@ kbd { font-size: 11px; }
 .browser-automation-card details li { display: grid; grid-template-columns: auto auto 1fr; gap: 5px; align-items: center; min-width: 0; }
 .browser-automation-card details li small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .browser-automation-mobile-note { padding: 7px; border-left: 2px solid var(--blue); background: var(--canvas); }
-@media (max-width: 760px) { .browser-ca-card dl, .browser-automation-card dl { grid-template-columns: 1fr; } .browser-automation-form .resource-form-grid { grid-template-columns: 1fr; } }
+@media (max-width: 760px) { .browser-ca-card dl, .browser-automation-card dl { grid-template-columns: 1fr; } .browser-automation-form .resource-form-grid, .browser-suite-form { grid-template-columns: 1fr; } }
 .browser-web-research-bar { display: flex; min-height: 45px; align-items: center; gap: 10px; padding: 5px 8px; border-bottom: 1px solid var(--border-soft); color: var(--muted); font-size: 11px; }
 .web-browser-fallback .browser-research-panel { top: 45px; width: min(430px, 100%); }
 .web-browser-fallback.research-open > .browser-surface { margin-right: min(430px, 42vw); }
@@ -1386,7 +1412,7 @@ kbd { font-size: 11px; }
 .setup-card small { color: var(--muted); font-size: 11px; }
 .core-connection-settings { width: 100%; min-width: 0; }
 .core-connection-form { display: grid; width: min(100%, 760px); min-width: 0; gap: 14px; }
-.core-connection-form > label:not(.core-connection-insecure) { display: grid; min-width: 0; gap: 6px; color: var(--muted-strong); font-size: 12px; font-weight: 650; }
+.core-connection-form > label:not(.core-connection-insecure) { display: grid; min-width: 0; gap: 6px; color: var(--muted-strong); font-size: 12px; font-weight: var(--weight-semibold); }
 .core-connection-form input:not([type="checkbox"]) { width: 100%; min-width: 0; }
 .core-connection-insecure { display: grid; grid-template-columns: 20px minmax(0, 1fr); align-items: start; gap: 10px; min-width: 0; padding: 12px; border: 1px solid var(--border); border-radius: var(--radius-control); background: var(--surface-subtle); }
 .core-connection-insecure input { width: 18px; height: 18px; margin: 1px 0 0; }

--- a/ui/src/components/BrowserResearchSuite.test.tsx
+++ b/ui/src/components/BrowserResearchSuite.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "../api/client";
+import type { SecurityBrowserIdentity, SecurityBrowserSession } from "../api/types";
+import { BrowserResearchSuite } from "./BrowserResearchSuite";
+
+const identity = { id: "identity-1", name: "Operator" } as SecurityBrowserIdentity;
+const session = {
+  id: "session-1",
+  activeTabId: "tab-1",
+  tabs: [{ id: "tab-1", url: "https://app.example.test/", title: "App", position: 0 }],
+} as SecurityBrowserSession;
+
+function api(): ApiClient {
+  return {
+    getSecurityBrowserResearch: vi.fn().mockResolvedValue({
+      siteNodes: [{
+        id: "node-1", revision: 1, sessionId: session.id, identityId: identity.id,
+        url: "https://app.example.test/api/users?page=1", method: "GET", kind: "api",
+        discoverySource: "proxy", statusCode: 200, parameterNames: ["page"], evidenceIds: [],
+        firstSeenAt: new Date().toISOString(), lastSeenAt: new Date().toISOString(),
+      }],
+      crawlJobs: [], intercepts: [], repeaterTabs: [], attacks: [], attackResults: [], tokenAnalyses: [],
+    }),
+  } as unknown as ApiClient;
+}
+
+describe("BrowserResearchSuite", () => {
+  it("renders the durable target map and bounded crawl controls", async () => {
+    render(<MemoryRouter><BrowserResearchSuite api={api()} desktop identity={identity} operatorId="operator" projectId="project-1" session={session} view="target" /></MemoryRouter>);
+
+    expect(await screen.findByRole("heading", { name: "Target map" })).toBeInTheDocument();
+    expect(screen.getByText("https://app.example.test/api/users?page=1")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create bounded crawl" })).toBeEnabled();
+    expect(screen.getByLabelText("Crawl start URL")).toHaveValue("https://app.example.test/");
+  });
+
+  it("keeps native crawl execution unavailable on a paired browser", async () => {
+    render(<MemoryRouter><BrowserResearchSuite api={api()} desktop={false} identity={identity} operatorId="operator" projectId="project-1" session={session} view="target" /></MemoryRouter>);
+
+    expect(await screen.findByRole("button", { name: "Create bounded crawl" })).toBeDisabled();
+    expect(screen.getByText(/desktop owns network execution/i)).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/BrowserResearchSuite.tsx
+++ b/ui/src/components/BrowserResearchSuite.tsx
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useState, type FormEvent } from "react";
+import { AlertTriangle, Braces, GitCompareArrows, LoaderCircle, Pause, Play, RefreshCw, Send, ShieldAlert, Square, Target } from "lucide-react";
+import { Link } from "react-router-dom";
+import type { ApiClient } from "../api/client";
+import type {
+  SecurityBrowserAttack,
+  SecurityBrowserCrawlJob,
+  SecurityBrowserIdentity,
+  SecurityBrowserResearchWorkspace,
+  SecurityBrowserSession,
+} from "../api/types";
+import { logCaughtDiagnostic } from "../diagnostics";
+
+export type BrowserResearchToolView = "target" | "intercepts" | "repeater" | "intruder" | "utilities";
+
+interface Props {
+  api: ApiClient;
+  desktop: boolean;
+  identity?: SecurityBrowserIdentity;
+  operatorId: string;
+  projectId: string;
+  session?: SecurityBrowserSession;
+  view: BrowserResearchToolView;
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function BrowserResearchSuite({ api, desktop, identity, operatorId, projectId, session, view }: Props) {
+  const [workspace, setWorkspace] = useState<SecurityBrowserResearchWorkspace>();
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string>();
+  const [notice, setNotice] = useState<string>();
+  const [repeaterName, setRepeaterName] = useState("Repeater");
+  const [repeaterMethod, setRepeaterMethod] = useState("GET");
+  const [repeaterUrl, setRepeaterUrl] = useState("");
+  const [attackName, setAttackName] = useState("Identifier boundaries");
+  const [attackStrategy, setAttackStrategy] = useState<SecurityBrowserAttack["strategy"]>("sniper");
+  const [attackMethod, setAttackMethod] = useState("GET");
+  const [attackUrl, setAttackUrl] = useState("");
+  const [attackPosition, setAttackPosition] = useState("id");
+  const [payloads, setPayloads] = useState("0\n1\n-1");
+  const [decoderOperation, setDecoderOperation] = useState("url_encode");
+  const [decoderInput, setDecoderInput] = useState("");
+  const [decoderOutput, setDecoderOutput] = useState("");
+  const [compareMode, setCompareMode] = useState("text");
+  const [compareLeft, setCompareLeft] = useState("");
+  const [compareRight, setCompareRight] = useState("");
+  const [compareOutput, setCompareOutput] = useState("");
+  const [tokenSamples, setTokenSamples] = useState("");
+  const [crawlUrl, setCrawlUrl] = useState("");
+  const [crawlDepth, setCrawlDepth] = useState(2);
+  const [crawlRequests, setCrawlRequests] = useState(100);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      setWorkspace(await api.getSecurityBrowserResearch(projectId));
+      setError(undefined);
+    } catch (caught) {
+      void logCaughtDiagnostic("interface.security_browser.research_suite_load_failed", "Burp-parity browser research state could not be loaded.", caught, "workbench_browser");
+      setError(message(caught));
+    } finally {
+      setLoading(false);
+    }
+  }, [api, projectId]);
+
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  useEffect(() => {
+    const current = session?.tabs.find((tab) => tab.id === session.activeTabId)?.url ?? session?.tabs[0]?.url ?? "";
+    if (!repeaterUrl) setRepeaterUrl(current);
+    if (!attackUrl) setAttackUrl(current ? `${current.replace(/\/$/, "")}/§id§` : "");
+    if (!crawlUrl) setCrawlUrl(current);
+  }, [attackUrl, crawlUrl, repeaterUrl, session]);
+
+  const sessionItems = <T extends { sessionId: string }>(items: T[] | undefined): T[] =>
+    items?.filter((item) => item.sessionId === session?.id) ?? [];
+
+  const decideIntercept = async (id: string, decision: "forward" | "drop") => {
+    const item = workspace?.intercepts.find((candidate) => candidate.id === id);
+    if (!item) return;
+    setBusy(true);
+    try {
+      await api.decideSecurityBrowserIntercept(item, decision, operatorId);
+      setNotice(decision === "forward" ? "The paused transaction was released." : "The paused transaction was dropped.");
+      await refresh();
+    } catch (caught) {
+      setError(message(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const createCrawl = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!session || !identity) return;
+    setBusy(true);
+    try {
+      await api.createSecurityBrowserCrawl(projectId, {
+        sessionId: session.id,
+        identityId: identity.id,
+        startUrl: crawlUrl,
+        maxDepth: crawlDepth,
+        maxRequests: crawlRequests,
+        maxConcurrency: 2,
+        maxDurationSeconds: 300,
+        maxBodyBytes: 1_048_576,
+      });
+      setNotice("Bounded crawl saved as a draft. Queue and start it explicitly from the owning desktop.");
+      await refresh();
+    } catch (caught) {
+      setError(message(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const transitionCrawl = async (crawl: SecurityBrowserCrawlJob, action: "queue" | "start" | "pause" | "resume" | "cancel") => {
+    setBusy(true);
+    try {
+      await api.transitionSecurityBrowserCrawl(crawl, action, operatorId);
+      await refresh();
+    } catch (caught) {
+      setError(message(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const createRepeater = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!session || !identity) return;
+    setBusy(true);
+    try {
+      await api.createSecurityBrowserRepeaterTab(projectId, {
+        sessionId: session.id,
+        identityId: identity.id,
+        name: repeaterName,
+        method: repeaterMethod,
+        url: repeaterUrl,
+      });
+      setNotice("Repeater tab saved. Sending remains an explicit native action.");
+      await refresh();
+    } catch (caught) {
+      setError(message(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const createAttack = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!session || !identity) return;
+    const values = payloads.split("\n").map((value) => value.trim()).filter(Boolean);
+    setBusy(true);
+    try {
+      await api.createSecurityBrowserAttack(projectId, {
+        sessionId: session.id,
+        identityId: identity.id,
+        name: attackName,
+        strategy: attackStrategy,
+        method: attackMethod,
+        urlTemplate: attackUrl,
+        positions: [attackPosition],
+        payloadValues: values,
+        transforms: ["url_encode"],
+        maxRequests: Math.min(1000, Math.max(1, values.length)),
+        maxConcurrency: 1,
+        requestsPerSecond: 2,
+      });
+      setNotice("Intruder attack saved as a draft. Queue it when its positions and budgets are correct.");
+      await refresh();
+    } catch (caught) {
+      setError(message(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const transitionAttack = async (attack: SecurityBrowserAttack, action: "queue" | "start" | "pause" | "resume" | "cancel") => {
+    setBusy(true);
+    try {
+      await api.transitionSecurityBrowserAttack(attack, action, operatorId);
+      await refresh();
+    } catch (caught) {
+      setError(message(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const decode = async (event: FormEvent) => {
+    event.preventDefault();
+    setBusy(true);
+    try {
+      const result = await api.securityBrowserDecode(decoderOperation, decoderInput);
+      setDecoderOutput(typeof result.result === "string" ? result.result : JSON.stringify(result.result, null, 2));
+      setError(undefined);
+    } catch (caught) {
+      setError(message(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const compare = async (event: FormEvent) => {
+    event.preventDefault();
+    setBusy(true);
+    try {
+      const result = await api.securityBrowserCompare(compareMode, compareLeft, compareRight);
+      setCompareOutput(JSON.stringify(result, null, 2));
+      setError(undefined);
+    } catch (caught) {
+      setError(message(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const sequence = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!session) return;
+    const samples = tokenSamples.split("\n").map((value) => value.trim()).filter(Boolean);
+    setBusy(true);
+    try {
+      await api.createSecurityBrowserTokenAnalysis(projectId, { sessionId: session.id, name: "Token analysis", samples });
+      setNotice("Token samples were analyzed descriptively; this is not a cryptographic certification.");
+      await refresh();
+    } catch (caught) {
+      setError(message(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading && !workspace) return <div className="browser-research-empty"><LoaderCircle className="spin" size={18} /> Loading durable research tools…</div>;
+  if (error && !workspace) return <div className="browser-research-empty error" role="alert"><strong>Research tools are unavailable</strong><span>{error}</span><button className="button secondary" onClick={() => void refresh()} type="button">Try again</button></div>;
+
+  return <div className="browser-suite" aria-busy={busy}>
+    {error && <div className="browser-notice error" role="alert"><AlertTriangle size={14} /><span>{error}</span><button type="button" aria-label="Dismiss research error" onClick={() => setError(undefined)}>×</button></div>}
+    {notice && <div className="browser-notice" role="status"><span>{notice}</span><button type="button" aria-label="Dismiss research notice" onClick={() => setNotice(undefined)}>×</button></div>}
+
+    {view === "target" && <section aria-labelledby="browser-target-heading">
+      <header className="browser-suite-heading"><div><Target size={16} /><span><h3 id="browser-target-heading">Target map</h3><small>In-scope locations discovered by browsing, proxy capture, HAR, crawl, and automation.</small></span></div><button className="icon-button subtle" aria-label="Refresh target map" type="button" onClick={() => void refresh()}><RefreshCw size={14} /></button></header>
+      <form className="browser-suite-form" onSubmit={createCrawl}><label className="browser-suite-wide">Crawl start URL<input required value={crawlUrl} onChange={(event) => setCrawlUrl(event.target.value)} /></label><label>Maximum depth<input type="number" min={0} max={10} value={crawlDepth} onChange={(event) => setCrawlDepth(Number(event.target.value))} /></label><label>Request budget<input type="number" min={1} max={10000} value={crawlRequests} onChange={(event) => setCrawlRequests(Number(event.target.value))} /></label><button className="button primary" disabled={busy || !desktop || !session || !identity || !crawlUrl} type="submit">Create bounded crawl</button>{!desktop && <small className="browser-suite-wide">A paired client can inspect and stop crawls; the desktop owns network execution.</small>}</form>
+      {sessionItems(workspace?.crawlJobs).length > 0 && <ol className="browser-suite-list">{[...sessionItems(workspace?.crawlJobs)].reverse().map((crawl) => <li key={crawl.id}><span className={`browser-action-status ${crawl.state}`}>{crawl.state}</span><div><strong>{crawl.startUrl}</strong><small>depth {crawl.maxDepth} · {crawl.requestsCompleted}/{crawl.maxRequests} requests · {crawl.nodesDiscovered} nodes</small><span className="browser-suite-actions">{crawl.state === "draft" && <button className="button secondary" type="button" onClick={() => void transitionCrawl(crawl, "queue")}>Queue</button>}{crawl.state === "queued" && desktop && <button className="button primary" type="button" onClick={() => void transitionCrawl(crawl, "start")}><Play size={13} /> Start</button>}{crawl.state === "running" && <button className="button secondary" type="button" onClick={() => void transitionCrawl(crawl, "pause")}><Pause size={13} /> Pause</button>}{crawl.state === "paused" && desktop && <button className="button primary" type="button" onClick={() => void transitionCrawl(crawl, "resume")}><Play size={13} /> Resume</button>}{["draft", "queued", "running", "paused"].includes(crawl.state) && <button className="button quiet danger" type="button" onClick={() => void transitionCrawl(crawl, "cancel")}><Square size={13} /> Cancel</button>}</span></div></li>)}</ol>}
+      {sessionItems(workspace?.siteNodes).length ? <ol className="browser-suite-list">{sessionItems(workspace?.siteNodes).map((node) => <li key={node.id}><span className={`browser-method method-${node.method.toLowerCase()}`}>{node.method}</span><div><strong>{node.url}</strong><small>{node.kind} · {node.discoverySource}{node.statusCode ? ` · ${node.statusCode}` : ""}{node.parameterNames.length ? ` · parameters: ${node.parameterNames.join(", ")}` : ""}</small></div></li>)}</ol> : <div className="browser-research-empty"><Target size={20} /><strong>No mapped targets</strong><span>Browse an authorized page, import a HAR, or start a bounded crawl.</span></div>}
+    </section>}
+
+    {view === "intercepts" && <section aria-labelledby="browser-intercept-heading">
+      <header className="browser-suite-heading"><div><ShieldAlert size={16} /><span><h3 id="browser-intercept-heading">Intercept queue</h3><small>Paused native requests and responses fail closed on expiry or disconnect.</small></span></div></header>
+      {!desktop && <p className="browser-automation-mobile-note">This paired device can decide durable items, but only the desktop owns the live transaction.</p>}
+      {sessionItems(workspace?.intercepts).length ? <ol className="browser-suite-list">{[...sessionItems(workspace?.intercepts)].reverse().map((item) => <li key={item.id}><span className={`browser-action-status ${item.state}`}>{item.state}</span><div><strong>{item.phase} · {item.method} {item.url}</strong><small>Expires {new Date(item.expiresAt).toLocaleTimeString()}{item.error ? ` · ${item.error}` : ""}</small>{item.state === "paused" && <span className="browser-suite-actions"><button className="button secondary" disabled={busy} type="button" onClick={() => void decideIntercept(item.id, "drop")}>Drop</button><button className="button primary" disabled={busy} type="button" onClick={() => void decideIntercept(item.id, "forward")}>Forward</button></span>}</div></li>)}</ol> : <div className="browser-research-empty"><ShieldAlert size={20} /><strong>No paused traffic</strong><span>Enable interception in Session, then configure a breakpoint in the native proxy.</span></div>}
+    </section>}
+
+    {view === "repeater" && <section aria-labelledby="browser-repeater-heading">
+      <header className="browser-suite-heading"><div><Send size={16} /><span><h3 id="browser-repeater-heading">Repeater</h3><small>Save protocol-aware request tabs without copying identity cookies.</small></span></div></header>
+      <form className="browser-suite-form" onSubmit={createRepeater}><label>Name<input value={repeaterName} onChange={(event) => setRepeaterName(event.target.value)} /></label><label>Method<input value={repeaterMethod} onChange={(event) => setRepeaterMethod(event.target.value.toUpperCase())} /></label><label>URL<input required value={repeaterUrl} onChange={(event) => setRepeaterUrl(event.target.value)} /></label><button className="button primary" disabled={busy || !session || !identity || !repeaterUrl} type="submit">Save Repeater tab</button></form>
+      {sessionItems(workspace?.repeaterTabs).length ? <ol className="browser-suite-list">{sessionItems(workspace?.repeaterTabs).map((tab) => <li key={tab.id}><span className={`browser-method method-${tab.method.toLowerCase()}`}>{tab.method}</span><div><strong>{tab.name}</strong><small>{tab.url} · {tab.historyExchangeIds.length} responses · identity isolated</small></div></li>)}</ol> : <div className="browser-research-empty"><Send size={20} /><strong>No Repeater tabs</strong><span>Save the current request or create a new in-scope request above.</span></div>}
+    </section>}
+
+    {view === "intruder" && <section aria-labelledby="browser-intruder-heading">
+      <header className="browser-suite-heading"><div><ShieldAlert size={16} /><span><h3 id="browser-intruder-heading">Intruder</h3><small>Curated or inert custom payloads with explicit rate, concurrency, and request budgets.</small></span></div></header>
+      <form className="browser-suite-form" onSubmit={createAttack}><label>Name<input value={attackName} onChange={(event) => setAttackName(event.target.value)} /></label><label>Strategy<select value={attackStrategy} onChange={(event) => setAttackStrategy(event.target.value as SecurityBrowserAttack["strategy"])}><option value="sniper">Sniper</option><option value="battering_ram">Battering ram</option><option value="pitchfork">Pitchfork</option><option value="cluster_bomb">Cluster bomb</option></select></label><label>Method<input value={attackMethod} onChange={(event) => setAttackMethod(event.target.value.toUpperCase())} /></label><label>Position name<input value={attackPosition} onChange={(event) => setAttackPosition(event.target.value)} /></label><label className="browser-suite-wide">URL template<input required value={attackUrl} onChange={(event) => setAttackUrl(event.target.value)} /><small>Mark a position as <code>§{attackPosition || "id"}§</code>.</small></label><label className="browser-suite-wide">Payloads<textarea rows={5} value={payloads} onChange={(event) => setPayloads(event.target.value)} /></label><button className="button primary" disabled={busy || !session || !identity || !attackUrl || !payloads.trim()} type="submit">Save attack draft</button></form>
+      {sessionItems(workspace?.attacks).length ? <ol className="browser-suite-list">{sessionItems(workspace?.attacks).map((attack) => <li key={attack.id}><span className={`browser-action-status ${attack.state}`}>{attack.state}</span><div><strong>{attack.name}</strong><small>{attack.strategy.replace("_", " ")} · {attack.requestCount}/{attack.maxRequests} requests · {attack.requestsPerSecond}/s</small><span className="browser-suite-actions">{attack.state === "draft" && <button className="button secondary" type="button" onClick={() => void transitionAttack(attack, "queue")}>Queue</button>}{attack.state === "queued" && <button className="button primary" type="button" onClick={() => void transitionAttack(attack, "start")}><Play size={13} /> Start</button>}{attack.state === "running" && <button className="button secondary" type="button" onClick={() => void transitionAttack(attack, "pause")}><Pause size={13} /> Pause</button>}{attack.state === "paused" && <button className="button primary" type="button" onClick={() => void transitionAttack(attack, "resume")}><Play size={13} /> Resume</button>}{["draft", "queued", "running", "paused"].includes(attack.state) && <button className="button quiet danger" type="button" onClick={() => void transitionAttack(attack, "cancel")}><Square size={13} /> Cancel</button>}</span></div></li>)}</ol> : <div className="browser-research-empty"><ShieldAlert size={20} /><strong>No attacks</strong><span>Create a bounded attack draft; it sends nothing until explicitly started.</span></div>}
+    </section>}
+
+    {view === "utilities" && <section aria-labelledby="browser-utilities-heading">
+      <header className="browser-suite-heading"><div><Braces size={16} /><span><h3 id="browser-utilities-heading">Decoder · Comparer · Sequencer</h3><small>Deterministic bounded utilities. Token analysis is descriptive, not a cryptographic certification.</small></span></div></header>
+      <div className="browser-utility-grid"><form onSubmit={decode}><h4>Decoder</h4><label>Operation<select value={decoderOperation} onChange={(event) => setDecoderOperation(event.target.value)}><option value="url_encode">URL encode</option><option value="url_decode">URL decode</option><option value="html_encode">HTML encode</option><option value="html_decode">HTML decode</option><option value="base64_encode">Base64 encode</option><option value="base64_decode">Base64 decode</option><option value="hex_encode">Hex encode</option><option value="hex_decode">Hex decode</option><option value="gzip_compress">Gzip + Base64</option><option value="gzip_decompress">Base64 + gunzip</option><option value="jwt_inspect">Inspect JWT</option><option value="sha256">SHA-256</option></select></label><textarea aria-label="Decoder input" rows={5} value={decoderInput} onChange={(event) => setDecoderInput(event.target.value)} /><button className="button secondary" disabled={busy} type="submit">Transform</button><textarea aria-label="Decoder output" readOnly rows={5} value={decoderOutput} /></form><form onSubmit={compare}><h4><GitCompareArrows size={14} /> Comparer</h4><label>Mode<select value={compareMode} onChange={(event) => setCompareMode(event.target.value)}><option value="text">Text</option><option value="json">JSON</option><option value="http">HTTP message</option><option value="bytes">Base64 bytes</option></select></label><textarea aria-label="Compare left" rows={4} value={compareLeft} onChange={(event) => setCompareLeft(event.target.value)} /><textarea aria-label="Compare right" rows={4} value={compareRight} onChange={(event) => setCompareRight(event.target.value)} /><button className="button secondary" disabled={busy} type="submit">Compare</button><pre>{compareOutput}</pre></form><form onSubmit={sequence}><h4>Sequencer</h4><label>One token per line<textarea rows={7} value={tokenSamples} onChange={(event) => setTokenSamples(event.target.value)} /></label><button className="button secondary" disabled={busy || !session || !tokenSamples.trim()} type="submit">Analyze samples</button>{sessionItems(workspace?.tokenAnalyses).map((analysis) => <dl key={analysis.id}><div><dt>Samples</dt><dd>{analysis.sampleCount}</dd></div><div><dt>Unique</dt><dd>{analysis.uniqueCount}</dd></div><div><dt>Collisions</dt><dd>{analysis.collisionCount}</dd></div><div><dt>Entropy/char</dt><dd>{analysis.shannonBitsPerCharacter.toFixed(3)} bits</dd></div></dl>)}</form></div>
+      <footer className="browser-suite-footer"><span>Promote verified request/response evidence through the existing finding lifecycle.</span><Link className="button secondary" to="/findings">Open Findings</Link></footer>
+    </section>}
+  </div>;
+}

--- a/ui/src/components/BrowserResearchSuite.tsx
+++ b/ui/src/components/BrowserResearchSuite.tsx
@@ -88,6 +88,7 @@ export function BrowserResearchSuite({ api, desktop, identity, operatorId, proje
       setNotice(decision === "forward" ? "The paused transaction was released." : "The paused transaction was dropped.");
       await refresh();
     } catch (caught) {
+      void logCaughtDiagnostic("interface.security_browser.intercept_decision_failed", "The paused browser transaction could not be decided.", caught, "browser_research_suite");
       setError(message(caught));
     } finally {
       setBusy(false);
@@ -112,6 +113,7 @@ export function BrowserResearchSuite({ api, desktop, identity, operatorId, proje
       setNotice("Bounded crawl saved as a draft. Queue and start it explicitly from the owning desktop.");
       await refresh();
     } catch (caught) {
+      void logCaughtDiagnostic("interface.security_browser.crawl_create_failed", "The bounded browser crawl could not be created.", caught, "browser_research_suite");
       setError(message(caught));
     } finally {
       setBusy(false);
@@ -124,6 +126,7 @@ export function BrowserResearchSuite({ api, desktop, identity, operatorId, proje
       await api.transitionSecurityBrowserCrawl(crawl, action, operatorId);
       await refresh();
     } catch (caught) {
+      void logCaughtDiagnostic("interface.security_browser.crawl_transition_failed", "The browser crawl state could not be changed.", caught, "browser_research_suite");
       setError(message(caught));
     } finally {
       setBusy(false);
@@ -145,6 +148,7 @@ export function BrowserResearchSuite({ api, desktop, identity, operatorId, proje
       setNotice("Repeater tab saved. Sending remains an explicit native action.");
       await refresh();
     } catch (caught) {
+      void logCaughtDiagnostic("interface.security_browser.repeater_create_failed", "The Repeater tab could not be saved.", caught, "browser_research_suite");
       setError(message(caught));
     } finally {
       setBusy(false);
@@ -174,6 +178,7 @@ export function BrowserResearchSuite({ api, desktop, identity, operatorId, proje
       setNotice("Intruder attack saved as a draft. Queue it when its positions and budgets are correct.");
       await refresh();
     } catch (caught) {
+      void logCaughtDiagnostic("interface.security_browser.attack_create_failed", "The bounded Intruder draft could not be saved.", caught, "browser_research_suite");
       setError(message(caught));
     } finally {
       setBusy(false);
@@ -186,6 +191,7 @@ export function BrowserResearchSuite({ api, desktop, identity, operatorId, proje
       await api.transitionSecurityBrowserAttack(attack, action, operatorId);
       await refresh();
     } catch (caught) {
+      void logCaughtDiagnostic("interface.security_browser.attack_transition_failed", "The Intruder attack state could not be changed.", caught, "browser_research_suite");
       setError(message(caught));
     } finally {
       setBusy(false);
@@ -200,6 +206,7 @@ export function BrowserResearchSuite({ api, desktop, identity, operatorId, proje
       setDecoderOutput(typeof result.result === "string" ? result.result : JSON.stringify(result.result, null, 2));
       setError(undefined);
     } catch (caught) {
+      void logCaughtDiagnostic("interface.security_browser.decoder_failed", "The browser Decoder transformation failed.", caught, "browser_research_suite");
       setError(message(caught));
     } finally {
       setBusy(false);
@@ -214,6 +221,7 @@ export function BrowserResearchSuite({ api, desktop, identity, operatorId, proje
       setCompareOutput(JSON.stringify(result, null, 2));
       setError(undefined);
     } catch (caught) {
+      void logCaughtDiagnostic("interface.security_browser.comparer_failed", "The browser comparison failed.", caught, "browser_research_suite");
       setError(message(caught));
     } finally {
       setBusy(false);
@@ -230,6 +238,7 @@ export function BrowserResearchSuite({ api, desktop, identity, operatorId, proje
       setNotice("Token samples were analyzed descriptively; this is not a cryptographic certification.");
       await refresh();
     } catch (caught) {
+      void logCaughtDiagnostic("interface.security_browser.sequencer_failed", "The token analysis could not be completed.", caught, "browser_research_suite");
       setError(message(caught));
     } finally {
       setBusy(false);

--- a/ui/src/components/WorkbenchBrowser.tsx
+++ b/ui/src/components/WorkbenchBrowser.tsx
@@ -164,15 +164,16 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
 
   useEffect(() => {
     if (!active) return;
-    const next = new URLSearchParams(searchParams);
-    // The mounted browser owns these URL fields while active. Keep the parent
-    // Workbench view in the same atomic update so a stale child render cannot
-    // restore the previously selected view during mobile navigation.
-    next.set("view", "browser");
+    const current = new URLSearchParams(window.location.search);
+    // The Browser owns only its nested URL fields. Checking the live location
+    // prevents a stale active render from writing after Workbench has moved to
+    // another view, while avoiding stale-hook races when Browser is entered.
+    if (current.get("view") !== "browser") return;
+    const next = new URLSearchParams(current);
     next.set("browserTool", researchView);
     if (sessionId) next.set("browserSession", sessionId); else next.delete("browserSession");
     if (activeId) next.set("browserTab", activeId); else next.delete("browserTab");
-    if (next.toString() !== searchParams.toString()) setSearchParams(next, { replace: true });
+    if (next.toString() !== current.toString()) setSearchParams(next, { replace: true });
   }, [active, activeId, researchView, searchParams, sessionId, setSearchParams]);
   const [automationBusy, setAutomationBusy] = useState(false);
   const [automationProviders, setAutomationProviders] = useState<ProviderHealth[]>([]);

--- a/ui/src/components/WorkbenchBrowser.tsx
+++ b/ui/src/components/WorkbenchBrowser.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { ArrowLeft, ArrowRight, BookOpenCheck, BookPlus, Bug, Check, Download, ExternalLink, GitCompareArrows, Globe2, History, LoaderCircle, Network, Plus, RefreshCw, Search, ShieldCheck, Sparkles, Trash2, UserRound, X } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { desktopDeviceId, isTauriRuntime } from "../api/runtime";
 import {
   buildBrowserScopeAddition,
@@ -19,13 +19,18 @@ import {
   type BrowserWebSocketFrameEvent,
   type BrowserActionEvent,
 } from "../api/workbenchBrowser";
-import type { EngagementScopePolicy, EvidenceSummary, EvidenceUploadRequest } from "../api/types";
+import type { EngagementScopePolicy, EvidenceSummary, EvidenceUploadRequest, HarnessProfile } from "../api/types";
 import type { ApiClient } from "../api/client";
 import type { ProviderHealth, SecurityBrowserAutomationStatus, SecurityBrowserExchange, SecurityBrowserSession, SecurityBrowserWorkspace } from "../api/types";
 import { logCaughtDiagnostic } from "../diagnostics";
 import { useChrome } from "../state/ChromeContext";
 import type { NebulaDraftRequest } from "../state/WorkbenchDraftContext";
 import { useConfirmation, useDialogOpen } from "./DialogSystem";
+import { aiRuntimeLabel, aiRuntimeOptions } from "./aiRuntimes";
+import { BrowserResearchSuite, type BrowserResearchToolView } from "./BrowserResearchSuite";
+
+type ResearchView = "traffic" | "actions" | "identities" | "session" | BrowserResearchToolView;
+const RESEARCH_VIEWS = new Set<ResearchView>(["target", "traffic", "intercepts", "repeater", "intruder", "utilities", "actions", "identities", "session"]);
 
 interface BrowserTab {
   id: string;
@@ -112,6 +117,7 @@ function visibleSurfaceRect(element: HTMLElement): DOMRect {
 }
 
 export function WorkbenchBrowser({ active, api, operatorId = "operator", projectId, scope, scopeLoading = false, onAddKnowledgeUrl, onAskNebula, onOpenFiles, onScopeUpdated, onUploadEvidence }: WorkbenchBrowserProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
   const confirm = useConfirmation();
   const dialogOpen = useDialogOpen();
   const { activityOpen, paletteOpen, sidebarCollapsed } = useChrome();
@@ -133,9 +139,12 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   const [workspaceLoading, setWorkspaceLoading] = useState(true);
   const [sessionHydrated, setSessionHydrated] = useState(false);
   const [workspaceError, setWorkspaceError] = useState<string>();
-  const [sessionId, setSessionId] = useState<string>();
+  const [sessionId, setSessionId] = useState<string | undefined>(() => searchParams.get("browserSession") ?? undefined);
   const [researchOpen, setResearchOpen] = useState(false);
-  const [researchView, setResearchView] = useState<"traffic" | "actions" | "identities" | "session">("traffic");
+  const [researchView, setResearchView] = useState<ResearchView>(() => {
+    const requested = searchParams.get("browserTool") as ResearchView | null;
+    return requested && RESEARCH_VIEWS.has(requested) ? requested : "traffic";
+  });
   const [selectedExchangeIds, setSelectedExchangeIds] = useState<string[]>([]);
   const [identityName, setIdentityName] = useState("");
   const [identityBusy, setIdentityBusy] = useState(false);
@@ -152,9 +161,19 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   const [caTrustAcknowledged, setCaTrustAcknowledged] = useState(false);
   const [automationStatus, setAutomationStatus] = useState<SecurityBrowserAutomationStatus>();
   const [automationFormOpen, setAutomationFormOpen] = useState(false);
+
+  useEffect(() => {
+    if (!active) return;
+    const next = new URLSearchParams(searchParams);
+    next.set("browserTool", researchView);
+    if (sessionId) next.set("browserSession", sessionId); else next.delete("browserSession");
+    if (activeId) next.set("browserTab", activeId); else next.delete("browserTab");
+    if (next.toString() !== searchParams.toString()) setSearchParams(next, { replace: true });
+  }, [active, activeId, researchView, searchParams, sessionId, setSearchParams]);
   const [automationBusy, setAutomationBusy] = useState(false);
   const [automationProviders, setAutomationProviders] = useState<ProviderHealth[]>([]);
-  const [automationProviderId, setAutomationProviderId] = useState("");
+  const [automationHarnesses, setAutomationHarnesses] = useState<HarnessProfile[]>([]);
+  const [automationRuntimeKey, setAutomationRuntimeKey] = useState("");
   const [automationModel, setAutomationModel] = useState("");
   const [automationTarget, setAutomationTarget] = useState("");
   const [automationRisks, setAutomationRisks] = useState<string[]>(["passive", "active_scan", "credential_use"]);
@@ -194,6 +213,11 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
     ...(scope?.allowedUrls ?? []),
     ...(scope?.allowedDomains ?? []).map((domain) => `https://${domain}/`),
   ].filter(Boolean))), [activeTab?.url, scope]);
+  const automationRuntimes = useMemo(
+    () => aiRuntimeOptions(automationProviders, automationHarnesses),
+    [automationHarnesses, automationProviders],
+  );
+  const selectedAutomationRuntime = automationRuntimes.find((runtime) => runtime.key === automationRuntimeKey);
   const activeAutomationLease = automationStatus?.leases.find((lease) => lease.sessionId === activeSession?.id && lease.status === "active");
   const scopeDecision = scopeLoading
     ? { state: "unknown" as const, label: "Checking scope", detail: "Loading the durable Project scope." }
@@ -461,10 +485,10 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
       setWorkspaceError(`The autonomous run was not started because its target is not in Project scope. ${targetDecision.detail}`);
       return;
     }
-    const provider = automationProviders.find((item) => item.id === automationProviderId);
-    const model = automationModel.trim() || provider?.effectiveDefaultModel || provider?.defaultModel || provider?.models[0] || "";
-    if (!provider || !model) {
-      setWorkspaceError("Choose a healthy, enabled model provider and model before starting the autonomous web test.");
+    const runtime = selectedAutomationRuntime;
+    const model = automationModel.trim() || runtime?.defaultModel || runtime?.models[0] || "";
+    if (!runtime || !model) {
+      setWorkspaceError("Choose a healthy provider or harness and model before starting the autonomous web test.");
       return;
     }
     const credentialRefs = automationCredentialRefs.split(",").map((value) => value.trim()).filter(Boolean);
@@ -479,8 +503,9 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
         engagementId: projectId,
         name: "Autonomous browser assessment",
         objective: `Run a bounded web application assessment for ${target}`,
-        backend: "native",
-        providerId: provider.id,
+        backend: runtime.kind === "harness" ? "harness" : "native",
+        providerId: runtime.kind === "provider" ? runtime.id : undefined,
+        harnessProfileId: runtime.kind === "harness" ? runtime.id : undefined,
         model,
         maxDurationSeconds: automationDuration * 60,
         maxToolCalls: automationMaxCommands,
@@ -514,11 +539,14 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   useEffect(() => {
     if (!desktop || !researchOpen || typeof api.listProviders !== "function") return;
     let disposed = false;
-    void api.listProviders().then((page) => {
+    void Promise.all([api.listProviders(), api.listHarnesses()]).then(([page, harnesses]) => {
       if (disposed) return;
       const available = page.items.filter((provider) => provider.enabled && provider.state !== "offline" && provider.state !== "unconfigured");
       setAutomationProviders(available);
-      setAutomationProviderId((current) => available.some((provider) => provider.id === current) ? current : available[0]?.id ?? "");
+      const availableHarnesses = harnesses.filter((harness) => harness.enabled && harness.models.length > 0);
+      setAutomationHarnesses(availableHarnesses);
+      const options = aiRuntimeOptions(available, availableHarnesses);
+      setAutomationRuntimeKey((current) => options.some((runtime) => runtime.key === current) ? current : options[0]?.key ?? "");
     }).catch((caught) => {
       void logCaughtDiagnostic("interface.security_browser.automation_provider_load_failed", "Model providers could not be loaded for the autonomous browser form.", caught, "workbench_browser");
     });
@@ -526,11 +554,10 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   }, [api, desktop, researchOpen]);
 
   useEffect(() => {
-    const provider = automationProviders.find((item) => item.id === automationProviderId);
-    if (!provider) return;
-    const defaultModel = provider.effectiveDefaultModel || provider.defaultModel || provider.models[0] || "";
-    if (!automationModel || !provider.models.includes(automationModel)) setAutomationModel(defaultModel);
-  }, [automationModel, automationProviderId, automationProviders]);
+    if (!selectedAutomationRuntime) return;
+    const defaultModel = selectedAutomationRuntime.defaultModel || selectedAutomationRuntime.models[0] || "";
+    if (!automationModel || !selectedAutomationRuntime.models.includes(automationModel)) setAutomationModel(defaultModel);
+  }, [automationModel, selectedAutomationRuntime]);
 
   useEffect(() => {
     setWorkspace(undefined);
@@ -606,11 +633,14 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
         }))
       : [blankTab()];
     setTabs(restored);
-    setActiveId(activeSession.activeTabId && restored.some((tab) => tab.id === activeSession.activeTabId)
-      ? activeSession.activeTabId
-      : restored[0].id);
+    const requestedTabId = searchParams.get("browserTab");
+    setActiveId(requestedTabId && restored.some((tab) => tab.id === requestedTabId)
+      ? requestedTabId
+      : activeSession.activeTabId && restored.some((tab) => tab.id === activeSession.activeTabId)
+        ? activeSession.activeTabId
+        : restored[0].id);
     setSessionHydrated(true);
-  }, [activeSession, projectId]);
+  }, [activeSession, projectId, searchParams]);
 
   useEffect(() => {
     const next = blankTab();
@@ -1351,7 +1381,6 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   const sessionTraffic = workspace?.traffic.filter((exchange) => exchange.sessionId === activeSession?.id) ?? [];
   const sessionAutomationCommands = automationStatus?.commands.filter((command) => command.sessionId === activeSession?.id) ?? [];
   const sessionAutomationRules = automationStatus?.rules.filter((rule) => rule.sessionId === activeSession?.id) ?? [];
-  const selectedAutomationProvider = automationProviders.find((provider) => provider.id === automationProviderId);
   const selectedExchanges = selectedExchangeIds
     .map((id) => sessionTraffic.find((exchange) => exchange.id === id))
     .filter((exchange): exchange is SecurityBrowserExchange => Boolean(exchange));
@@ -1370,12 +1399,17 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
       <button type="button" aria-label="Close research workbench" onClick={() => setResearchOpen(false)}><X size={15} /></button>
     </header>
     <nav aria-label="Research tools">
-      <button type="button" className={researchView === "traffic" ? "active" : ""} onClick={() => setResearchView("traffic")}><Network size={14} /> Traffic <span>{sessionTraffic.length}</span></button>
+      <button type="button" className={researchView === "target" ? "active" : ""} onClick={() => setResearchView("target")}>Target</button>
+      <button type="button" className={researchView === "traffic" ? "active" : ""} onClick={() => setResearchView("traffic")}><Network size={14} /> Proxy <span>{sessionTraffic.length}</span></button>
+      <button type="button" className={researchView === "intercepts" ? "active" : ""} onClick={() => setResearchView("intercepts")}>Intercept</button>
+      <button type="button" className={researchView === "repeater" ? "active" : ""} onClick={() => setResearchView("repeater")}>Repeater</button>
+      <button type="button" className={researchView === "intruder" ? "active" : ""} onClick={() => setResearchView("intruder")}>Intruder</button>
+      <button type="button" className={researchView === "utilities" ? "active" : ""} onClick={() => setResearchView("utilities")}>Decoder · Comparer · Sequencer</button>
       <button type="button" className={researchView === "actions" ? "active" : ""} onClick={() => setResearchView("actions")}><Sparkles size={14} /> Actions <span>{workspace?.actions.filter((action) => action.sessionId === activeSession?.id).length ?? 0}</span></button>
       <button type="button" className={researchView === "identities" ? "active" : ""} onClick={() => setResearchView("identities")}><UserRound size={14} /> Identities <span>{workspace?.identities.length ?? 0}</span></button>
       <button type="button" className={researchView === "session" ? "active" : ""} onClick={() => setResearchView("session")}><History size={14} /> Session</button>
     </nav>
-    {workspaceLoading ? <div className="browser-research-empty"><LoaderCircle className="spin" size={18} /> Loading durable browser state…</div> : workspaceError ? <div className="browser-research-empty error" role="alert"><strong>Research state is unavailable</strong><span>{workspaceError}</span><button className="button secondary" type="button" onClick={() => void refreshWorkspace()}>Try again</button></div> : researchView === "traffic" ? <div className="browser-traffic-workbench">
+    {workspaceLoading ? <div className="browser-research-empty"><LoaderCircle className="spin" size={18} /> Loading durable browser state…</div> : workspaceError ? <div className="browser-research-empty error" role="alert"><strong>Research state is unavailable</strong><span>{workspaceError}</span><button className="button secondary" type="button" onClick={() => void refreshWorkspace()}>Try again</button></div> : (["target", "intercepts", "repeater", "intruder", "utilities"] as const).includes(researchView as BrowserResearchToolView) ? <BrowserResearchSuite api={api} desktop={desktop} identity={activeIdentity} operatorId={operatorId} projectId={projectId} session={activeSession} view={researchView as BrowserResearchToolView} /> : researchView === "traffic" ? <div className="browser-traffic-workbench">
       <div className="browser-research-toolbar"><span>Metadata and redacted headers</span><button type="button" disabled={selectedExchangeIds.length !== 2} onClick={() => setSelectedExchangeIds([])}><GitCompareArrows size={13} /> {selectedExchangeIds.length === 2 ? "Clear comparison" : "Select two to compare"}</button></div>
       {comparison && <div className="browser-exchange-diff"><strong>Authorization response diff</strong><span>Status: {comparison.status}</span><span>Bytes: {comparison.bytes}</span><span>{comparison.changedHeaders.length ? `${comparison.changedHeaders.length} response headers changed: ${comparison.changedHeaders.join(", ")}` : "Response headers are identical."}</span></div>}
       {sessionTraffic.length ? <ol className="browser-traffic-list">{[...sessionTraffic].reverse().map((exchange) => <li key={exchange.id} className={selectedExchangeIds.includes(exchange.id) ? "selected" : ""}>
@@ -1425,13 +1459,13 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
           {!desktop ? <p className="browser-automation-mobile-note">Mobile can observe and stop an existing run. Pair a desktop browser to start or execute native commands.</p> : <button className="button primary" type="button" disabled={!activeTab?.created || scopeDecision.state !== "in_scope"} onClick={() => setAutomationFormOpen((value) => !value)}>{automationFormOpen ? "Hide start form" : "Start autonomous web test"}</button>}
           {automationFormOpen && desktop && <form className="browser-automation-form" onSubmit={startAutonomousRun}>
             <label>Target subset<select value={automationTarget} onChange={(event) => setAutomationTarget(event.target.value)} required><option value="">Choose an authorized target</option>{automationTargetOptions.map((target) => <option value={target} key={target}>{target}</option>)}</select></label>
-            <label>Model provider<select value={automationProviderId} onChange={(event) => setAutomationProviderId(event.target.value)} required><option value="">Choose an enabled provider</option>{automationProviders.map((provider) => <option key={provider.id} value={provider.id}>{provider.name} · {provider.state}</option>)}</select></label>
-            <label>Model<select value={automationModel} onChange={(event) => setAutomationModel(event.target.value)} required disabled={!selectedAutomationProvider}><option value="">Choose a verified model</option>{selectedAutomationProvider?.models.map((model) => <option key={model} value={model}>{model}</option>)}</select></label>
+            <label>Investigation runtime<select value={automationRuntimeKey} onChange={(event) => setAutomationRuntimeKey(event.target.value)} required><option value="">Choose an enabled provider or harness</option>{automationRuntimes.map((runtime) => <option key={runtime.key} value={runtime.key}>{aiRuntimeLabel(runtime)}</option>)}</select></label>
+            <label>Model<select value={automationModel} onChange={(event) => setAutomationModel(event.target.value)} required disabled={!selectedAutomationRuntime}><option value="">Choose a verified model</option>{selectedAutomationRuntime?.models.map((model) => <option key={model} value={model}>{model}</option>)}</select></label>
             <fieldset><legend>Allowed risk classes</legend>{[["passive", "Passive observation"], ["active_scan", "Active scan and replay"], ["credential_use", "Credential use by reference"]].map(([value, label]) => <label key={value}><input type="checkbox" checked={automationRisks.includes(value)} onChange={(event) => setAutomationRisks((current) => event.target.checked ? [...current, value] : current.filter((item) => item !== value))} /><span>{label}</span></label>)}</fieldset>
             {automationRisks.includes("credential_use") && <label>Credential references<input value={automationCredentialRefs} placeholder="vault:reference-1, session:reference-2" onChange={(event) => setAutomationCredentialRefs(event.target.value)} /><small>References only. Never paste a password, cookie, token, or API key.</small></label>}
             <div className="resource-form-grid"><label>Duration (minutes)<input type="number" min={1} max={60} value={automationDuration} onChange={(event) => setAutomationDuration(Number(event.target.value))} /></label><label>Tool-call budget<input type="number" min={1} max={100} value={automationMaxCommands} onChange={(event) => setAutomationMaxCommands(Number(event.target.value))} /></label><label>Request budget<input type="number" min={1} max={1000000} value={automationMaxRequests} onChange={(event) => setAutomationMaxRequests(Number(event.target.value))} /></label></div>
             <p>Exploitation, persistence, destructive actions, and scope changes require a separate durable step-up grant and are not enabled by this form.</p>
-            <button className="button primary" type="submit" disabled={automationBusy || !automationProviderId || !automationModel || !automationTarget || !automationRisks.length}>{automationBusy ? <LoaderCircle className="spin" size={14} /> : <Sparkles size={14} />} {automationBusy ? "Starting…" : "Approve and start run"}</button>
+            <button className="button primary" type="submit" disabled={automationBusy || !automationRuntimeKey || !automationModel || !automationTarget || !automationRisks.length}>{automationBusy ? <LoaderCircle className="spin" size={14} /> : <Sparkles size={14} />} {automationBusy ? "Starting…" : "Approve and start run"}</button>
           </form>}
         </>}
       </section>

--- a/ui/src/components/WorkbenchBrowser.tsx
+++ b/ui/src/components/WorkbenchBrowser.tsx
@@ -165,6 +165,10 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   useEffect(() => {
     if (!active) return;
     const next = new URLSearchParams(searchParams);
+    // The mounted browser owns these URL fields while active. Keep the parent
+    // Workbench view in the same atomic update so a stale child render cannot
+    // restore the previously selected view during mobile navigation.
+    next.set("view", "browser");
     next.set("browserTool", researchView);
     if (sessionId) next.set("browserSession", sessionId); else next.delete("browserSession");
     if (activeId) next.set("browserTab", activeId); else next.delete("browserTab");

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -461,7 +461,14 @@ async function openWorkspace(page: Page, route: string, heading: string) {
       }
     }, route);
   }
-  await expect.poll(() => page.evaluate(() => `${location.pathname}${location.search}${location.hash}`)).toBe(route);
+  if (route === "/?view=browser") {
+    await expect.poll(() => page.evaluate(() => ({
+      pathname: location.pathname,
+      view: new URLSearchParams(location.search).get("view"),
+    }))).toEqual({ pathname: "/", view: "browser" });
+  } else {
+    await expect.poll(() => page.evaluate(() => `${location.pathname}${location.search}${location.hash}`)).toBe(route);
+  }
   if (heading === "Workbench") {
     if ((page.viewportSize()?.width ?? 1_000) <= 760) {
       await expect(page.getByRole("navigation", { name: "Mobile operator navigation" })).toBeVisible({ timeout: 15_000 });


### PR DESCRIPTION
Adds the durable AI browser research foundation: Target mapping and bounded crawl jobs, protocol-aware proxy artifacts and intercept decisions, Repeater and Intruder lifecycles, Decoder/Comparer/Sequencer utilities, HAR transfer, evidence-backed finding promotion, and a normalized provider/harness runtime selector with a shared lease-bound tool gateway.\n\nVerification:\n- 57 focused Python browser, security, automation, and harness tests\n- 10 focused React browser tests\n- 8 native proxy Rust tests and 14 native browser Rust tests\n- production TypeScript/Vite build\n- calm CSS audit\n- focused real-Core Browser journey\n\nNative transport execution for the newly durable crawl, live breakpoint, grouped Repeater, and Intruder lifecycles remains follow-up work; this PR establishes the durable state, API, runtime, and operator surfaces without claiming those native paths are complete.