### PR TITLE
Stabilize mobile sidebar continuity test

### DIFF
--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -2199,7 +2199,9 @@ test("conversation switching between projects detaches the provider viewer witho
   if (mobileViewport) {
     await page.getByRole("button", { name: "Close sidebar" }).click({
       position: { x: (page.viewportSize()?.width ?? 390) - 8, y: 80 },
+      force: true,
     });
+    await expect(page.locator(".app-shell")).toHaveClass(/sidebar-collapsed/);
   }
   await page.getByRole("button", { name: "New chat", exact: true }).click();
   await page.getByPlaceholder("Ask about this project…").fill("Stop this response explicitly");


### PR DESCRIPTION
## Summary
- exercise the mobile sidebar scrim directly instead of waiting for WebKit's stability heuristic during its transition
- assert the sidebar reaches the collapsed state before continuing the project-switch continuity workflow

## Verification
- mobile WebKit wide exact continuity case repeated 5 times with one worker: 5 passed