### PR TITLE
Fix Browser project workflow and folder creation

### DIFF
--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -581,6 +581,26 @@ class CodeCompletionResponse(NebulaModel):
     items: list[dict[str, Any]] = Field(default_factory=list, max_length=30)
 
 
+class HostWorkspaceFolderCreateRequest(NebulaModel):
+    parent_path: str = Field(min_length=1, max_length=4096)
+    name: str = Field(min_length=1, max_length=255)
+
+    @model_validator(mode="after")
+    def folder_name_is_one_portable_component(
+        self,
+    ) -> "HostWorkspaceFolderCreateRequest":
+        if (
+            self.name in {".", ".."}
+            or "/" in self.name
+            or "\\" in self.name
+            or any(ord(character) < 32 for character in self.name)
+        ):
+            raise ValueError("folder name must be one path component")
+        if len(self.name.encode("utf-8")) > 255:
+            raise ValueError("folder name is too long for the host filesystem")
+        return self
+
+
 class EventList(NebulaModel):
     events: list[RunEvent]
     next_sequence: int
@@ -5115,6 +5135,52 @@ def create_app(
             "directories": directories,
             "truncated": len(directories) >= 500,
         }
+
+    @app.post(
+        f"{API_PREFIX}/workspace-folders",
+        status_code=201,
+        tags=["workspace"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def create_host_workspace_folder(
+        request: HostWorkspaceFolderCreateRequest,
+    ) -> dict[str, Any]:
+        requested_parent = Path(request.parent_path).expanduser()
+        if not requested_parent.is_absolute():
+            raise HTTPException(
+                status_code=422, detail="parent folder path must be absolute"
+            )
+        try:
+            parent = requested_parent.resolve(strict=True)
+        except OSError as exc:
+            raise HTTPException(
+                status_code=404, detail="parent folder is unavailable"
+            ) from exc
+        if not parent.is_dir():
+            raise HTTPException(status_code=422, detail="parent path is not a folder")
+        descriptor: int | None = None
+        try:
+            descriptor = os.open(
+                parent,
+                os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0),
+            )
+            os.mkdir(request.name, mode=0o700, dir_fd=descriptor)
+        except FileExistsError as exc:
+            raise HTTPException(
+                status_code=409, detail="folder already exists"
+            ) from exc
+        except PermissionError as exc:
+            raise HTTPException(
+                status_code=403, detail="folder cannot be created"
+            ) from exc
+        except OSError as exc:
+            raise HTTPException(
+                status_code=422, detail="folder cannot be created"
+            ) from exc
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+        return await list_host_workspace_folders(str(parent / request.name))
 
     @app.get(
         f"{API_PREFIX}/engagements/{{engagement_id}}/workspace",

--- a/tests/v3/test_workspace.py
+++ b/tests/v3/test_workspace.py
@@ -429,6 +429,41 @@ def test_host_workspace_folder_browser_lists_only_directories(tmp_path):
     assert unavailable.json()["detail"] == "folder is unavailable"
 
 
+def test_host_workspace_folder_browser_creates_one_bounded_child(tmp_path):
+    _store, _artifacts, _platform, _workspace, _engagement, client = _services(tmp_path)
+
+    created = client.post(
+        "/api/v1/workspace-folders",
+        headers=AUTH,
+        json={"parent_path": str(tmp_path), "name": "new-project"},
+    )
+
+    assert created.status_code == 201
+    listing = created.json()
+    expected = (tmp_path / "new-project").resolve()
+    assert expected.is_dir()
+    assert listing["path"] == str(expected)
+    assert listing["parent"] == str(tmp_path.resolve())
+
+    duplicate = client.post(
+        "/api/v1/workspace-folders",
+        headers=AUTH,
+        json={"parent_path": str(tmp_path), "name": "new-project"},
+    )
+    assert duplicate.status_code == 409
+    assert duplicate.json()["detail"] == "folder already exists"
+
+    for invalid_name in ("../outside", "nested/child", r"nested\child"):
+        rejected = client.post(
+            "/api/v1/workspace-folders",
+            headers=AUTH,
+            json={"parent_path": str(tmp_path), "name": invalid_name},
+        )
+        assert rejected.status_code == 422
+    assert not (tmp_path.parent / "outside").exists()
+    assert not (tmp_path / "nested").exists()
+
+
 def test_promotion_survives_symlink_safe_workspace_reset(tmp_path):
     store, artifacts, platform, workspace, engagement, client = _services(tmp_path)
     root = platform.workspace_for(engagement.id)

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -64,13 +64,13 @@ export default defineConfig({
     {
       name: "mobile-chromium-wide",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|VPN settings keep|theme picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output|terminal VPN boundary/,
+      grep: /universal search opens|VPN settings keep|theme picker|host folder picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output|terminal VPN boundary/,
       use: { ...devices["Pixel 5"], viewport: { width: 430, height: 932 } },
     },
     {
       name: "mobile-webkit-small",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|VPN settings keep|theme picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output|terminal VPN boundary/,
+      grep: /universal search opens|VPN settings keep|theme picker|host folder picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output|terminal VPN boundary/,
       use: { ...devices["iPhone 13"], viewport: { width: 320, height: 700 } },
     },
     {

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -7126,6 +7126,26 @@ export class ApiClient {
     }));
   }
 
+  createHostWorkspaceFolder(parentPath: string, name: string): Promise<{
+    path: string;
+    parent?: string;
+    directories: Array<{ name: string; path: string }>;
+    truncated: boolean;
+  }> {
+    return this.request<{
+      path: string;
+      parent?: string | null;
+      directories: Array<{ name: string; path: string }>;
+      truncated: boolean;
+    }>("workspace-folders", {
+      method: "POST",
+      body: JSON.stringify({ parent_path: parentPath, name }),
+    }).then((value) => ({
+      ...value,
+      parent: value.parent ?? undefined,
+    }));
+  }
+
   previewWorkspaceFile(
     engagementId: string,
     path: string,

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -1908,7 +1908,7 @@ button.harness-status-summary:focus-visible { outline: 2px solid var(--focus); o
   display: grid;
   width: min(680px, calc(100vw - 32px));
   max-height: min(760px, calc(100dvh - 32px));
-  grid-template-rows: auto auto minmax(180px, 1fr) auto auto;
+  grid-template-rows: auto auto auto minmax(180px, 1fr) auto auto;
   overflow: hidden;
 }
 .host-folder-dialog > header {
@@ -1927,6 +1927,12 @@ button.harness-status-summary:focus-visible { outline: 2px solid var(--focus); o
 .host-folder-location { display: grid; min-width: 0; gap: 6px; padding: 14px 22px; border-bottom: 1px solid var(--border-soft); background: var(--surface-muted); }
 .host-folder-location > span { color: var(--muted); font-size: 11px; font-weight: var(--weight-bold); text-transform: uppercase; letter-spacing: .045em; }
 .host-folder-location code { min-width: 0; color: var(--blue-bright); font-size: 12px; line-height: 1.45; overflow-wrap: anywhere; word-break: break-word; }
+.host-folder-create { display: grid; min-width: 0; gap: 7px; padding: 10px 22px; border-bottom: 1px solid var(--border-soft); }
+.host-folder-create > .button { justify-self: start; }
+.host-folder-create > form { display: grid; min-width: 0; grid-template-columns: minmax(0, 1fr) auto auto; align-items: end; gap: 8px; }
+.host-folder-create label { display: grid; min-width: 0; gap: 4px; color: var(--muted); font-size: 11px; }
+.host-folder-create input { width: 100%; min-width: 0; min-height: 36px; padding: 6px 9px; border: 1px solid var(--border); border-radius: var(--radius-control); background: var(--surface); }
+.host-folder-create > small { color: var(--red); overflow-wrap: anywhere; }
 .host-folder-list { min-width: 0; min-height: 0; overflow-y: auto; overscroll-behavior: contain; padding: 8px; }
 .host-folder-list > button { display: grid; width: 100%; min-width: 0; min-height: 46px; grid-template-columns: 24px minmax(0, 1fr) 20px; align-items: center; gap: 9px; padding: 8px 10px; border: 0; border-radius: var(--radius-control); color: var(--text); background: transparent; text-align: left; cursor: pointer; }
 .host-folder-list > button:hover, .host-folder-list > button:focus-visible { background: var(--surface-hover); }
@@ -2071,12 +2077,16 @@ button.harness-status-summary:focus-visible { outline: 2px solid var(--focus); o
      keyboard does not crop chat or make a full-screen workbench look smaller. */
   :root .page :is(input:not([type="checkbox"]):not([type="radio"]), textarea, select) { font-size: 16px; }
   .dialog-backdrop:has(.host-folder-dialog) { align-items: end; padding: 8px; }
-  .modal-surface.host-folder-dialog { width: 100%; max-height: calc(100dvh - 16px); border-radius: var(--radius-dialog); grid-template-rows: auto auto minmax(160px, 1fr) auto auto; }
+  .modal-surface.host-folder-dialog { width: 100%; max-height: calc(100dvh - 16px); border-radius: var(--radius-dialog); grid-template-rows: auto auto auto minmax(120px, 1fr) auto auto; }
   .host-folder-dialog > header { grid-template-columns: minmax(0, 1fr) 44px; gap: 10px; padding: 16px 16px 13px; }
   .host-folder-dialog > header h2 { margin-top: 5px; font-size: var(--type-title-sm); }
   .host-folder-dialog > header p { font-size: 11px; }
   .host-folder-location { padding: 12px 16px; }
   .host-folder-location code { max-height: 3.1em; overflow-y: auto; font-size: 12px; }
+  .host-folder-create { padding: 10px 16px; }
+  .host-folder-create > form { grid-template-columns: 1fr 1fr; }
+  .host-folder-create label { grid-column: 1 / -1; }
+  .host-folder-create .button { min-height: 44px; justify-content: center; }
   .host-folder-list { padding: 6px; }
   .host-folder-list > button { min-height: 48px; padding-inline: 10px; }
   .host-folder-dialog > footer { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 8px; padding: 10px; padding-bottom: calc(10px + env(safe-area-inset-bottom)); }

--- a/ui/src/components/DialogSystem.test.tsx
+++ b/ui/src/components/DialogSystem.test.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
-import { ModalSurface } from "./DialogSystem";
+import { DialogProvider, ModalSurface, useDialogOpen } from "./DialogSystem";
 
 function DialogHarness() {
   const [open, setOpen] = useState(false);
@@ -14,6 +14,10 @@ function DialogHarness() {
       <button type="submit">Save</button>
     </ModalSurface>}
   </>;
+}
+
+function DialogState() {
+  return <output aria-label="Dialog state">{useDialogOpen() ? "open" : "closed"}</output>;
 }
 
 describe("ModalSurface", () => {
@@ -36,5 +40,15 @@ describe("ModalSurface", () => {
     await user.click(screen.getByRole("button", { name: "Open dialog" }));
     await user.click(container.querySelector(".dialog-backdrop") as HTMLElement);
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("publishes ordinary modal presence to native-surface consumers", async () => {
+    const user = userEvent.setup();
+    render(<DialogProvider><DialogState /><DialogHarness /></DialogProvider>);
+    expect(screen.getByLabelText("Dialog state")).toHaveTextContent("closed");
+    await user.click(screen.getByRole("button", { name: "Open dialog" }));
+    expect(screen.getByLabelText("Dialog state")).toHaveTextContent("open");
+    await user.keyboard("{Escape}");
+    expect(screen.getByLabelText("Dialog state")).toHaveTextContent("closed");
   });
 });

--- a/ui/src/components/DialogSystem.tsx
+++ b/ui/src/components/DialogSystem.tsx
@@ -7,6 +7,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -39,10 +40,16 @@ interface ModalSurfaceProps extends PropsWithChildren {
   noValidate?: boolean;
 }
 
+type RegisterDialog = () => () => void;
+const DialogRegistrationContext = createContext<RegisterDialog>(() => () => undefined);
+
 export function ModalSurface({ children, className = "", labelledBy, onClose, as = "div", onSubmit, noValidate }: ModalSurfaceProps) {
+  const registerDialog = useContext(DialogRegistrationContext);
   const surfaceRef = useRef<HTMLElement>(null);
   const returnFocusRef = useRef<HTMLElement | null>(null);
   const returnFocusIdentityRef = useRef<{ tag: string; ariaLabel: string; text: string } | undefined>(undefined);
+
+  useLayoutEffect(() => registerDialog(), [registerDialog]);
 
   useEffect(() => {
     const surface = surfaceRef.current;
@@ -157,6 +164,17 @@ const DialogOpenContext = createContext(false);
 
 export function DialogProvider({ children }: PropsWithChildren) {
   const [pending, setPending] = useState<PendingConfirmation>();
+  const [registeredDialogs, setRegisteredDialogs] = useState(0);
+
+  const registerDialog = useCallback<RegisterDialog>(() => {
+    setRegisteredDialogs((count) => count + 1);
+    let registered = true;
+    return () => {
+      if (!registered) return;
+      registered = false;
+      setRegisteredDialogs((count) => Math.max(0, count - 1));
+    };
+  }, []);
 
   const confirm = useCallback<Confirm>((options) => new Promise((resolve) => {
     setPending({ options, resolve });
@@ -169,40 +187,48 @@ export function DialogProvider({ children }: PropsWithChildren) {
 
   return (
     <ConfirmationContext.Provider value={confirm}>
-      <DialogOpenContext.Provider value={Boolean(pending)}>
-        {children}
-        {pending && (
-        <ModalSurface labelledBy="confirmation-title" className="confirmation-dialog" onClose={() => finish(false)}>
-          <header role="presentation">
-            <span className={`confirmation-icon ${pending.options.tone ?? "default"}`} aria-hidden="true">
-              <AlertTriangle size={20} />
-            </span>
-            <div>
-              <h2 id="confirmation-title">{pending.options.title}</h2>
-              <div className="confirmation-message">{pending.options.message}</div>
-            </div>
-            <button className="icon-button subtle" type="button" aria-label="Close" onClick={() => finish(false)}>
-              <X size={17} />
-            </button>
-          </header>
-          <footer>
-            <button className="button secondary" type="button" onClick={() => finish(false)}>
-              {pending.options.cancelLabel ?? "Cancel"}
-            </button>
-            <button
-              className={`button ${pending.options.tone === "danger" ? "danger" : "primary"}`}
-              type="button"
-              data-autofocus
-              onClick={() => finish(true)}
-            >
-              {pending.options.confirmLabel ?? "Continue"}
-            </button>
-          </footer>
-        </ModalSurface>
-        )}
-      </DialogOpenContext.Provider>
+      <DialogRegistrationContext.Provider value={registerDialog}>
+        <DialogOpenContext.Provider value={Boolean(pending) || registeredDialogs > 0}>
+          {children}
+          {pending && (
+          <ModalSurface labelledBy="confirmation-title" className="confirmation-dialog" onClose={() => finish(false)}>
+            <header role="presentation">
+              <span className={`confirmation-icon ${pending.options.tone ?? "default"}`} aria-hidden="true">
+                <AlertTriangle size={20} />
+              </span>
+              <div>
+                <h2 id="confirmation-title">{pending.options.title}</h2>
+                <div className="confirmation-message">{pending.options.message}</div>
+              </div>
+              <button className="icon-button subtle" type="button" aria-label="Close" onClick={() => finish(false)}>
+                <X size={17} />
+              </button>
+            </header>
+            <footer>
+              <button className="button secondary" type="button" onClick={() => finish(false)}>
+                {pending.options.cancelLabel ?? "Cancel"}
+              </button>
+              <button
+                className={`button ${pending.options.tone === "danger" ? "danger" : "primary"}`}
+                type="button"
+                data-autofocus
+                onClick={() => finish(true)}
+              >
+                {pending.options.confirmLabel ?? "Continue"}
+              </button>
+            </footer>
+          </ModalSurface>
+          )}
+        </DialogOpenContext.Provider>
+      </DialogRegistrationContext.Provider>
     </ConfirmationContext.Provider>
   );
+}
+
+/** Register a non-modal blocking surface that must occlude native child webviews. */
+export function useDialogPresence(open: boolean): void {
+  const registerDialog = useContext(DialogRegistrationContext);
+  useLayoutEffect(() => open ? registerDialog() : undefined, [open, registerDialog]);
 }
 
 export function useDialogOpen(): boolean {

--- a/ui/src/components/HostFolderPicker.test.tsx
+++ b/ui/src/components/HostFolderPicker.test.tsx
@@ -1,30 +1,73 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import type { FormEvent } from "react";
 import type { ApiClient } from "../api/client";
+import { DialogProvider } from "./DialogSystem";
 import { HostFolderPicker } from "./HostFolderPicker";
 
 describe("HostFolderPicker", () => {
-  it("keeps an unavailable path actionable and retries from the host home folder", async () => {
-    const listHostWorkspaceFolders = vi.fn()
-      .mockRejectedValueOnce(new Error("folder is unavailable"))
-      .mockResolvedValueOnce({ path: "/home/agent", parent: "/home", directories: [], truncated: false });
-    const api = { listHostWorkspaceFolders } as unknown as ApiClient;
+  it("creates a child folder, enters it, and returns the selected host path", async () => {
+    const api = {
+      listHostWorkspaceFolders: vi.fn(async () => ({
+        path: "/srv/projects",
+        parent: "/srv",
+        directories: [],
+        truncated: false,
+      })),
+      createHostWorkspaceFolder: vi.fn(async () => ({
+        path: "/srv/projects/acme-review",
+        parent: "/srv/projects",
+        directories: [],
+        truncated: false,
+      })),
+    } as unknown as ApiClient;
+    const onSelect = vi.fn();
+    const onParentSubmit = vi.fn((event: FormEvent) => event.preventDefault());
     const user = userEvent.setup();
-    render(<HostFolderPicker api={api} value="/missing/project" onSelect={vi.fn()} />);
 
+    render(<DialogProvider><form onSubmit={onParentSubmit}><HostFolderPicker api={api} onSelect={onSelect} /></form></DialogProvider>);
     const browse = screen.getByRole("button", { name: "Browse folders" });
     await user.click(browse);
     const dialog = await screen.findByRole("dialog", { name: "Choose project folder" });
-    expect(within(dialog).getByRole("alert")).toHaveTextContent("Folder unavailablefolder is unavailable");
-    expect(listHostWorkspaceFolders).toHaveBeenNthCalledWith(1, "/missing/project");
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByRole("textbox", { name: "New folder name" }), "acme-review");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
 
-    await user.click(within(dialog).getByRole("button", { name: "Try again" }));
-    expect(await within(dialog).findByText("/home/agent", { exact: true })).toBeVisible();
-    expect(listHostWorkspaceFolders).toHaveBeenNthCalledWith(2, undefined);
-
-    await user.keyboard("{Escape}");
+    await waitFor(() => expect(api.createHostWorkspaceFolder).toHaveBeenCalledWith("/srv/projects", "acme-review"));
+    expect(onParentSubmit).not.toHaveBeenCalled();
+    expect(dialog).toHaveTextContent("/srv/projects/acme-review");
+    await waitFor(() => expect(screen.getByRole("button", { name: "Select folder" })).toHaveFocus());
+    await user.click(screen.getByRole("button", { name: "Select folder" }));
+    expect(onSelect).toHaveBeenCalledWith("/srv/projects/acme-review");
     expect(screen.queryByRole("dialog", { name: "Choose project folder" })).not.toBeInTheDocument();
     expect(browse).toHaveFocus();
+  });
+
+  it("keeps the folder form usable when creation fails and permits a corrected retry", async () => {
+    const createHostWorkspaceFolder = vi.fn()
+      .mockRejectedValueOnce(new Error("folder already exists"))
+      .mockResolvedValueOnce({ path: "/srv/projects/acme-review-2", parent: "/srv/projects", directories: [], truncated: false });
+    const api = {
+      listHostWorkspaceFolders: vi.fn(async () => ({ path: "/srv/projects", parent: "/srv", directories: [], truncated: false })),
+      createHostWorkspaceFolder,
+    } as unknown as ApiClient;
+    const user = userEvent.setup();
+
+    render(<DialogProvider><HostFolderPicker api={api} onSelect={vi.fn()} /></DialogProvider>);
+    await user.click(screen.getByRole("button", { name: "Browse folders" }));
+    await user.click(await screen.findByRole("button", { name: "New folder" }));
+    const name = screen.getByRole("textbox", { name: "New folder name" });
+    await user.type(name, "acme-review");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("folder already exists");
+    expect(name).toHaveValue("acme-review");
+    await waitFor(() => expect(name).toHaveFocus());
+    await user.clear(name);
+    await user.type(name, "acme-review-2");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+    await waitFor(() => expect(createHostWorkspaceFolder).toHaveBeenLastCalledWith("/srv/projects", "acme-review-2"));
+    expect(screen.getByRole("dialog", { name: "Choose project folder" })).toHaveTextContent("/srv/projects/acme-review-2");
   });
 });

--- a/ui/src/components/HostFolderPicker.tsx
+++ b/ui/src/components/HostFolderPicker.tsx
@@ -1,6 +1,6 @@
-import { useRef, useState } from "react";
+import { useRef, useState, type FormEvent } from "react";
 import { createPortal } from "react-dom";
-import { ArrowUp, ChevronRight, Folder, FolderOpen, LoaderCircle, Server, X } from "lucide-react";
+import { ArrowUp, ChevronRight, Folder, FolderOpen, FolderPlus, LoaderCircle, Server, X } from "lucide-react";
 import type { ApiClient } from "../api/client";
 import { logCaughtDiagnostic } from "../diagnostics";
 import { ModalSurface } from "./DialogSystem";
@@ -21,13 +21,23 @@ export function HostFolderPicker({ api, value, onSelect }: {
   const [listing, setListing] = useState<FolderListing>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
+  const [newFolderOpen, setNewFolderOpen] = useState(false);
+  const [newFolderName, setNewFolderName] = useState("");
+  const [creatingFolder, setCreatingFolder] = useState(false);
+  const [createError, setCreateError] = useState<string>();
   const browseButtonRef = useRef<HTMLButtonElement>(null);
   const folderListRef = useRef<HTMLDivElement>(null);
+  const newFolderInputRef = useRef<HTMLInputElement>(null);
   const retryButtonRef = useRef<HTMLButtonElement>(null);
   const selectButtonRef = useRef<HTMLButtonElement>(null);
 
   const load = async (path?: string, moveFocus = false) => {
     if (!api) return;
+    if (moveFocus) {
+      setNewFolderOpen(false);
+      setNewFolderName("");
+      setCreateError(undefined);
+    }
     setLoading(true);
     setError(undefined);
     try {
@@ -54,7 +64,43 @@ export function HostFolderPicker({ api, value, onSelect }: {
   const closeBrowser = () => {
     setOpen(false);
     setError(undefined);
+    setNewFolderOpen(false);
+    setNewFolderName("");
+    setCreateError(undefined);
     requestAnimationFrame(() => browseButtonRef.current?.focus());
+  };
+
+  const beginCreateFolder = () => {
+    setNewFolderOpen(true);
+    setCreateError(undefined);
+    requestAnimationFrame(() => newFolderInputRef.current?.focus());
+  };
+
+  const cancelCreateFolder = () => {
+    setNewFolderOpen(false);
+    setNewFolderName("");
+    setCreateError(undefined);
+  };
+
+  const createFolder = async (event: FormEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!api || !listing || creatingFolder || !newFolderName.trim()) return;
+    setCreatingFolder(true);
+    setCreateError(undefined);
+    try {
+      const created = await api.createHostWorkspaceFolder(listing.path, newFolderName);
+      setListing(created);
+      setNewFolderOpen(false);
+      setNewFolderName("");
+      requestAnimationFrame(() => selectButtonRef.current?.focus());
+    } catch (caught) {
+      logCaughtDiagnostic("interface.host_folder.create_failed", "A host workspace folder could not be created.", caught, "host-folder-picker");
+      setCreateError(caught instanceof Error ? caught.message : "Folder could not be created.");
+      requestAnimationFrame(() => newFolderInputRef.current?.focus());
+    } finally {
+      setCreatingFolder(false);
+    }
   };
 
   const selectCurrentFolder = () => {
@@ -81,6 +127,14 @@ export function HostFolderPicker({ api, value, onSelect }: {
         <div className="host-folder-location">
           <span>Current folder</span>
           <code title={listing?.path}>{(listing?.path ?? value?.trim()) || "Loading home folder…"}</code>
+        </div>
+        <div className="host-folder-create">
+          {newFolderOpen ? <form onSubmit={(event) => void createFolder(event)}>
+            <label><span>New folder name</span><input ref={newFolderInputRef} required maxLength={255} value={newFolderName} onChange={(event) => { setNewFolderName(event.target.value); if (createError) setCreateError(undefined); }} /></label>
+            <button className="button quiet" type="button" disabled={creatingFolder} onClick={cancelCreateFolder}>Cancel</button>
+            <button className="button primary" type="submit" disabled={creatingFolder || !newFolderName.trim()}>{creatingFolder ? <LoaderCircle className="spin" size={14} /> : <FolderPlus size={14} />} {creatingFolder ? "Creating…" : "Create folder"}</button>
+          </form> : <button className="button secondary" type="button" disabled={!listing || loading} onClick={beginCreateFolder}><FolderPlus size={14} /> New folder</button>}
+          {createError && <small role="alert">{createError}</small>}
         </div>
         <div ref={folderListRef} className="host-folder-list" aria-busy={loading}>
           {loading && <div className="host-folder-state" role="status"><LoaderCircle className="spin" size={20} /><span>Loading folders…</span></div>}

--- a/ui/src/components/SideNav.tsx
+++ b/ui/src/components/SideNav.tsx
@@ -6,6 +6,7 @@ import { canonicalNavigationPath, replaceProjectInPath } from "../resourceRoutes
 import { useWorkspace } from "../state/WorkspaceContext";
 import { DiagnosticErrorNotice, logCaughtDiagnostic } from "../diagnostics";
 import { HostFolderPicker } from "./HostFolderPicker";
+import { useDialogPresence } from "./DialogSystem";
 
 interface SideNavProps {
   collapsed: boolean;
@@ -31,6 +32,7 @@ export function SideNav({ collapsed, onNavigate, variant = "standard" }: SideNav
   const [workspacePath, setWorkspacePath] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string>();
+  useDialogPresence(open);
   const engagementName = engagement?.name ?? "No project available";
   const initials = engagementName
     .split(/\s+/)

--- a/ui/src/components/WorkbenchBrowser.test.tsx
+++ b/ui/src/components/WorkbenchBrowser.test.tsx
@@ -1,10 +1,11 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
+import { useState } from "react";
 import type { EngagementScopePolicy } from "../api/types";
 import type { ApiClient } from "../api/client";
 import { ChromeProvider, type ChromeContextValue } from "../state/ChromeContext";
-import { DialogProvider } from "./DialogSystem";
+import { DialogProvider, useDialogPresence } from "./DialogSystem";
 import { WorkbenchBrowser } from "./WorkbenchBrowser";
 
 const runtimeMocks = vi.hoisted(() => ({
@@ -115,6 +116,12 @@ function browserApi(): ApiClient {
   } as unknown as ApiClient;
 }
 
+function BlockingSurfaceControl() {
+  const [open, setOpen] = useState(false);
+  useDialogPresence(open);
+  return <button type="button" onClick={() => setOpen((value) => !value)}>{open ? "Close blocking surface" : "Open blocking surface"}</button>;
+}
+
 function renderBrowser(
   onAddKnowledgeUrl = vi.fn(async () => ({ id: "source-1", name: "Guide" })),
   onAskNebula = vi.fn(),
@@ -138,6 +145,7 @@ function renderBrowser(
       <MemoryRouter>
         <DialogProvider>
           <ChromeProvider value={chrome}>
+            <BlockingSurfaceControl />
             <WorkbenchBrowser
               active
               api={api}
@@ -226,6 +234,23 @@ describe("WorkbenchBrowser", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add to Sources" }));
     await waitFor(() => expect(onAddKnowledgeUrl).toHaveBeenCalledWith("https://docs.example.com/guide"));
     expect(screen.getByRole("status")).toHaveTextContent("Guide is ready for cited retrieval.");
+  });
+
+  it("hides and restores the native browser while a blocking application surface is open", async () => {
+    runtimeMocks.isTauriRuntime.mockReturnValue(true);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
+      return new DOMRect(0, 0, 900, this.classList.contains("browser-toolbar") ? 48 : 600);
+    });
+    renderBrowser();
+    await openPage();
+    const tabId = browserMocks.create.mock.calls[0][0] as string;
+    await waitFor(() => expect(browserMocks.visible).toHaveBeenCalledWith(tabId, "project-1", true));
+
+    fireEvent.click(screen.getByRole("button", { name: "Open blocking surface" }));
+    await waitFor(() => expect(browserMocks.visible).toHaveBeenCalledWith(tabId, "project-1", false));
+
+    fireEvent.click(screen.getByRole("button", { name: "Close blocking surface" }));
+    await waitFor(() => expect(browserMocks.visible).toHaveBeenLastCalledWith(tabId, "project-1", true));
   });
 
   it("adds the final URL of the current page to Project Sources and links to it", async () => {

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -119,6 +119,7 @@ async function installTruthfulCore(page: Page) {
     const url = new URL(request.url());
     const path = url.pathname;
     let body: unknown = [];
+    let responseStatus = 200;
     if (path.endsWith("/health")) {
       body = {
         status: "ok",
@@ -243,16 +244,22 @@ async function installTruthfulCore(page: Page) {
         assistant: { status: "needs_model", provider_profile_id: null, detail: "Optional model connection not configured." },
       };
     } else if (path.endsWith("/workspace-folders")) {
-      const requested = url.searchParams.get("path") ?? "/home/agent";
-      body = {
-        path: requested,
-        parent: requested === "/home/agent" ? "/home" : "/home/agent",
-        directories: requested === "/home/agent" ? [{
-          name: "a-very-long-project-folder-name-that-must-not-expand-the-dialog",
-          path: "/home/agent/a-very-long-project-folder-name-that-must-not-expand-the-dialog",
-        }] : [],
-        truncated: false,
-      };
+      if (request.method() === "POST") {
+        const create = request.postDataJSON() as { parent_path: string; name: string };
+        responseStatus = 201;
+        body = { path: `${create.parent_path}/${create.name}`, parent: create.parent_path, directories: [], truncated: false };
+      } else {
+        const requested = url.searchParams.get("path") ?? "/home/agent";
+        body = {
+          path: requested,
+          parent: requested === "/home/agent" ? "/home" : "/home/agent",
+          directories: requested === "/home/agent" ? [{
+            name: "a-very-long-project-folder-name-that-must-not-expand-the-dialog",
+            path: "/home/agent/a-very-long-project-folder-name-that-must-not-expand-the-dialog",
+          }] : [],
+          truncated: false,
+        };
+      }
     } else if (path.endsWith("/engagements/scratch-project/scope")) {
       body = {
         ...entity,
@@ -529,7 +536,7 @@ async function installTruthfulCore(page: Page) {
       };
     }
     await route.fulfill({
-      status: 200,
+      status: responseStatus,
       contentType: "application/json",
       body: JSON.stringify(body),
     });
@@ -1801,7 +1808,7 @@ test("the 320px mobile companion keeps controls visible and the composer above n
 });
 
 test("host folder picker remains usable as a bounded project workflow", async ({ page }, testInfo) => {
-  test.skip(testInfo.project.name !== "desktop" && !testInfo.project.name.startsWith("mobile-"), "Covered by the permanent desktop and mobile browser projects.");
+  test.skip(!["desktop", "compact"].includes(testInfo.project.name) && !testInfo.project.name.startsWith("mobile-"), "Covered by the permanent desktop and mobile browser projects.");
   await page.addInitScript(() => localStorage.setItem("nebula.theme", "zero-dark"));
   await openWorkspace(page, "/settings", "Settings");
   if (testInfo.project.name.startsWith("mobile-")) {
@@ -1842,6 +1849,13 @@ test("host folder picker remains usable as a bounded project workflow", async ({
     geometry.footerButtons.every(({ height, left, right }) => height >= minimumActionHeight && left >= 0 && right <= geometry.viewportWidth + 1),
     JSON.stringify(geometry),
   ).toBe(true);
+
+  await dialog.getByRole("button", { name: "New folder" }).click();
+  await dialog.getByRole("textbox", { name: "New folder name" }).fill("fresh-assessment");
+  await dialog.getByRole("button", { name: "Create folder" }).click();
+  await expect(dialog.getByText("/home/agent/fresh-assessment", { exact: true })).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "Select folder" })).toBeFocused();
+  await dialog.getByRole("button", { name: "Up one level" }).click();
 
   await dialog.getByRole("button", { name: "a-very-long-project-folder-name-that-must-not-expand-the-dialog" }).click();
   await expect(dialog.getByText("/home/agent/a-very-long-project-folder-name-that-must-not-expand-the-dialog", { exact: true })).toBeVisible();

--- a/ui/tests/real-core.spec.ts
+++ b/ui/tests/real-core.spec.ts
@@ -1169,8 +1169,12 @@ test("production Code quick-open works from a non-loopback LAN origin", async ({
 
 test("real Core persists a project folder chosen through the host browser", async ({ page }) => {
   test.setTimeout(60_000);
-  const core = await startRealCore();
-  const selectedFolder = await mkdtemp(path.join(homedir(), ".nebula-folder-picker-"));
+  const lanAddress = Object.values(networkInterfaces())
+    .flat()
+    .find((address) => address?.family === "IPv4" && !address.internal)?.address;
+  const core = await startRealCore(lanAddress ? { bindHost: "0.0.0.0", browserHost: lanAddress } : {});
+  const folderParent = await mkdtemp(path.join(homedir(), ".nebula-folder-picker-"));
+  const selectedFolder = path.join(folderParent, "fresh-project");
   const api = await playwrightRequest.newContext({
     baseURL: `${core.origin}/api/v1/`,
     extraHTTPHeaders: { Authorization: `Bearer ${core.token}` },
@@ -1178,6 +1182,7 @@ test("real Core persists a project folder chosen through the host browser", asyn
   try {
     await page.goto(`${core.origin}/settings#token=${encodeURIComponent(core.token)}`);
     await expect(page.getByRole("heading", { name: "Settings", exact: true })).toBeVisible({ timeout: 20_000 });
+    if (lanAddress) expect(new URL(page.url()).hostname).toBe(lanAddress);
     await page.getByRole("button", { name: "Switch project" }).click();
     const switcher = page.getByRole("dialog", { name: "Project switcher" });
     await switcher.getByRole("button", { name: "New project" }).click();
@@ -1186,8 +1191,13 @@ test("real Core persists a project folder chosen through the host browser", asyn
 
     const browser = page.getByRole("dialog", { name: "Choose project folder" });
     await expect(browser).toBeVisible();
-    await browser.getByRole("button", { name: path.basename(selectedFolder), exact: true }).click();
+    await browser.getByRole("button", { name: path.basename(folderParent), exact: true }).click();
+    await expect(browser.getByText(folderParent, { exact: true })).toBeVisible();
+    await browser.getByRole("button", { name: "New folder" }).click();
+    await browser.getByRole("textbox", { name: "New folder name" }).fill("fresh-project");
+    await browser.getByRole("button", { name: "Create folder" }).click();
     await expect(browser.getByText(selectedFolder, { exact: true })).toBeVisible();
+    expect(existsSync(selectedFolder)).toBe(true);
     await browser.getByRole("button", { name: "Select folder" }).click();
     await expect(switcher.getByLabel("Project folder", { exact: true })).toHaveValue(selectedFolder);
     await switcher.getByRole("button", { name: "Create" }).click();
@@ -1205,8 +1215,8 @@ test("real Core persists a project folder chosen through the host browser", asyn
   } finally {
     await api.dispose();
     await stopRealCore(core);
-    if (path.basename(selectedFolder).startsWith(".nebula-folder-picker-")) {
-      await rm(selectedFolder, { recursive: true, force: true });
+    if (path.basename(folderParent).startsWith(".nebula-folder-picker-")) {
+      await rm(folderParent, { recursive: true, force: true });
     }
   }
 });


### PR DESCRIPTION
## Outcome

- Hide native Browser child webviews whenever the project switcher or any modal is open.
- Add bounded host-folder creation to the project picker.
- Prevent the portal-backed folder form from submitting the parent project form.

## Verification

- `npm --prefix ui test -- --run` — 67 files, 349 tests passed
- `poetry run pytest -q tests/v3/test_workspace.py` — 18 passed
- `npm --prefix ui run build` — passed
- `npm --prefix ui run test:e2e -- --grep "host folder picker"` — desktop Chromium 1440/1024 plus mobile Chromium/WebKit 320/390/430 passed (one redundant narrow project skipped)
- `TMPDIR=/dev/shm npm --prefix ui run test:e2e -- --project=real-core --no-deps --grep "real Core persists a project folder"` — passed through a non-loopback LAN origin

## Remaining evidence

- Packaged Tauri desktop and physical-device validation were not run.
- `npm --prefix ui run audit:css` still reports two pre-existing unrelated style-contract violations.