### PR TITLE
Fix conversation switching and activity freshness

### DIFF
--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
     {
       name: "mobile-chromium",
       testMatch: "**/interface.spec.ts",
-      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"] },
     },
     {
@@ -52,7 +52,7 @@ export default defineConfig({
     {
       name: "mobile-chromium-small",
       testMatch: "**/interface.spec.ts",
-      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"], viewport: { width: 320, height: 700 } },
     },
     {
@@ -70,13 +70,13 @@ export default defineConfig({
     {
       name: "mobile-webkit",
       testMatch: "**/interface.spec.ts",
-      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["iPhone 13"] },
     },
     {
       name: "mobile-webkit-wide",
       testMatch: "**/interface.spec.ts",
-      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant context pack|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["iPhone 13"], viewport: { width: 430, height: 932 } },
     },
     {

--- a/ui/src/components/ActivityLedger.test.tsx
+++ b/ui/src/components/ActivityLedger.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ActivityLedger } from "./ActivityLedger";
 import type { ActivityLedgerViewModel } from "./activityLedgerModel";
 
@@ -59,6 +59,26 @@ describe("ActivityLedger", () => {
     rerender(<ActivityLedger model={model({ status: "complete", currentAction: undefined })} />);
     expect(screen.getByText("Newest first")).toBeVisible();
     expect(screen.getByRole("button", { name: "Hide activity" })).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("updates Now when a newer stream snapshot arrives", () => {
+    const { rerender } = render(<ActivityLedger model={model({ currentAction: "Reviewing AirPlay sources." })} />);
+    expect(screen.getByText("Reviewing AirPlay sources.")).toBeVisible();
+
+    rerender(<ActivityLedger model={model({ currentAction: "Saving the refreshed results." })} />);
+    expect(screen.queryByText("Reviewing AirPlay sources.")).toBeNull();
+    expect(screen.getByText("Saving the refreshed results.")).toBeVisible();
+  });
+
+  it("loads saved activity only when the audit is expanded", async () => {
+    const user = userEvent.setup();
+    const onExpandedChange = vi.fn();
+    render(<ActivityLedger model={model({ status: "complete", entries: [], currentAction: undefined, actionCount: 0, phases: [] })} onExpandedChange={onExpandedChange} emptyState={<p>Loading saved work…</p>} />);
+
+    expect(onExpandedChange).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Show activity" }));
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+    expect(screen.getByText("Loading saved work…")).toBeVisible();
   });
 
   it("keeps failures visible without opening the audit", () => {

--- a/ui/src/components/ActivityLedger.tsx
+++ b/ui/src/components/ActivityLedger.tsx
@@ -52,10 +52,14 @@ export function ActivityLedger({
   model,
   renderEntryDetails,
   renderEntryActions,
+  onExpandedChange,
+  emptyState,
 }: {
   model: ActivityLedgerViewModel;
   renderEntryDetails?: (entry: ActivityLedgerEntry) => ReactNode;
   renderEntryActions?: (entry: ActivityLedgerEntry) => ReactNode;
+  onExpandedChange?: (expanded: boolean) => void;
+  emptyState?: ReactNode;
 }) {
   const [expanded, setExpanded] = useState(false);
   const auditId = useId();
@@ -98,7 +102,11 @@ export function ActivityLedger({
           type="button"
           aria-expanded={expanded}
           aria-controls={auditId}
-          onClick={() => setExpanded((value) => !value)}
+          onClick={() => setExpanded((value) => {
+            const next = !value;
+            onExpandedChange?.(next);
+            return next;
+          })}
         >
           {expanded ? "Hide activity" : "Show activity"}
           <ChevronDown size={14} aria-hidden="true" />
@@ -123,7 +131,7 @@ export function ActivityLedger({
               </div>
             </li>;
           })}
-        </ol> : <p>No activity has been recorded yet.</p>}
+        </ol> : emptyState ?? <p>No activity has been recorded yet.</p>}
       </div>}
     </section>
   );

--- a/ui/src/components/activityLedgerModel.test.ts
+++ b/ui/src/components/activityLedgerModel.test.ts
@@ -72,6 +72,37 @@ describe("activity ledger presentation model", () => {
     expect(model.actionCount).toBe(1);
   });
 
+  it("advances Now to newer completed work instead of pinning stale streaming context", () => {
+    const model = activityLedgerFromHarness("Work summary", "streaming", [
+      harnessItem({
+        key: "goal",
+        kind: "goal",
+        title: "AirPlay research",
+        summary: "Revisit the active goal.",
+        sequence: 1,
+        goal: {
+          objective: "Revisit AirPlay research.",
+          currentStep: "Revisit the active goal.",
+          status: "running",
+          childAgents: 0,
+        },
+      }),
+      harnessItem({ key: "narrative", kind: "reasoning", title: "Revisit the active goal", status: "streaming", sequence: 2 }),
+      harnessItem({ key: "tool", kind: "tool", title: "Refresh AirPlay sources", status: "completed", sequence: 3 }),
+    ]);
+
+    expect(model.currentAction).toBe("Refresh AirPlay sources");
+  });
+
+  it("keeps unresolved operator attention ahead of newer routine activity", () => {
+    const model = activityLedgerFromHarness("Work summary", "streaming", [
+      harnessItem({ key: "approval", kind: "tool", title: "Approve network access", status: "waiting_approval", sequence: 1 }),
+      harnessItem({ key: "tool", kind: "tool", title: "Refresh local index", status: "completed", sequence: 2 }),
+    ]);
+
+    expect(model.currentAction).toBe("Approve network access");
+  });
+
   it("deduplicates replayed mission harness lifecycle updates", () => {
     const events: RunEvent[] = [
       {

--- a/ui/src/components/activityLedgerModel.ts
+++ b/ui/src/components/activityLedgerModel.ts
@@ -410,8 +410,9 @@ export function buildActivityLedger(options: {
       total: entries.length,
     }];
   });
-  const current = [...uniqueEntries].reverse().find((entry) => entry.status === "active" || entry.status === "attention" || entry.status === "failed")
-    ?? [...uniqueEntries].reverse().find((entry) => entry.countsAsAction || entry.summary);
+  const newestFirst = [...uniqueEntries].reverse();
+  const current = newestFirst.find((entry) => entry.status === "attention" || entry.status === "failed")
+    ?? newestFirst.find((entry) => entry.status === "active" || entry.countsAsAction || entry.summary);
   const goal = options.harnessItems
     ? [...options.harnessItems].reverse().find((item) => item.goal?.currentStep || item.goal?.objective)?.goal
     : undefined;
@@ -424,7 +425,7 @@ export function buildActivityLedger(options: {
     status: overallStatus(options.status, uniqueEntries),
     entries: [...uniqueEntries].reverse(),
     phases,
-    currentAction: goal?.currentStep || goal?.objective || current?.label,
+    currentAction: current?.label || goal?.currentStep || goal?.objective,
     actionCount: uniqueEntries.filter((entry) => entry.countsAsAction).length,
     attentionCount: uniqueEntries.filter((entry) => ["attention", "failed"].includes(entry.status)).length,
     artifactCount: artifacts.size,

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -497,6 +497,8 @@ export function SessionsPage() {
   const [toolCards, setToolCards] = useState<ToolLifecycleCard[]>([]);
   const [activityItems, setActivityItems] = useState<HarnessActivityItem[]>([]);
   const [harnessInteractions, setHarnessInteractions] = useState<HarnessInteraction[]>([]);
+  const [historicalActivityState, setHistoricalActivityState] = useState<Record<string, "loading" | "loaded" | "failed">>({});
+  const [historicalActivityErrors, setHistoricalActivityErrors] = useState<Record<string, string>>({});
   const [interactionAnswers, setInteractionAnswers] = useState<Record<string, string>>({});
   const [harnessControlBusy, setHarnessControlBusy] = useState(false);
   const [artifactInspector, setArtifactInspector] = useState<ToolLifecycleCard>();
@@ -535,7 +537,10 @@ export function SessionsPage() {
   const attemptedToolVerificationRef = useRef(new Set<string>());
   const runtimeDefaultEngagementRef = useRef<string | undefined>(undefined);
   const explicitNewConversationRef = useRef(false);
+  const pendingSessionNavigationRef = useRef<string | undefined>(undefined);
   const sessionSelectionGenerationRef = useRef(0);
+  const sessionLoadAbortRef = useRef<AbortController | undefined>(undefined);
+  const historicalActivityAbortRef = useRef(new Map<string, AbortController>());
   const assistantSettingsButtonRef = useRef<HTMLButtonElement>(null);
   const assistantSettingsPanelRef = useRef<HTMLElement>(null);
   const sessionActionsButtonRef = useRef<HTMLButtonElement>(null);
@@ -1008,11 +1013,15 @@ export function SessionsPage() {
   }, [canUseKnowledge, coreState, runtimeKind, selectedHarness, selectedProvider]);
 
   useEffect(() => {
+    sessionLoadAbortRef.current?.abort();
+    historicalActivityAbortRef.current.forEach((controller) => controller.abort());
+    historicalActivityAbortRef.current.clear();
     if (!detachActiveHarnessStream()) abortRef.current?.abort();
     harnessFollowDetachRef.current?.();
     harnessFollowDetachRef.current = undefined;
     setSending(false);
     setSessions([]);
+    pendingSessionNavigationRef.current = undefined;
     setSessionId("");
     setConversationOpen(Boolean(assistantDrafts.length || requestedSessionId));
     setHarnessSessionId("");
@@ -1028,6 +1037,8 @@ export function SessionsPage() {
     setToolCards([]);
     setActivityItems([]);
     setHarnessInteractions([]);
+    setHistoricalActivityState({});
+    setHistoricalActivityErrors({});
     setPendingResponse(undefined);
   }, [engagement?.id]);
 
@@ -1084,6 +1095,9 @@ export function SessionsPage() {
 
   useEffect(() => {
     return () => {
+      sessionLoadAbortRef.current?.abort();
+      historicalActivityAbortRef.current.forEach((controller) => controller.abort());
+      historicalActivityAbortRef.current.clear();
       if (!detachActiveHarnessStream()) abortRef.current?.abort();
     };
   }, []);
@@ -1132,6 +1146,11 @@ export function SessionsPage() {
 
   const resetConversation = (open: boolean) => {
     sessionSelectionGenerationRef.current += 1;
+    pendingSessionNavigationRef.current = undefined;
+    sessionLoadAbortRef.current?.abort();
+    sessionLoadAbortRef.current = undefined;
+    historicalActivityAbortRef.current.forEach((controller) => controller.abort());
+    historicalActivityAbortRef.current.clear();
     followUpAutoDrainRef.current = false;
     followUpDrainIdRef.current = undefined;
     if (!detachActiveHarnessStream()) abortRef.current?.abort();
@@ -1153,6 +1172,8 @@ export function SessionsPage() {
     setToolCards([]);
     setActivityItems([]);
     setHarnessInteractions([]);
+    setHistoricalActivityState({});
+    setHistoricalActivityErrors({});
     setPendingResponse(undefined);
   };
 
@@ -1352,39 +1373,53 @@ export function SessionsPage() {
         ? "No models discovered"
         : "Select provider first";
 
-  const restoreHarnessActivity = async (history: PersistedChatMessage[], isCurrent: () => boolean = () => true) => {
-    if (!api) return;
-    const owners = history.filter((message) => message.role === "assistant" && message.harnessTurnId);
-    if (!owners.length) {
-      if (!isCurrent()) return;
-      setActivityItems([]);
-      setHarnessInteractions([]);
-      return;
-    }
-    const restored = await Promise.all(owners.map(async (message) => {
-      const turnId = message.harnessTurnId as string;
+  const loadHistoricalHarnessActivity = async (message: ConversationMessage) => {
+    const turnId = message.harnessTurnId;
+    if (!api || !turnId || historicalActivityAbortRef.current.has(turnId) || historicalActivityState[turnId] === "loaded") return;
+    const selectionGeneration = sessionSelectionGenerationRef.current;
+    const controller = new AbortController();
+    historicalActivityAbortRef.current.set(turnId, controller);
+    setHistoricalActivityState((current) => ({ ...current, [turnId]: "loading" }));
+    setHistoricalActivityErrors((current) => {
+      const next = { ...current };
+      delete next[turnId];
+      return next;
+    });
+    try {
       const [page, interactions] = await Promise.all([
-        api.getHarnessTurnEvents(turnId),
-        api.listHarnessInteractions(turnId),
+        api.getHarnessTurnEvents(turnId, 0, controller.signal),
+        api.listHarnessInteractions(turnId, controller.signal),
       ]);
-      return { message, events: page.events, interactions };
-    }));
-    if (!isCurrent()) return;
-    let reduced: HarnessActivityItem[] = [];
-    const interactions: HarnessInteraction[] = [];
-    for (const group of restored) {
-      for (const event of group.events) {
-        if (isTimelineActivity(event)) {
-          reduced = reduceHarnessActivity(reduced, event, group.message.id);
-        }
-      }
-      interactions.push(...group.interactions);
+      if (controller.signal.aborted || sessionSelectionGenerationRef.current !== selectionGeneration) return;
+      const restored = page.events.reduce(
+        (items, event) => isTimelineActivity(event)
+          ? reduceHarnessActivity(items, event, message.id)
+          : items,
+        [] as HarnessActivityItem[],
+      );
+      setActivityItems((current) => [
+        ...current.filter((item) => item.turnId !== turnId),
+        ...restored,
+      ]);
+      setHarnessInteractions((current) => [
+        ...current.filter((interaction) => interaction.harnessTurnId !== turnId),
+        ...interactions,
+      ]);
+      setHistoricalActivityState((current) => ({ ...current, [turnId]: "loaded" }));
+    } catch (error) {
+      if (controller.signal.aborted || sessionSelectionGenerationRef.current !== selectionGeneration) return;
+      void logCaughtDiagnostic("interface.sessions_page.historical_activity", "Historical harness activity could not be loaded.", error, "sessions_page");
+      setHistoricalActivityState((current) => ({ ...current, [turnId]: "failed" }));
+      setHistoricalActivityErrors((current) => ({
+        ...current,
+        [turnId]: error instanceof Error ? error.message : "Could not load this turn's work details.",
+      }));
+    } finally {
+      if (historicalActivityAbortRef.current.get(turnId) === controller) historicalActivityAbortRef.current.delete(turnId);
     }
-    setActivityItems(reduced);
-    setHarnessInteractions(interactions);
   };
 
-  const selectSession = async (id: string) => {
+  const selectSession = async (id: string, updateUrl = true) => {
     explicitNewConversationRef.current = false;
     if (!id) {
       newConversation();
@@ -1394,25 +1429,51 @@ export function SessionsPage() {
     const selectionGeneration = sessionSelectionGenerationRef.current + 1;
     sessionSelectionGenerationRef.current = selectionGeneration;
     const selectionIsCurrent = () => sessionSelectionGenerationRef.current === selectionGeneration;
+    sessionLoadAbortRef.current?.abort();
+    historicalActivityAbortRef.current.forEach((controller) => controller.abort());
+    historicalActivityAbortRef.current.clear();
+    const loadController = new AbortController();
+    sessionLoadAbortRef.current = loadController;
     followUpAutoDrainRef.current = false;
     followUpDrainIdRef.current = undefined;
     detachActiveHarnessStream();
     setSending(false);
+    setSessionId(id);
     setConversationOpen(true);
+    if (updateUrl) {
+      pendingSessionNavigationRef.current = id;
+      openSessionChatView(id);
+    }
     setLoadingHistory(true);
     setChatError(undefined);
     setHarnessProgress(undefined);
     setHarnessActivity(undefined);
+    setMessages([]);
+    setToolCards([]);
+    setActivityItems([]);
+    setHarnessInteractions([]);
+    setHistoricalActivityState({});
+    setHistoricalActivityErrors({});
     harnessFollowDetachRef.current?.();
     harnessFollowDetachRef.current = undefined;
+    const summary = sessions.find((session) => session.id === id);
+    if (summary) {
+      setRuntimeKind(summary.backend);
+      setProviderId(summary.providerId ?? "");
+      setHarnessId(summary.harnessProfileId ?? "");
+      setHarnessSessionId(summary.harnessSessionId ?? "");
+      setModel(summary.model ?? "");
+    }
     try {
-      const summary = sessions.find((session) => session.id === id);
       const [history, pendingTurn] = await Promise.all([
-        api.listChatMessages(id),
-        api.getPendingChatTurn(id).catch((caughtError) => { void logCaughtDiagnostic("interface.sessions_page.caught_failure_08", "A handled interface operation failed.", caughtError, "sessions_page"); return undefined; }),
+        api.listChatMessages(id, loadController.signal),
+        api.getPendingChatTurn(id, loadController.signal).catch((caughtError) => {
+          if (loadController.signal.aborted) return undefined;
+          void logCaughtDiagnostic("interface.sessions_page.caught_failure_08", "A handled interface operation failed.", caughtError, "sessions_page");
+          return undefined;
+        }),
       ]);
       if (!selectionIsCurrent()) return;
-      setSessionId(id);
       setMessages(history.map(persistedMessage));
       const restoredToolCards: ToolLifecycleCard[] = history.flatMap((message) => message.role === "assistant"
         ? (message.toolResults ?? []).map((result) => ({
@@ -1428,15 +1489,7 @@ export function SessionsPage() {
           }))
         : []);
       setToolCards(restoredToolCards);
-      await restoreHarnessActivity(history, selectionIsCurrent);
-      if (!selectionIsCurrent()) return;
-      if (summary) {
-        setRuntimeKind(summary.backend);
-        setProviderId(summary.providerId ?? "");
-        setHarnessId(summary.harnessProfileId ?? "");
-        setHarnessSessionId(summary.harnessSessionId ?? "");
-        setModel(summary.model ?? "");
-      }
+      setLoadingHistory(false);
       if (pendingTurn && summary?.backend === "provider") {
         const assistantId = makeId("assistant-pending");
         const approval = approvals.find((item) => item.id === pendingTurn.approvalId);
@@ -1493,7 +1546,7 @@ export function SessionsPage() {
       } else if (pendingTurn?.harnessTurnId && summary?.backend === "harness") {
         const assistantId = makeId("assistant-harness-pending");
         const turnId = pendingTurn.harnessTurnId;
-        const page = await api.getHarnessTurnEvents(turnId);
+        const page = await api.getHarnessTurnEvents(turnId, 0, loadController.signal);
         if (!selectionIsCurrent()) return;
         setActivityItems((current) => page.events.reduce(
           (restored, event) => isTimelineActivity(event)
@@ -1501,7 +1554,7 @@ export function SessionsPage() {
             : restored,
           current,
         ));
-        const turnInteractions = await api.listHarnessInteractions(turnId);
+        const turnInteractions = await api.listHarnessInteractions(turnId, loadController.signal);
         if (!selectionIsCurrent()) return;
         setHarnessInteractions(turnInteractions);
         setMessages((current) => [...current, {
@@ -1543,7 +1596,8 @@ export function SessionsPage() {
             harnessFollowDetachRef.current = undefined;
             void api.listChatMessages(id).then(async (authoritative) => {
               setMessages(authoritative.map(persistedMessage));
-              await restoreHarnessActivity(authoritative);
+              const completedOwner = authoritative.find((message) => message.role === "assistant" && message.harnessTurnId === turnId);
+              if (completedOwner) await loadHistoricalHarnessActivity(persistedMessage(completedOwner));
               await refreshSessions(id);
             }).catch((error) => {
               void logCaughtDiagnostic("interface.sessions_page.harness_follow_complete", "A completed harness turn could not be restored.", error, "sessions_page");
@@ -1579,17 +1633,17 @@ export function SessionsPage() {
           const assistantTurnIds = new Set(history.filter((message) => message.role === "assistant").map((message) => message.harnessTurnId));
           const dangling = [...history].reverse().find((message) => message.role === "user" && message.harnessTurnId && !assistantTurnIds.has(message.harnessTurnId));
           if (dangling?.harnessTurnId) {
-            const turn = await api.getHarnessTurn(dangling.harnessTurnId);
+            const turn = await api.getHarnessTurn(dangling.harnessTurnId, loadController.signal);
             if (!selectionIsCurrent()) return;
             if (["failed", "cancelled", "interrupted"].includes(turn.status)) {
               const assistantId = makeId("assistant-harness-recovery");
-              const page = await api.getHarnessTurnEvents(turn.id);
+              const page = await api.getHarnessTurnEvents(turn.id, 0, loadController.signal);
               if (!selectionIsCurrent()) return;
               setActivityItems((current) => page.events.reduce(
                 (restored, event) => isTimelineActivity(event) ? reduceHarnessActivity(restored, event, assistantId) : restored,
                 current,
               ));
-              const interruptedInteractions = await api.listHarnessInteractions(turn.id);
+              const interruptedInteractions = await api.listHarnessInteractions(turn.id, loadController.signal);
               if (!selectionIsCurrent()) return;
               setHarnessInteractions(interruptedInteractions);
               setMessages((current) => [...current, {
@@ -1608,14 +1662,16 @@ export function SessionsPage() {
         }
       }
       if (!selectionIsCurrent()) return;
-      openSessionChatView(id);
       setMobileListOpen(false);
     } catch (error) {
-      if (!selectionIsCurrent()) return;
+      if (!selectionIsCurrent() || loadController.signal.aborted) return;
       void logCaughtDiagnostic("interface.sessions_page.caught_failure_10", "A handled interface operation failed.", error, "sessions_page");
       setChatError(error instanceof Error ? error.message : "Could not load the selected conversation.");
     } finally {
-      if (selectionIsCurrent()) setLoadingHistory(false);
+      if (selectionIsCurrent()) {
+        if (sessionLoadAbortRef.current === loadController) sessionLoadAbortRef.current = undefined;
+        setLoadingHistory(false);
+      }
     }
   };
 
@@ -1655,13 +1711,18 @@ export function SessionsPage() {
   };
 
   useEffect(() => {
+    const pendingNavigation = pendingSessionNavigationRef.current;
+    if (pendingNavigation) {
+      if (requestedSessionId === pendingNavigation) pendingSessionNavigationRef.current = undefined;
+      else return;
+    }
     if (!requestedSessionId) {
       explicitNewConversationRef.current = false;
       return;
     }
     if (explicitNewConversationRef.current) return;
     if (!requestedSessionId || requestedSessionId === sessionId || !api || !sessions.some((session) => session.id === requestedSessionId)) return;
-    void selectSession(requestedSessionId);
+    void selectSession(requestedSessionId, false);
   }, [api, requestedSessionId, sessionId, sessions]);
 
   useEffect(() => {
@@ -1686,7 +1747,10 @@ export function SessionsPage() {
       setSessionId(id);
       setConversationOpen(true);
       setMessages(history.map(persistedMessage));
-      await restoreHarnessActivity(history);
+      setActivityItems([]);
+      setHarnessInteractions([]);
+      setHistoricalActivityState({});
+      setHistoricalActivityErrors({});
       if (summary) {
         setRuntimeKind(summary.backend);
         setProviderId(summary.providerId ?? "");
@@ -3026,11 +3090,16 @@ export function SessionsPage() {
                   if (!message) return null;
                   const messageActivityItems = activityItems.filter((item) => item.assistantId === message.id && shouldShowActivityItem(item));
                   const messageToolCards = toolCards.filter((card) => card.assistantId === message.id);
+                  const historicalTurnId = message.durable ? message.harnessTurnId : undefined;
+                  const historicalState = historicalTurnId ? historicalActivityState[historicalTurnId] : undefined;
+                  const historicalError = historicalTurnId ? historicalActivityErrors[historicalTurnId] : undefined;
                   const activityLedger = messageActivityItems.length > 0
                     ? activityLedgerFromHarness("Work summary", message.state, messageActivityItems)
                     : messageToolCards.length > 0
                       ? activityLedgerFromNative("Work summary", message.state, messageToolCards)
-                      : undefined;
+                      : historicalTurnId
+                        ? activityLedgerFromHarness("Work summary", message.state, [])
+                        : undefined;
                   return (
                   <article
                     className={`chat-message ${message.role === "user" ? "operator" : "assistant"}`}
@@ -3047,6 +3116,14 @@ export function SessionsPage() {
                       {api && message.contentBlocks?.filter((block) => block.type === "image").map((block, index) => <AuthenticatedChatImage api={api} block={block} key={`${block.artifactId ?? "image"}-${index}`} />)}
                       {activityLedger && <ActivityLedger
                         model={activityLedger}
+                        onExpandedChange={historicalTurnId ? (expanded) => {
+                          if (expanded) void loadHistoricalHarnessActivity(message);
+                        } : undefined}
+                        emptyState={historicalState === "loading"
+                          ? <div className="chat-thinking"><LoaderCircle className="spin" size={14} /> Loading saved work…</div>
+                          : historicalState === "failed" && historicalError
+                            ? <div className="harness-activity-load-error"><DiagnosticErrorNotice error={historicalError} fallback="Could not load this turn's work details." compact /><button className="button quiet" type="button" onClick={() => void loadHistoricalHarnessActivity(message)}>Retry work details</button></div>
+                            : undefined}
                         renderEntryDetails={(entry) => <AssistantLedgerEntryDetails entry={entry} />}
                         renderEntryActions={(entry) => {
                           const item = entry.sourceItem;

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -1949,6 +1949,136 @@ test("New chat detaches from an in-flight saved conversation load", async ({ pag
   await expect.poll(() => new URL(page.url()).searchParams.get("session")).toBeNull();
 });
 
+test("conversation switching commits URL identity before loading and defers saved work details", async ({ page }) => {
+  const sourceSessionId = "chat-switch-source";
+  const targetSessionId = "chat-switch-target";
+  let sourceMessageLoads = 0;
+  let targetActivityLoads = 0;
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    if (path.endsWith("/chat-sessions")) {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([
+        {
+          ...entity,
+          id: targetSessionId,
+          engagement_id: "scratch-project",
+          title: "Target conversation",
+          backend: "harness",
+          harness_profile_id: "harness-ready",
+          harness_session_id: "harness-session-target",
+          model: "gpt-5-codex",
+          metadata: {},
+        },
+        {
+          ...entity,
+          id: sourceSessionId,
+          engagement_id: "scratch-project",
+          title: "Source conversation",
+          backend: "harness",
+          harness_profile_id: "harness-ready",
+          harness_session_id: "harness-session-source",
+          model: "gpt-5-codex",
+          metadata: {},
+        },
+      ]) });
+      return;
+    }
+    if (path.endsWith(`/chat/sessions/${sourceSessionId}/messages`)) {
+      sourceMessageLoads += 1;
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([{
+        ...entity,
+        id: "assistant-switch-source",
+        engagement_id: "scratch-project",
+        session_id: sourceSessionId,
+        sequence: 1,
+        role: "assistant",
+        content: "Source transcript",
+        citations: [],
+        metadata: { harness_turn_id: "turn-switch-source" },
+      }]) });
+      return;
+    }
+    if (path.endsWith(`/chat/sessions/${targetSessionId}/messages`)) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([{
+        ...entity,
+        id: "assistant-switch-target",
+        engagement_id: "scratch-project",
+        session_id: targetSessionId,
+        sequence: 1,
+        role: "assistant",
+        content: "Target transcript",
+        citations: [],
+        metadata: { harness_turn_id: "turn-switch-target" },
+      }]) });
+      return;
+    }
+    if (path.endsWith("/pending-turn")) {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "null" });
+      return;
+    }
+    if (path.includes("/harness-sessions/") && path.endsWith("/activity")) {
+      const target = path.includes("harness-session-target");
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({
+        session_id: target ? "harness-session-target" : "harness-session-source",
+        session_status: "idle",
+        busy: false,
+        live: true,
+        turn_id: null,
+        turn_status: null,
+        turn_origin: null,
+        started_at: null,
+        last_activity_at: entity.updated_at,
+        detail: "This harness session is idle.",
+      }) });
+      return;
+    }
+    if (path.endsWith("/harness-turns/turn-switch-target/events")) {
+      targetActivityLoads += 1;
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({
+        events: [{
+          id: "event-switch-target",
+          schema_version: "nebula.harness-activity/v1",
+          sequence: 1,
+          type: "item_upsert",
+          vendor: "codex_app_server",
+          harness_session_id: "harness-session-target",
+          harness_turn_id: "turn-switch-target",
+          item_id: "command-switch-target",
+          item_kind: "command",
+          item_status: "completed",
+          title: "Deferred command",
+          artifact_ids: [],
+          payload: {},
+        }],
+        next_sequence: 1,
+      }) });
+      return;
+    }
+    if (path.endsWith("/harness-turns/turn-switch-target/interactions")) {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await openWorkspace(page, `/?view=chat&session=${sourceSessionId}`, "Workbench");
+  await expect(page.getByText("Source transcript")).toBeVisible();
+  if ((page.viewportSize()?.width ?? 1_000) <= 760) await page.getByRole("button", { name: "Open conversations", exact: true }).click();
+  else await page.getByRole("button", { name: "Show conversations" }).click();
+  await page.locator(".session-select").filter({ hasText: "Target conversation" }).click();
+
+  await expect.poll(() => new URL(page.url()).searchParams.get("session")).toBe(targetSessionId);
+  await expect(page.locator(".session-list-item.active")).toContainText("Target conversation");
+  await expect(page.getByText("Target transcript")).toBeVisible();
+  expect(sourceMessageLoads).toBe(1);
+  expect(targetActivityLoads).toBe(0);
+
+  await page.locator(".chat-message.assistant").filter({ hasText: "Target transcript" }).getByRole("button", { name: "Show activity" }).click();
+  await expect(page.getByText("Deferred command")).toBeVisible();
+  expect(targetActivityLoads).toBe(1);
+});
+
 test("harness model controls expose only the selected runtime's advertised options", async ({ page }, testInfo) => {
   const harnesses = [{
     ...entity,
@@ -2260,10 +2390,26 @@ test("oversized harness activity fails compactly without blocking mobile chat", 
       await route.fulfill({ status: 200, contentType: "application/json", body: "null" });
       return;
     }
+    if (path.endsWith("/harness-sessions/session-verbose/activity")) {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({
+        session_id: "session-verbose",
+        session_status: "idle",
+        busy: false,
+        live: true,
+        turn_id: null,
+        turn_status: null,
+        turn_origin: null,
+        started_at: null,
+        last_activity_at: entity.updated_at,
+        detail: "This harness session is idle.",
+      }) });
+      return;
+    }
     await route.fallback();
   });
 
   await openWorkspace(page, "/?view=chat&session=chat-verbose-activity", "Workbench");
+  await page.getByRole("button", { name: "Show activity" }).click();
   const notice = page.locator(".chat-panel .diagnostic-error-notice.compact");
   await expect(notice).toBeVisible();
   await expect(notice.locator("strong")).toHaveText("The supplied summary exceeded its validated length limit.");
@@ -2290,6 +2436,7 @@ test("oversized harness activity fails compactly without blocking mobile chat", 
 test("activity ledger groups repeated work into a compact operator receipt", async ({ page }, testInfo) => {
   test.skip(!["desktop", "compact", "narrow"].includes(testInfo.project.name) && !testInfo.project.name.startsWith("mobile-"), "Covered by permanent desktop and mobile browser projects.");
   const turnId = "turn-activity-ledger";
+  let activityLoads = 0;
   await page.route("**/api/v1/**", async (route) => {
     const path = new URL(route.request().url()).pathname;
     if (path.endsWith("/chat-sessions")) {
@@ -2321,6 +2468,7 @@ test("activity ledger groups repeated work into a compact operator receipt", asy
       return;
     }
     if (path.endsWith(`/harness-turns/${turnId}/events`)) {
+      activityLoads += 1;
       const events = Array.from({ length: 36 }, (_, index) => ({
         id: `activity-${index + 1}`,
         type: "item_upsert",
@@ -2369,8 +2517,8 @@ test("activity ledger groups repeated work into a compact operator receipt", asy
 
   await openWorkspace(page, "/?view=chat&session=chat-activity-ledger", "Workbench");
   const ledger = page.getByRole("region", { name: "Work summary" });
-  await expect(ledger.getByText(/36 actions/).first()).toBeVisible();
-  await expect(ledger).not.toContainText("item upsert");
+  await expect(ledger.getByText(/0 actions/).first()).toBeVisible();
+  expect(activityLoads).toBe(0);
   const showActivity = ledger.getByRole("button", { name: "Show activity" });
   if (testInfo.project.name.startsWith("mobile-") || testInfo.project.name === "narrow") {
     const bounds = await showActivity.boundingBox();
@@ -2389,7 +2537,10 @@ test("activity ledger groups repeated work into a compact operator receipt", asy
   const accessibility = await new AxeBuilder({ page }).include(".activity-ledger").analyze();
   expect(accessibility.violations).toEqual([]);
   await showActivity.click();
+  await expect(ledger.getByText(/36 actions/).first()).toBeVisible();
+  await expect(ledger).not.toContainText("item upsert");
   await expect(ledger.locator(".activity-ledger-audit > ol > li")).toHaveCount(36);
+  expect(activityLoads).toBe(1);
 });
 
 test("native assistant tools use the shared activity ledger", async ({ page }, testInfo) => {

--- a/ui/tests/real-core.spec.ts
+++ b/ui/tests/real-core.spec.ts
@@ -242,6 +242,18 @@ test("production assistant preserves exact research context and relaunch-safe dr
       }],
     });
 
+    const switchTargetResponse = await api.post("chat/completions", { data: {
+      backend: "provider",
+      provider_id: provider.id,
+      model: "security-model",
+      engagement_id: projectId,
+      messages: [{ role: "user", content: "Switch target conversation" }],
+      include_knowledge: false,
+      stream: false,
+    } });
+    expect(switchTargetResponse.ok(), await switchTargetResponse.text()).toBe(true);
+    const switchTarget = await switchTargetResponse.json() as { session_id: string };
+
     const assistantUrl = `${core.origin}/?view=chat&session=${encodeURIComponent(completion.session_id)}#token=${encodeURIComponent(core.token)}`;
     await page.goto(assistantUrl);
     await expect(page.getByText("Real Core retained the exact research context.")).toBeVisible({ timeout: 20_000 });
@@ -266,6 +278,12 @@ test("production assistant preserves exact research context and relaunch-safe dr
     const savedSession = sessions.find((session) => session.id === completion.session_id);
     expect(savedSession).toBeTruthy();
     expect(savedSession!.title).toBe("Review the exact 443/tcp observation.");
+    await page.locator(".session-select").filter({ hasText: "Switch target conversation" }).click();
+    await expect.poll(() => new URL(page.url()).searchParams.get("session")).toBe(switchTarget.session_id);
+    await expect(page.locator(".chat-message.operator").getByText("Switch target conversation", { exact: true })).toBeVisible();
+    await page.locator(".session-select").filter({ hasText: savedSession!.title }).click();
+    await expect.poll(() => new URL(page.url()).searchParams.get("session")).toBe(completion.session_id);
+    await expect(page.locator(".chat-message.operator").getByText("Review the exact 443/tcp observation.", { exact: true })).toBeVisible();
     const activeConversation = page.locator(".session-list-item.active");
     const activeConversationActions = page.locator(".session-list-item.active .session-actions-trigger");
     await activeConversation.hover();


### PR DESCRIPTION
## Summary
- commit conversation identity and URL atomically, cancel stale loads, and render transcripts before supplemental recovery work
- lazy-load durable harness activity from the unified ledger instead of fetching every historical event during conversation switching
- advance the live **Now** label to newer meaningful activity while preserving unresolved approvals and failures
- cover desktop, compact, 320–430 px Chromium/WebKit, and production real-Core LAN workflows

## Verification
- `npm test` — 338 passed
- `npm run audit:diagnostics`
- `npm run audit:css`
- `npm run build`
- targeted Playwright desktop — 3 passed
- targeted responsive Playwright — 19 passed, 2 intentionally skipped
- production real-Core Playwright on non-loopback LAN origin — 1 passed
