### PR TITLE
Fix unlimited missions without command runtime

### DIFF
--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -6095,8 +6095,19 @@ def create_app(
                 )
             except Exception as exc:
                 raise HTTPException(status_code=409, detail=str(exc)) from exc
+        default_command_runtime_ready = False
+        if (
+            request.backend == RunBackend.NATIVE
+            and request.max_tool_calls is None
+            and automation_runtime is not None
+        ):
+            default_command_runtime_ready = (
+                await automation_runtime.runtime_info()
+            ).ready
         wants_command_tools = (
-            request.max_tool_calls is None or request.max_tool_calls > 0
+            default_command_runtime_ready
+            if request.max_tool_calls is None
+            else request.max_tool_calls > 0
         )
         command_tools = (
             [RUN_COMMAND_NAME, PROCESS_IO_NAME]

--- a/tests/v3/test_automation_runtime.py
+++ b/tests/v3/test_automation_runtime.py
@@ -31,6 +31,7 @@ from nebula.v3.domain import (
     CommandExecution,
     CommandExecutionStatus,
     Engagement,
+    ProviderProfile,
     RunnerIsolation,
     RunnerProfile,
     RunnerRuntime,
@@ -733,6 +734,48 @@ def test_api_exposes_only_the_fixed_runtime_command_surface(tmp_path):
             for path in paths
             for marker in ("tool-packs", "tool-catalog", "tool-assignment")
         )
+
+
+def test_default_mission_degrades_to_analysis_when_command_runtime_is_unprepared(
+    tmp_path,
+):
+    manager, store, artifacts, engagement, _sessions = runtime(tmp_path)
+    manager.runtime_image = ""
+    manager.runtime_digest = ""
+    provider = store.create(
+        ProviderProfile(
+            name="Local analysis model",
+            provider_type="vllm",
+            endpoint="http://127.0.0.1:9/v1",
+            is_local=True,
+            model_allowlist=["security-model"],
+        )
+    )
+    app = create_app(
+        store,
+        artifact_store=artifacts,
+        auth_token="runtime-test-token",
+        automation_runtime=manager,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/missions",
+            headers={"Authorization": "Bearer runtime-test-token"},
+            json={
+                "engagement_id": engagement.id,
+                "name": "Analysis without command runtime",
+                "objective": "Review the bounded scope",
+                "provider_id": provider.id,
+                "model": "security-model",
+            },
+        )
+
+    assert response.status_code == 202, response.text
+    payload = response.json()
+    assert payload["metadata"]["analysis_only"] is True
+    assert payload["budget"]["max_duration_seconds"] is None
+    assert payload["budget"]["max_tool_calls"] is None
 
 
 def test_api_runtime_lifecycle_uses_registered_diagnostics_feature(tmp_path):

--- a/tests/v3/test_harnesses.py
+++ b/tests/v3/test_harnesses.py
@@ -967,7 +967,7 @@ def test_explicit_stop_cancels_detached_work_without_completing_it(tmp_path):
             objective="Block mission until stopped",
             profile_id=profile.id,
             model=None,
-            budget=RunBudget(max_duration_seconds=5),
+            budget=RunBudget(),
         )
         mission_task = runtime._mission_tasks[run.id]
         mission_turn = next(
@@ -994,6 +994,7 @@ def test_explicit_stop_cancels_detached_work_without_completing_it(tmp_path):
 
         assert stopped_mission.status == HarnessTurnStatus.CANCELLED
         assert store.get(AgentRun, run.id).status == RunStatus.CANCELLED
+        assert store.get(AgentRun, run.id).budget.max_duration_seconds is None
         assert any(
             event.event_type == "run.cancelled" for event in store.replay_events(run.id)
         )
@@ -2385,10 +2386,11 @@ def test_harness_api_chat_mission_handoff_and_catalog(tmp_path):
         handoff = client.post(
             f"/api/v1/chat/sessions/{body['session_id']}/continue-as-mission",
             headers=headers,
-            json={"objective": "API mission", "max_duration_seconds": 5},
+            json={"objective": "API mission"},
         )
         assert handoff.status_code == 202, handoff.text
         run_id = handoff.json()["id"]
+        assert handoff.json()["budget"]["max_duration_seconds"] is None
         for _ in range(100):
             if store.get(AgentRun, run_id).status == RunStatus.COMPLETE:
                 break

--- a/tests/v3/test_missions.py
+++ b/tests/v3/test_missions.py
@@ -531,6 +531,34 @@ def test_api_starts_explicit_analysis_mission_and_persists_events(tmp_path):
         )
 
 
+def test_api_mission_defaults_to_unlimited_duration(tmp_path):
+    store = NebulaStore(tmp_path / "unlimited.db")
+    engagement = store.create(Engagement(name="Unlimited mission"))
+    profile = _profile(store)
+    provider = RecordingProvider(profile)
+    service = MissionService(
+        store,
+        checkpoint_path=tmp_path / "unlimited-checkpoints.db",
+        provider_factory=lambda selected: provider,
+    )
+    payload = _start_payload(engagement, profile)
+    payload.pop("max_duration_seconds")
+
+    with TestClient(
+        create_app(store, auth_token="test-token", mission_service=service)
+    ) as client:
+        response = client.post("/api/v1/missions", headers=_auth(), json=payload)
+        assert response.status_code == 202, response.text
+        queued = response.json()
+        assert queued["budget"]["max_duration_seconds"] is None
+        assert _wait_for_status(client, queued["id"], "complete")["status"] == (
+            "complete"
+        )
+
+    persisted = store.get(AgentRun, queued["id"])
+    assert persisted.budget.max_duration_seconds is None
+
+
 def test_api_retry_creates_a_new_audited_run_with_frozen_runtime(tmp_path):
     store = NebulaStore(tmp_path / "retry.db")
     engagement = store.create(Engagement(name="Mission retry"))

--- a/ui/tests/real-core.spec.ts
+++ b/ui/tests/real-core.spec.ts
@@ -121,10 +121,39 @@ async function startLocalModelStub(options: { fail?: boolean } = {}): Promise<Lo
     if (request.method === "POST" && request.url === "/v1/chat/completions") {
       const chunks: Buffer[] = [];
       for await (const chunk of request) chunks.push(Buffer.from(chunk));
-      requests.push(JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>);
+      const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+      requests.push(body);
       if (stub.fail) {
         response.statusCode = 503;
         response.end(JSON.stringify({ error: { message: "deliberate acceptance failure" } }));
+        return;
+      }
+      const tools = Array.isArray(body.tools) ? body.tools as Array<{
+        function?: { name?: string; parameters?: { properties?: { nonce?: { enum?: string[] } } } };
+      }> : [];
+      const capabilityProbe = tools.find((tool) => tool.function?.name === "nebula_capability_probe");
+      const nonce = capabilityProbe?.function?.parameters?.properties?.nonce?.enum?.[0];
+      if (nonce) {
+        response.end(JSON.stringify({
+          id: "chatcmpl-real-core-probe",
+          object: "chat.completion",
+          created: 1,
+          model: "security-model",
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: null,
+              tool_calls: [{
+                id: "call-real-core-probe",
+                type: "function",
+                function: { name: "nebula_capability_probe", arguments: JSON.stringify({ nonce }) },
+              }],
+            },
+            finish_reason: "tool_calls",
+          }],
+          usage: { prompt_tokens: 12, completion_tokens: 4, total_tokens: 16 },
+        }));
         return;
       }
       response.end(JSON.stringify({
@@ -160,6 +189,73 @@ async function stopLocalModelStub(stub: LocalModelStub): Promise<void> {
     stub.server.close((error) => error ? reject(error) : resolve());
   });
 }
+
+test("production mission defaults to unlimited duration through real Core", async ({ page }) => {
+  test.setTimeout(60_000);
+  const lanAddress = localNetworkIpv4();
+  const core = await startRealCore({ bindHost: "0.0.0.0", browserHost: lanAddress });
+  const modelStub = await startLocalModelStub();
+  const api = await playwrightRequest.newContext({
+    baseURL: `${core.origin}/api/v1/`,
+    extraHTTPHeaders: { Authorization: `Bearer ${core.token}` },
+  });
+  try {
+    const engagementsResponse = await api.get("engagements");
+    expect(engagementsResponse.ok()).toBe(true);
+    const engagements = await engagementsResponse.json() as Array<{ id: string }>;
+    const projectId = engagements[0]?.id;
+    expect(projectId).toBeTruthy();
+
+    const providerResponse = await api.post("providers", { data: {
+      name: "Unlimited mission model",
+      provider_type: "vllm",
+      endpoint: `${modelStub.origin}/v1`,
+      enabled: true,
+      is_local: true,
+      model_allowlist: ["security-model"],
+      privacy: { local_only: true, residency: [], permits_sensitive_data: false },
+      metadata: { default_model: "security-model" },
+    } });
+    expect(providerResponse.ok(), await providerResponse.text()).toBe(true);
+    const provider = await providerResponse.json() as { id: string; revision: number };
+    const verificationResponse = await api.post(
+      `providers/${encodeURIComponent(provider.id)}/capabilities/verify`,
+      { data: { model: "security-model", expected_revision: provider.revision } },
+    );
+    expect(verificationResponse.ok(), await verificationResponse.text()).toBe(true);
+    expect(await verificationResponse.json()).toMatchObject({
+      verification: { model: "security-model", status: "verified" },
+    });
+
+    await page.goto(`${core.origin}/?view=missions#token=${encodeURIComponent(core.token)}`);
+    const controls = page.getByRole("region", { name: "Mission controls" });
+    await controls.getByRole("button", { name: "Automate task" }).click();
+    const dialog = page.getByRole("dialog", { name: "Automate task" });
+    await dialog.getByLabel("Mission name").fill("Unlimited production mission");
+    await dialog.getByLabel("Objective", { exact: true }).first().fill("Confirm the unlimited mission default");
+    await dialog.getByText("Advanced", { exact: true }).click();
+    await expect(dialog.getByLabel("Duration (minutes)")).toHaveValue("");
+    await expect(dialog.getByLabel("Duration (minutes)")).toHaveAttribute("placeholder", "Unlimited");
+    await dialog.getByRole("button", { name: "Automate task" }).click();
+
+    await expect.poll(async () => {
+      const response = await api.get("runs", { params: { engagement_id: projectId } });
+      expect(response.ok(), await response.text()).toBe(true);
+      const runs = await response.json() as Array<{
+        metadata?: { name?: string };
+        status: string;
+        budget: { max_duration_seconds: number | null };
+      }>;
+      const run = runs.find((item) => item.metadata?.name === "Unlimited production mission");
+      return run ? { status: run.status, duration: run.budget.max_duration_seconds } : undefined;
+    }, { timeout: 20_000 }).toEqual({ status: "complete", duration: null });
+    await expect(page.getByRole("navigation", { name: "Mission history" }).getByText("Unlimited production mission")).toBeVisible();
+  } finally {
+    await api.dispose();
+    await stopLocalModelStub(modelStub);
+    await stopRealCore(core);
+  }
+});
 
 test("production assistant preserves exact research context and relaunch-safe drafts through real Core", async ({ page }) => {
   test.setTimeout(60_000);


### PR DESCRIPTION
## Outcome

New missions keep the unlimited duration and resource defaults merged in #196, but no longer treat an omitted tool-call limit as a request to use an unavailable command runtime. If the optional command runtime is not ready, Core starts a text-only analysis mission. Explicit positive tool-call budgets retain strict command-runtime preflight.

## Coverage

- Adds an API regression for analysis-only fallback with an unprepared runner.
- Verifies default native missions persist an unlimited duration and complete.
- Verifies harness stop and chat-to-mission handoff with unlimited duration.
- Adds a production-bundle, non-loopback LAN, real-Core browser journey from the visible mission dialog through durable completion and mission history.
- Extends the local model stub with the harmless exact-model capability probe used by the real UI.

## Verification

- Python suite: 655 passed, 5 skipped.
- Frontend suite: 325 passed across 64 files.
- Production UI build: passed.
- Mission Playwright matrix: 7 passed across desktop, compact, narrow, mobile Chromium 320 and 390, and mobile WebKit 390 and 430.
- Real-Core production LAN mission journey: passed twice consecutively.
- Calm CSS and frontend diagnostic audits: passed.