### PR TITLE
Let operators load more host project folders

### DIFF
--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -5098,6 +5098,8 @@ def create_app(
     )
     async def list_host_workspace_folders(
         path: str | None = Query(default=None, max_length=4096),
+        offset: int = Query(default=0, ge=0),
+        limit: int = Query(default=500, ge=1, le=500),
     ) -> dict[str, Any]:
         requested = Path(path).expanduser() if path else Path.home()
         if not requested.is_absolute():
@@ -5111,16 +5113,23 @@ def create_app(
         if not current.is_dir():
             raise HTTPException(status_code=422, detail="selected path is not a folder")
         directories: list[dict[str, str]] = []
+        directory_index = 0
         try:
             with os.scandir(current) as entries:
-                for entry in sorted(entries, key=lambda item: item.name.casefold()):
-                    if len(directories) >= 500:
-                        break
+                for entry in sorted(
+                    entries, key=lambda item: (item.name.casefold(), item.name)
+                ):
                     try:
                         if entry.is_dir(follow_symlinks=False):
+                            if directory_index < offset:
+                                directory_index += 1
+                                continue
                             directories.append(
                                 {"name": entry.name, "path": str(current / entry.name)}
                             )
+                            directory_index += 1
+                            if len(directories) > limit:
+                                break
                     except OSError:
                         # diagnostic-expected: an unreadable entry is omitted from the bounded browser.
                         continue
@@ -5128,12 +5137,15 @@ def create_app(
             raise HTTPException(
                 status_code=403, detail="folder cannot be listed"
             ) from exc
+        has_more = len(directories) > limit
+        page = directories[:limit]
         parent = None if current.parent == current else str(current.parent)
         return {
             "path": str(current),
             "parent": parent,
-            "directories": directories,
-            "truncated": len(directories) >= 500,
+            "directories": page,
+            "truncated": has_more,
+            "next_offset": offset + len(page) if has_more else None,
         }
 
     @app.post(

--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -5192,7 +5192,9 @@ def create_app(
         finally:
             if descriptor is not None:
                 os.close(descriptor)
-        return await list_host_workspace_folders(str(parent / request.name))
+        return await list_host_workspace_folders(
+            str(parent / request.name), offset=0, limit=500
+        )
 
     @app.get(
         f"{API_PREFIX}/engagements/{{engagement_id}}/workspace",

--- a/tests/v3/test_workspace.py
+++ b/tests/v3/test_workspace.py
@@ -464,6 +464,46 @@ def test_host_workspace_folder_browser_creates_one_bounded_child(tmp_path):
     assert not (tmp_path / "nested").exists()
 
 
+def test_host_workspace_folder_browser_paginates_all_directories(tmp_path):
+    _store, _artifacts, _platform, _workspace, _engagement, client = _services(tmp_path)
+    browse_root = tmp_path / "many-projects"
+    browse_root.mkdir()
+    for index in range(503):
+        (browse_root / f"project-{index:03d}").mkdir()
+
+    first = client.get(
+        "/api/v1/workspace-folders",
+        params={"path": str(browse_root), "limit": 500},
+        headers=AUTH,
+    )
+    assert first.status_code == 200
+    first_listing = first.json()
+    assert len(first_listing["directories"]) == 500
+    assert first_listing["directories"][0]["name"] == "project-000"
+    assert first_listing["directories"][-1]["name"] == "project-499"
+    assert first_listing["next_offset"] == 500
+    assert first_listing["truncated"] is True
+
+    second = client.get(
+        "/api/v1/workspace-folders",
+        params={
+            "path": str(browse_root),
+            "offset": first_listing["next_offset"],
+            "limit": 500,
+        },
+        headers=AUTH,
+    )
+    assert second.status_code == 200
+    second_listing = second.json()
+    assert [directory["name"] for directory in second_listing["directories"]] == [
+        "project-500",
+        "project-501",
+        "project-502",
+    ]
+    assert second_listing["next_offset"] is None
+    assert second_listing["truncated"] is False
+
+
 def test_promotion_survives_symlink_safe_workspace_reset(tmp_path):
     store, artifacts, platform, workspace, engagement, client = _services(tmp_path)
     root = platform.workspace_for(engagement.id)

--- a/ui/src/api/client.test.ts
+++ b/ui/src/api/client.test.ts
@@ -1635,6 +1635,28 @@ describe("ApiClient", () => {
     );
   });
 
+  it("requests and maps a later host-folder page", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
+      path: "/projects",
+      parent: "/",
+      directories: [{ name: "project-500", path: "/projects/project-500" }],
+      truncated: false,
+      next_offset: null,
+    }), { status: 200 }));
+    const client = new ApiClient({ baseUrl: "http://127.0.0.1:8765", fetch: fetchMock });
+
+    await expect(client.listHostWorkspaceFolders("/projects", 500)).resolves.toEqual({
+      path: "/projects",
+      parent: "/",
+      directories: [{ name: "project-500", path: "/projects/project-500" }],
+      truncated: false,
+      nextOffset: undefined,
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "http://127.0.0.1:8765/api/v1/workspace-folders?path=%2Fprojects&offset=500",
+    );
+  });
+
   it("maps bounded VS Code launch profiles and preserves disabled reasons", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
       engagement_id: "project/one",

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -7108,21 +7108,27 @@ export class ApiClient {
     ).then(mapSourceControlDiff);
   }
 
-  listHostWorkspaceFolders(path?: string): Promise<{
+  listHostWorkspaceFolders(path?: string, offset = 0): Promise<{
     path: string;
     parent?: string;
     directories: Array<{ name: string; path: string }>;
     truncated: boolean;
+    nextOffset?: number;
   }> {
-    const query = path ? `?path=${encodeURIComponent(path)}` : "";
+    const parameters = new URLSearchParams();
+    if (path) parameters.set("path", path);
+    if (offset > 0) parameters.set("offset", String(offset));
+    const query = parameters.size ? `?${parameters}` : "";
     return this.request<{
       path: string;
       parent?: string | null;
       directories: Array<{ name: string; path: string }>;
       truncated: boolean;
-    }>(`workspace-folders${query}`).then((value) => ({
+      next_offset?: number | null;
+    }>(`workspace-folders${query}`).then(({ parent, next_offset, ...value }) => ({
       ...value,
-      parent: value.parent ?? undefined,
+      parent: parent ?? undefined,
+      nextOffset: next_offset ?? undefined,
     }));
   }
 

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -1942,7 +1942,10 @@ button.harness-status-summary:focus-visible { outline: 2px solid var(--focus); o
 .host-folder-state { display: grid; min-height: 180px; place-items: center; align-content: center; gap: 9px; padding: 22px; color: var(--muted); text-align: center; }
 .host-folder-state.error { color: var(--red); }
 .host-folder-state.error span { max-width: 440px; color: var(--muted); overflow-wrap: anywhere; }
-.host-folder-truncated { padding: 0 22px 8px; color: var(--muted); }
+.host-folder-truncated { display: flex; min-width: 0; min-height: 44px; align-items: center; justify-content: space-between; gap: 12px; padding: 4px 16px 8px 22px; color: var(--muted); font-size: 11px; }
+.host-folder-truncated > span { min-width: 0; overflow-wrap: anywhere; }
+.host-folder-truncated.error > span { color: var(--red); }
+.host-folder-truncated .button { flex: 0 0 auto; min-height: 36px; }
 .host-folder-dialog > footer { display: grid; min-width: 0; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 12px; padding: 13px 16px; border-top: 1px solid var(--border-soft); background: var(--surface-raised); }
 .host-folder-dialog > footer > span { min-width: 0; color: var(--muted); font-size: 11px; text-align: right; }
 .confirmation-dialog > header { display: grid; grid-template-columns: 38px 1fr 32px; gap: 12px; align-items: start; padding: 22px; }
@@ -2089,6 +2092,8 @@ button.harness-status-summary:focus-visible { outline: 2px solid var(--focus); o
   .host-folder-create .button { min-height: 44px; justify-content: center; }
   .host-folder-list { padding: 6px; }
   .host-folder-list > button { min-height: 48px; padding-inline: 10px; }
+  .host-folder-truncated { min-height: 48px; padding: 4px 10px 6px 16px; }
+  .host-folder-truncated .button { min-height: 44px; }
   .host-folder-dialog > footer { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 8px; padding: 10px; padding-bottom: calc(10px + env(safe-area-inset-bottom)); }
   .host-folder-dialog > footer > span { display: none; }
   .host-folder-dialog > footer .button { min-width: 0; width: 100%; min-height: 48px; justify-content: center; padding-inline: 8px; }

--- a/ui/src/components/HostFolderPicker.test.tsx
+++ b/ui/src/components/HostFolderPicker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { FormEvent } from "react";
@@ -69,5 +69,41 @@ describe("HostFolderPicker", () => {
     await user.click(screen.getByRole("button", { name: "Create folder" }));
     await waitFor(() => expect(createHostWorkspaceFolder).toHaveBeenLastCalledWith("/srv/projects", "acme-review-2"));
     expect(screen.getByRole("dialog", { name: "Choose project folder" })).toHaveTextContent("/srv/projects/acme-review-2");
+  });
+
+  it("loads every page without duplicates and keeps a failed continuation retryable", async () => {
+    const firstPage = Array.from({ length: 500 }, (_, index) => ({
+      name: `project-${index.toString().padStart(3, "0")}`,
+      path: `/projects/project-${index.toString().padStart(3, "0")}`,
+    }));
+    const listHostWorkspaceFolders = vi.fn()
+      .mockResolvedValueOnce({ path: "/projects", parent: "/", directories: firstPage, truncated: true, nextOffset: 500 })
+      .mockRejectedValueOnce(new Error("folder page could not be listed"))
+      .mockResolvedValueOnce({
+        path: "/projects",
+        parent: "/",
+        directories: [firstPage[499], { name: "project-500", path: "/projects/project-500" }],
+        truncated: false,
+      });
+    const api = { listHostWorkspaceFolders } as unknown as ApiClient;
+    const user = userEvent.setup();
+    render(<HostFolderPicker api={api} value="/projects" onSelect={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Browse folders" }));
+    const dialog = await screen.findByRole("dialog", { name: "Choose project folder" });
+    const loadMore = within(dialog).getByRole("button", { name: "Load more folders" });
+    expect(within(dialog).getByText("500 folders shown.")).toBeVisible();
+
+    await user.click(loadMore);
+    expect(await within(dialog).findByRole("alert")).toHaveTextContent("folder page could not be listed");
+    expect(within(dialog).getByRole("button", { name: "Try loading more again" })).toHaveFocus();
+
+    await user.click(within(dialog).getByRole("button", { name: "Try loading more again" }));
+    expect(await within(dialog).findByRole("button", { name: "project-500" })).toBeVisible();
+    expect(within(dialog).getAllByRole("button", { name: "project-499" })).toHaveLength(1);
+    expect(within(dialog).queryByRole("button", { name: "Load more folders" })).not.toBeInTheDocument();
+    expect(listHostWorkspaceFolders).toHaveBeenNthCalledWith(1, "/projects");
+    expect(listHostWorkspaceFolders).toHaveBeenNthCalledWith(2, "/projects", 500);
+    expect(listHostWorkspaceFolders).toHaveBeenNthCalledWith(3, "/projects", 500);
   });
 });

--- a/ui/src/components/HostFolderPicker.tsx
+++ b/ui/src/components/HostFolderPicker.tsx
@@ -10,6 +10,7 @@ interface FolderListing {
   parent?: string;
   directories: Array<{ name: string; path: string }>;
   truncated: boolean;
+  nextOffset?: number;
 }
 
 export function HostFolderPicker({ api, value, onSelect }: {
@@ -20,15 +21,18 @@ export function HostFolderPicker({ api, value, onSelect }: {
   const [open, setOpen] = useState(false);
   const [listing, setListing] = useState<FolderListing>();
   const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string>();
   const [newFolderOpen, setNewFolderOpen] = useState(false);
   const [newFolderName, setNewFolderName] = useState("");
   const [creatingFolder, setCreatingFolder] = useState(false);
   const [createError, setCreateError] = useState<string>();
+  const [loadMoreError, setLoadMoreError] = useState<string>();
   const browseButtonRef = useRef<HTMLButtonElement>(null);
   const folderListRef = useRef<HTMLDivElement>(null);
   const newFolderInputRef = useRef<HTMLInputElement>(null);
   const retryButtonRef = useRef<HTMLButtonElement>(null);
+  const retryLoadMoreButtonRef = useRef<HTMLButtonElement>(null);
   const selectButtonRef = useRef<HTMLButtonElement>(null);
 
   const load = async (path?: string, moveFocus = false) => {
@@ -40,6 +44,7 @@ export function HostFolderPicker({ api, value, onSelect }: {
     }
     setLoading(true);
     setError(undefined);
+    setLoadMoreError(undefined);
     try {
       setListing(await api.listHostWorkspaceFolders(path));
       if (moveFocus) requestAnimationFrame(() => {
@@ -56,6 +61,30 @@ export function HostFolderPicker({ api, value, onSelect }: {
     }
   };
 
+  const loadMore = async () => {
+    if (!api || !listing?.truncated || listing.nextOffset === undefined) return;
+    const { path, nextOffset } = listing;
+    setLoadingMore(true);
+    setLoadMoreError(undefined);
+    try {
+      const page = await api.listHostWorkspaceFolders(path, nextOffset);
+      setListing((current) => {
+        if (!current || current.path !== page.path) return current;
+        const known = new Set(current.directories.map((directory) => directory.path));
+        return {
+          ...page,
+          directories: [...current.directories, ...page.directories.filter((directory) => !known.has(directory.path))],
+        };
+      });
+    } catch (caught) {
+      logCaughtDiagnostic("interface.host_folder.page_failed", "More host workspace folders could not be listed.", caught, "host-folder-picker");
+      setLoadMoreError(caught instanceof Error ? caught.message : "More folders could not be listed.");
+      requestAnimationFrame(() => retryLoadMoreButtonRef.current?.focus());
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
   const openBrowser = () => {
     setOpen(true);
     void load(value?.trim() || listing?.path);
@@ -67,6 +96,7 @@ export function HostFolderPicker({ api, value, onSelect }: {
     setNewFolderOpen(false);
     setNewFolderName("");
     setCreateError(undefined);
+    setLoadMoreError(undefined);
     requestAnimationFrame(() => browseButtonRef.current?.focus());
   };
 
@@ -142,7 +172,11 @@ export function HostFolderPicker({ api, value, onSelect }: {
           {!loading && !error && listing?.directories.map((directory) => <button type="button" key={directory.path} title={directory.path} onClick={() => void load(directory.path, true)}><Folder size={18} /><span>{directory.name}</span><ChevronRight size={16} /></button>)}
           {!loading && !error && listing && !listing.directories.length && <div className="host-folder-state"><FolderOpen size={20} /><span>This folder has no child folders.</span></div>}
         </div>
-        {listing?.truncated && <small className="host-folder-truncated">Showing the first 500 folders.</small>}
+        {!loading && !error && listing?.truncated && <div className={`host-folder-truncated${loadMoreError ? " error" : ""}`}>
+          {loadMoreError
+            ? <><span role="alert">More folders could not be loaded. {loadMoreError}</span><button ref={retryLoadMoreButtonRef} className="button quiet" type="button" aria-label="Try loading more again" disabled={loadingMore} onClick={() => void loadMore()}>{loadingMore ? <LoaderCircle className="spin" size={14} /> : null} Try again</button></>
+            : <><span>{listing.directories.length.toLocaleString()} folders shown.</span><button className="button quiet" type="button" aria-label="Load more folders" disabled={loadingMore} onClick={() => void loadMore()}>{loadingMore ? <LoaderCircle className="spin" size={14} /> : null} {loadingMore ? "Loading more…" : "Load more"}</button></>}
+        </div>}
         <footer>
           <button className="button secondary" type="button" disabled={!listing?.parent || loading} onClick={() => void load(listing?.parent, true)}><ArrowUp size={16} /> Up one level</button>
           <span>{listing?.path === "/" ? "The filesystem root cannot be used as a project folder." : "Select the folder shown above."}</span>

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -250,14 +250,19 @@ async function installTruthfulCore(page: Page) {
         body = { path: `${create.parent_path}/${create.name}`, parent: create.parent_path, directories: [], truncated: false };
       } else {
         const requested = url.searchParams.get("path") ?? "/home/agent";
+        const offset = Number(url.searchParams.get("offset") ?? "0");
         body = {
           path: requested,
           parent: requested === "/home/agent" ? "/home" : "/home/agent",
-          directories: requested === "/home/agent" ? [{
+          directories: requested === "/home/agent" && offset === 0 ? [{
             name: "a-very-long-project-folder-name-that-must-not-expand-the-dialog",
             path: "/home/agent/a-very-long-project-folder-name-that-must-not-expand-the-dialog",
+          }] : requested === "/home/agent" ? [{
+            name: "z-folder-loaded-from-the-next-page",
+            path: "/home/agent/z-folder-loaded-from-the-next-page",
           }] : [],
-          truncated: false,
+          truncated: requested === "/home/agent" && offset === 0,
+          next_offset: requested === "/home/agent" && offset === 0 ? 1 : null,
         };
       }
     } else if (path.endsWith("/engagements/scratch-project/scope")) {
@@ -1856,6 +1861,12 @@ test("host folder picker remains usable as a bounded project workflow", async ({
   await expect(dialog.getByText("/home/agent/fresh-assessment", { exact: true })).toBeVisible();
   await expect(dialog.getByRole("button", { name: "Select folder" })).toBeFocused();
   await dialog.getByRole("button", { name: "Up one level" }).click();
+
+  const loadMore = dialog.getByRole("button", { name: "Load more folders" });
+  await expect(loadMore).toBeVisible();
+  await loadMore.click();
+  await expect(dialog.getByRole("button", { name: "z-folder-loaded-from-the-next-page" })).toBeVisible();
+  await expect(loadMore).toHaveCount(0);
 
   await dialog.getByRole("button", { name: "a-very-long-project-folder-name-that-must-not-expand-the-dialog" }).click();
   await expect(dialog.getByText("/home/agent/a-very-long-project-folder-name-that-must-not-expand-the-dialog", { exact: true })).toBeVisible();

--- a/ui/tests/real-core.spec.ts
+++ b/ui/tests/real-core.spec.ts
@@ -1175,6 +1175,8 @@ test("real Core persists a project folder chosen through the host browser", asyn
   const core = await startRealCore(lanAddress ? { bindHost: "0.0.0.0", browserHost: lanAddress } : {});
   const folderParent = await mkdtemp(path.join(homedir(), ".nebula-folder-picker-"));
   const selectedFolder = path.join(folderParent, "fresh-project");
+  const paginatedFolder = path.join(folderParent, "project-502");
+  await Promise.all(Array.from({ length: 503 }, (_, index) => mkdir(path.join(folderParent, `project-${index.toString().padStart(3, "0")}`))));
   const api = await playwrightRequest.newContext({
     baseURL: `${core.origin}/api/v1/`,
     extraHTTPHeaders: { Authorization: `Bearer ${core.token}` },
@@ -1198,8 +1200,13 @@ test("real Core persists a project folder chosen through the host browser", asyn
     await browser.getByRole("button", { name: "Create folder" }).click();
     await expect(browser.getByText(selectedFolder, { exact: true })).toBeVisible();
     expect(existsSync(selectedFolder)).toBe(true);
+    await browser.getByRole("button", { name: "Up one level" }).click();
+    await expect(browser.getByRole("button", { name: "project-498", exact: true })).toBeVisible();
+    await browser.getByRole("button", { name: "Load more folders" }).click();
+    await browser.getByRole("button", { name: "project-502", exact: true }).click();
+    await expect(browser.getByText(paginatedFolder, { exact: true })).toBeVisible();
     await browser.getByRole("button", { name: "Select folder" }).click();
-    await expect(switcher.getByLabel("Project folder", { exact: true })).toHaveValue(selectedFolder);
+    await expect(switcher.getByLabel("Project folder", { exact: true })).toHaveValue(paginatedFolder);
     await switcher.getByRole("button", { name: "Create" }).click();
     await expect(page.getByRole("button", { name: "Switch project" })).toContainText("Linked Folder Acceptance");
 
@@ -1207,7 +1214,7 @@ test("real Core persists a project folder chosen through the host browser", asyn
     expect(response.ok()).toBe(true);
     const projects = await response.json() as Array<{ name: string; workspace_path?: string }>;
     expect(projects.find((project) => project.name === "Linked Folder Acceptance")).toMatchObject({
-      workspace_path: selectedFolder,
+      workspace_path: paginatedFolder,
     });
 
     await page.goto(`${core.origin}/settings#token=${encodeURIComponent(core.token)}`);


### PR DESCRIPTION
## Summary
- paginate the host workspace-folder API beyond the existing 500-entry bound
- add an accessible Load more action with inline retry and de-duplicated accumulation
- cover pagination in Core, client, component, desktop/mobile browser, real-Core, production, and LAN-origin tests

## Verification
- ============================= test session starts ==============================
platform linux -- Python 3.11.7, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/agent/nebula
configfile: pyproject.toml
plugins: anyio-4.8.0, langsmith-0.7.26, cov-7.1.0
collected 18 items / 16 deselected / 2 selected

tests/v3/test_workspace.py ..                                            [100%]

=============================== warnings summary ===============================
.venv/lib/python3.11/site-packages/fastapi/testclient.py:1
  /home/agent/nebula/.venv/lib/python3.11/site-packages/fastapi/testclient.py:1: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
    from starlette.testclient import TestClient as TestClient  # noqa

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================= 2 passed, 16 deselected, 1 warning in 19.11s ================= (2 passed)
- 
> nebula-ui@3.0.0-alpha.10 test
> vitest run --run src/components/HostFolderPicker.test.tsx src/api/client.test.ts


 RUN  v4.1.10 /home/agent/nebula/ui


 Test Files  2 passed (2)
      Tests  41 passed (41)
   Start at  12:20:25
   Duration  5.48s (transform 519ms, setup 328ms, import 844ms, tests 3.65s, environment 2.30s) (41 passed)
- 
> nebula-ui@3.0.0-alpha.10 build
> tsc -b && vite build

vite v8.1.4 building client environment for production...
[2Ktransforming...✓ 2852 modules transformed.
rendering chunks...
computing gzip size...
dist/assets/geist-mono-symbols2-wght-normal-CO5SzqOn.woff2        5.81 kB
dist/assets/geist-mono-cyrillic-ext-wght-normal-X_5orZeX.woff2    6.17 kB
dist/assets/geist-cyrillic-ext-wght-normal-DjL33-gN.woff2         7.42 kB
dist/assets/geist-mono-vietnamese-wght-normal-DadHysG0.woff2      7.69 kB
dist/assets/geist-vietnamese-wght-normal-6IgcOCM7.woff2           8.00 kB
dist/index.html                                                   8.02 kB │ gzip:   2.36 kB
dist/assets/geist-mono-cyrillic-wght-normal-DiZS0aHC.woff2       12.94 kB
dist/assets/geist-mono-latin-ext-wght-normal-Bwz-egvJ.woff2      14.69 kB
dist/assets/geist-cyrillic-wght-normal-BEAKL7Jp.woff2            15.08 kB
dist/assets/geist-latin-ext-wght-normal-DC-KSUi6.woff2           16.51 kB
dist/assets/geist-mono-latin-wght-normal-XN7g48iV.woff2          23.12 kB
dist/assets/geist-latin-wght-normal-BgDaEnEv.woff2               29.40 kB
dist/assets/selection-CNq0kV96.css                                1.68 kB │ gzip:   0.73 kB
dist/assets/SessionsPage-Dyc2erDS.css                             5.14 kB │ gzip:   1.27 kB
dist/assets/ContainerTerminalPanel-CA1_r1UQ.css                   7.39 kB │ gzip:   2.07 kB
dist/assets/index-CSUnfeZL.css                                  349.36 kB │ gzip:  55.38 kB
dist/assets/chevron-down-ZH-eOu1k.js                              0.12 kB │ gzip:   0.13 kB
dist/assets/loader-circle-D2TbZfiD.js                             0.13 kB │ gzip:   0.15 kB
dist/assets/plus-D-ZMY9QZ.js                                      0.14 kB │ gzip:   0.14 kB
dist/assets/core-IUlRufS4.js                                      0.16 kB │ gzip:   0.14 kB
dist/assets/circle-stop-DoyYBUvo.js                               0.19 kB │ gzip:   0.17 kB
dist/assets/rotate-ccw-DQVbPZdQ.js                                0.19 kB │ gzip:   0.18 kB
dist/assets/upload-Di0WaQab.js                                    0.22 kB │ gzip:   0.19 kB
dist/assets/link-2-BaYmIJzM.js                                    0.23 kB │ gzip:   0.20 kB
dist/assets/square-terminal-005KJyN-.js                           0.23 kB │ gzip:   0.20 kB
dist/assets/database-BcL1wMGX.js                                  0.23 kB │ gzip:   0.19 kB
dist/assets/InlineValidationNotice-hcj4JEiQ.js                    0.24 kB │ gzip:   0.20 kB
dist/assets/list-todo-L2yCz2Y5.js                                 0.29 kB │ gzip:   0.21 kB
dist/assets/shield-check-CEAHiOSm.js                              0.31 kB │ gzip:   0.24 kB
dist/assets/save-bMmsbZMD.js                                      0.32 kB │ gzip:   0.22 kB
dist/assets/trash-2-DDLuzxNX.js                                   0.32 kB │ gzip:   0.21 kB
dist/assets/message-square-quote-DuxpCaT6.js                      0.34 kB │ gzip:   0.24 kB
dist/assets/file-plus-corner-BtzgoymK.js                          0.34 kB │ gzip:   0.24 kB
dist/assets/file-code-corner-B9Wnrxjo.js                          0.35 kB │ gzip:   0.24 kB
dist/assets/network-C1LpLcSG.js                                   0.37 kB │ gzip:   0.23 kB
dist/assets/user-round-DK8yMuZ1.js                                0.40 kB │ gzip:   0.29 kB
dist/assets/sparkles-CHdHTxp3.js                                  0.48 kB │ gzip:   0.28 kB
dist/assets/message-square-text-BDvQgv9q.js                       0.54 kB │ gzip:   0.33 kB
dist/assets/PageHeader-BiILEHMP.js                                0.68 kB │ gzip:   0.37 kB
dist/assets/toml-LvoKBwCs.js                                      1.19 kB │ gzip:   0.53 kB
dist/assets/preload-helper-Czpn1I53.js                            1.19 kB │ gzip:   0.67 kB
dist/assets/yaml-DjjjKWKb.js                                      1.49 kB │ gzip:   0.71 kB
dist/assets/dist-CzJFYUn4.js                                      1.99 kB │ gzip:   1.26 kB
dist/assets/shell-Du5Qg9im.js                                     2.44 kB │ gzip:   1.20 kB
dist/assets/go-zaFg-XIf.js                                        2.75 kB │ gzip:   1.30 kB
dist/assets/react-dom-Dk75L2DG.js                                 3.54 kB │ gzip:   1.34 kB
dist/assets/WorkspaceEntryContextMenu-DshusaZZ.js                 4.11 kB │ gzip:   1.70 kB
dist/assets/rust-B2xrr2_0.js                                      4.33 kB │ gzip:   1.91 kB
dist/assets/ruby-DsYpTuWg.js                                      5.10 kB │ gzip:   2.15 kB
dist/assets/play-DTxIwNjt.js                                      5.60 kB │ gzip:   2.80 kB
dist/assets/AIWritingDialog-DjOiPf7R.js                           6.27 kB │ gzip:   2.45 kB
dist/assets/LibraryPage-BiK_z9ry.js                               6.80 kB │ gzip:   2.73 kB
dist/assets/selection-BdzWgwi9.js                                 7.18 kB │ gzip:   2.86 kB
dist/assets/dist-ncKvXPy_.js                                     13.73 kB │ gzip:   5.94 kB
dist/assets/ReportsPage-S48AX_hF.js                              17.97 kB │ gzip:   5.63 kB
dist/assets/FindingsPage-BBmZ_GTm.js                             19.44 kB │ gzip:   5.35 kB
dist/assets/clike-0UEdDywI.js                                    22.14 kB │ gzip:   7.80 kB
dist/assets/MissionControls-BXXii2fu.js                          24.35 kB │ gzip:   7.47 kB
dist/assets/dist-D2Th5cKq.js                                     26.46 kB │ gzip:   8.67 kB
dist/assets/dist-BKBTiOIz.js                                     26.71 kB │ gzip:  12.65 kB
dist/assets/dist-jzXyIjyH.js                                     28.26 kB │ gzip:  11.48 kB
dist/assets/dist-CJwE39nz.js                                     35.04 kB │ gzip:  12.33 kB
dist/assets/chunk-62JRHF6Z-DARxE3OW.js                           41.51 kB │ gzip:  14.79 kB
dist/assets/dist-Bg9cmxwH.js                                     43.80 kB │ gzip:  15.08 kB
dist/assets/ProjectPage-zDVl3ios.js                              43.90 kB │ gzip:  11.26 kB
dist/assets/dist-CImpCbtE.js                                     44.57 kB │ gzip:  19.31 kB
dist/assets/dist-BVMbvk8y.js                                     84.62 kB │ gzip:  33.74 kB
dist/assets/SettingsPage-BPaH0La6.js                            115.07 kB │ gzip:  30.63 kB
dist/assets/CodeEditorPanel-Cix8yddd.js                         207.12 kB │ gzip:  62.67 kB
dist/assets/diagnostics-DdshzPGA.js                             210.04 kB │ gzip:  56.07 kB
dist/assets/AssistantMarkdown-Bhhi1fVT.js                       244.76 kB │ gzip:  74.45 kB
dist/assets/index-BSd68ySu.js                                   255.64 kB │ gzip:  80.11 kB
dist/assets/dist-DiHO-XwR.js                                    306.79 kB │ gzip:  99.52 kB
dist/assets/ContainerTerminalPanel-BnaON0v6.js                  403.69 kB │ gzip: 105.31 kB
dist/assets/SessionsPage-CymXTJBD.js                            474.15 kB │ gzip: 127.28 kB

✓ built in 1.59s
- 
> nebula-ui@3.0.0-alpha.10 audit:css
> node scripts/validate-calm-css.mjs

Calm CSS contract passed; all imported application styles use the approved product scale.
- 
> nebula-ui@3.0.0-alpha.10 audit:diagnostics
> node ../scripts/audit_typescript_diagnostics.mjs

Frontend diagnostic audit: zero unclassified catch handlers.
- host-folder Playwright matrix: desktop 1440/1024; mobile Chromium and WebKit 320/390/430 (8 passed)
- focused real-Core production bundle over non-loopback LAN origin (1 passed)