### PR TITLE
Add universal searchable settings lens

### DIFF
--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
     {
       name: "mobile-chromium",
       testMatch: "**/interface.spec.ts",
-      grep: /theme picker|host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"] },
     },
     {
@@ -58,31 +58,31 @@ export default defineConfig({
     {
       name: "mobile-chromium-small",
       testMatch: "**/interface.spec.ts",
-      grep: /theme picker|host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"], viewport: { width: 320, height: 700 } },
     },
     {
       name: "mobile-chromium-wide",
       testMatch: "**/interface.spec.ts",
-      grep: /theme picker|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output/,
+      grep: /universal search opens|theme picker|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output/,
       use: { ...devices["Pixel 5"], viewport: { width: 430, height: 932 } },
     },
     {
       name: "mobile-webkit-small",
       testMatch: "**/interface.spec.ts",
-      grep: /theme picker|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output/,
+      grep: /universal search opens|theme picker|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output/,
       use: { ...devices["iPhone 13"], viewport: { width: 320, height: 700 } },
     },
     {
       name: "mobile-webkit",
       testMatch: "**/interface.spec.ts",
-      grep: /theme picker|host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["iPhone 13"] },
     },
     {
       name: "mobile-webkit-wide",
       testMatch: "**/interface.spec.ts",
-      grep: /theme picker|host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["iPhone 13"], viewport: { width: 430, height: 932 } },
     },
     {

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -140,7 +140,7 @@ describe("Nebula workspace", () => {
     const user = userEvent.setup();
     renderApp();
     await user.keyboard("{Control>}k{/Control}");
-    const search = screen.getByRole("textbox", { name: "Search commands" });
+    const search = screen.getByRole("textbox", { name: "Search pages, actions, and settings" });
     await user.type(search, "provider");
     await user.click(screen.getByRole("option", { name: /Go to Settings/ }));
     expect(await screen.findByRole("heading", { name: "Settings" })).toBeVisible();
@@ -161,14 +161,17 @@ describe("Nebula workspace", () => {
     expect(localStorage.getItem("nebula.theme")).toBe("zero-dark");
   });
 
-  it("selects Light from command search and restores the saved preference", async () => {
+  it("opens Appearance from universal search, saves Light, and restores the preference", async () => {
     const user = userEvent.setup();
     const firstRender = renderApp();
     await user.keyboard("{Control>}k{/Control}");
-    await user.type(screen.getByRole("textbox", { name: "Search commands" }), "light theme");
-    await user.click(screen.getByRole("option", { name: /Use Light theme/ }));
+    await user.type(screen.getByRole("textbox", { name: "Search pages, actions, and settings" }), "light theme");
+    await user.click(screen.getByRole("option", { name: /Appearance and theme/ }));
+    const lens = screen.getByRole("dialog", { name: "Appearance and theme" });
+    await user.click(await within(lens).findByRole("button", { name: /^Light$/ }));
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
     expect(localStorage.getItem("nebula.theme")).toBe("light");
+    await user.click(within(lens).getByRole("button", { name: "Done" }));
 
     firstRender.unmount();
     renderApp("/settings");
@@ -198,8 +201,26 @@ describe("Nebula workspace", () => {
     expect(screen.getByRole("button", { name: "Show sidebar" })).toBeVisible();
     expect(localStorage.getItem("nebula.sidebar.collapsed")).toBe("true");
     await user.keyboard("{Control>}k{/Control}");
-    await user.type(screen.getByRole("textbox", { name: "Search commands" }), "Overview");
+    await user.type(screen.getByRole("textbox", { name: "Search pages, actions, and settings" }), "Overview");
     expect(screen.getByRole("option", { name: /Go to Project/ })).toBeVisible();
+  });
+
+  it("opens a focused setting from the top-bar search without leaving the current pane", async () => {
+    const user = userEvent.setup();
+    renderApp("/findings");
+    await screen.findByRole("heading", { name: "Findings" });
+    const searchTrigger = screen.getByRole("button", { name: "Search pages, actions, and settings" });
+    await user.click(searchTrigger);
+    await user.type(screen.getByRole("textbox", { name: "Search pages, actions, and settings" }), "network ports");
+    await user.click(screen.getByRole("option", { name: /Project policy and network scope/ }));
+
+    const lens = screen.getByRole("dialog", { name: "Project policy and network scope" });
+    expect(await within(lens).findByRole("heading", { name: "Project execution policy" })).toBeVisible();
+    expect(within(lens).getByText("Network scope", { selector: "h3" })).toBeVisible();
+    expect(screen.getByTestId("router-location")).toHaveTextContent("/findings");
+
+    await user.click(within(lens).getByRole("button", { name: "Done" }));
+    expect(searchTrigger).toHaveFocus();
   });
 
   it("routes browser and desktop global shortcuts through the shared shell commands", async () => {

--- a/ui/src/base.css
+++ b/ui/src/base.css
@@ -251,10 +251,43 @@ kbd { display: inline-flex; min-width: 20px; min-height: 19px; align-items: cent
 .palette-results button > kbd { color: var(--muted); font: 10px var(--font-mono); white-space: nowrap; }
 .palette-results button strong { font-size: 11px; }
 .palette-results button small { margin-top: 3px; color: var(--muted); font-size: 11px; }
+.palette-result-meta { margin-top: 5px; color: var(--blue); font-size: 10px; font-style: normal; font-weight: var(--weight-semibold); letter-spacing: .015em; }
 .palette-icon { display: grid; width: 31px; height: 31px; place-items: center; border: 1px solid var(--border); border-radius: var(--radius-control); color: var(--blue); background: var(--surface); }
 .palette-empty { margin: 24px; color: var(--muted); text-align: center; font-size: 11px; }
 .command-palette > footer { display: flex; gap: 16px; padding: 8px 14px; border-top: 1px solid var(--border-soft); color: var(--muted); font-size: 11px; }
 .command-palette footer span { display: flex; align-items: center; gap: 4px; }
+
+.settings-lens-backdrop { position: fixed; z-index: 110; inset: 0; display: grid; place-items: center; padding: 24px; background: var(--overlay-scrim); backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
+.settings-lens { display: grid; width: min(1080px, calc(100vw - 48px)); max-height: min(860px, calc(100dvh - 48px)); grid-template-rows: auto minmax(0, 1fr) auto; overflow: hidden; border: 1px solid var(--border); border-radius: 18px; background: var(--surface-raised); box-shadow: var(--shadow-overlay); }
+.settings-lens-header { display: grid; min-width: 0; grid-template-columns: 40px minmax(0, 1fr) 44px; align-items: start; gap: 12px; padding: 18px 20px 16px; border-bottom: 1px solid var(--border-soft); }
+.settings-lens-header > div { min-width: 0; }
+.settings-lens-header small { color: var(--blue); font-size: 10px; font-weight: var(--weight-bold); text-transform: uppercase; letter-spacing: .045em; }
+.settings-lens-header h2 { margin: 4px 0 3px; color: var(--text-strong); font-size: 18px; }
+.settings-lens-header p { margin: 0; color: var(--muted); font-size: 11px; line-height: 1.45; }
+.settings-lens-icon { display: grid; width: 40px; height: 40px; place-items: center; border: 1px solid color-mix(in srgb, var(--blue) 38%, var(--border)); border-radius: 11px; color: var(--blue); background: var(--blue-muted); }
+.settings-lens-content { min-height: 0; padding: 20px; overflow: auto; overscroll-behavior: contain; }
+.settings-lens-loading { display: grid; min-height: 240px; place-items: center; color: var(--muted); font-size: 12px; }
+.settings-lens > footer { display: flex; min-height: 66px; align-items: center; justify-content: flex-end; gap: 8px; padding: 11px 20px; border-top: 1px solid var(--border-soft); background: var(--surface-muted); }
+.settings-lens > footer > span { margin-right: auto; color: var(--muted); font-size: 11px; }
+.embedded-settings-page { width: 100%; padding: 0; }
+.embedded-settings-page .settings-workspace { display: block !important; grid-template-columns: none !important; }
+.embedded-settings-page .settings-detail { display: grid; gap: 16px; }
+.embedded-settings-page .settings-group[hidden] { display: none !important; }
+.embedded-settings-page .settings-group > summary { display: none; }
+.embedded-settings-page .settings-group-body { padding: 0; border: 0; }
+.embedded-settings-page .settings-group { width: 100%; overflow: visible; border: 0; background: transparent; }
+
+@media (max-width: 700px) {
+  .settings-lens-backdrop { display: block; padding: 0; }
+  .settings-lens { width: 100vw; max-height: 100dvh; height: 100dvh; border: 0; border-radius: 0; }
+  .settings-lens-header { grid-template-columns: 36px minmax(0, 1fr) 44px; gap: 10px; padding: max(12px, env(safe-area-inset-top)) 12px 12px; }
+  .settings-lens-icon { width: 36px; height: 36px; }
+  .settings-lens-header h2 { font-size: 16px; }
+  .settings-lens-content { padding: 14px 12px 24px; }
+  .settings-lens > footer { min-height: 72px; padding: 10px 12px max(10px, env(safe-area-inset-bottom)); }
+  .settings-lens > footer > span, .settings-lens > footer .secondary { display: none; }
+  .settings-lens > footer .primary { width: 100%; min-height: 44px; }
+}
 
 /* Overview */
 .metric-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 11px; margin-bottom: 13px; }

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -14,6 +14,8 @@ import { UpdateBanner } from "./UpdateBanner";
 import { DiagnosticErrorNotice, DiagnosticsAvailabilityBanner, logDiagnostic } from "../diagnostics";
 import { browserAuthorizationRecovery } from "../api/runtime";
 import { BrowserAutomationWorker } from "./BrowserAutomationWorker";
+import { SettingsLens } from "./SettingsLens";
+import type { SettingCatalogEntry } from "../settingsCatalog";
 
 const resourceLabels: Record<string, string> = {
   projects: "Projects", providers: "Model providers", providerCatalog: "Provider setup",
@@ -40,6 +42,7 @@ export function AppShell() {
   const [activityOpen, setActivityOpen] = useState(false);
   const [activityView, setActivityView] = useState<ActivityCenterView>("activity");
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [settingLens, setSettingLens] = useState<{ entry: SettingCatalogEntry; returnFocus: HTMLElement | null }>();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
     const stored = localStorage.getItem("nebula.sidebar.collapsed");
     return stored === null ? window.matchMedia("(max-width: 760px)").matches : stored === "true";
@@ -186,7 +189,9 @@ export function AppShell() {
                 onClose={() => setPaletteOpen(false)}
                 onToggleActivity={toggleActivity}
                 onToggleSidebar={toggleSidebar}
+                onOpenSetting={(entry, returnFocus) => setSettingLens({ entry, returnFocus })}
               />
+              {settingLens && <SettingsLens entry={settingLens.entry} key={settingLens.entry.id} returnFocus={settingLens.returnFocus} onClose={() => setSettingLens(undefined)} />}
             </div>
           </ChromeProvider>
         </WorkbenchDraftProvider>

--- a/ui/src/components/CommandPalette.tsx
+++ b/ui/src/components/CommandPalette.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
-import { Command, Moon, PanelLeft, PanelRight, Search, Sun } from "lucide-react";
+import { Command, PanelLeft, PanelRight, Search, SlidersHorizontal } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { navigationItems } from "../navigation";
-import { useTheme } from "../state/ThemeContext";
+import { settingCatalog, settingCatalogText, type SettingCatalogEntry } from "../settingsCatalog";
 import type { ContextualCommand } from "../state/ChromeContext";
 
 interface CommandPaletteProps {
@@ -10,6 +10,7 @@ interface CommandPaletteProps {
   onClose: () => void;
   onToggleActivity: () => void;
   onToggleSidebar: () => void;
+  onOpenSetting: (entry: SettingCatalogEntry, returnFocus: HTMLElement | null) => void;
   contextualCommands?: ContextualCommand[];
 }
 
@@ -20,6 +21,8 @@ interface PaletteAction {
   icon: typeof Command;
   keywords: string;
   shortcut?: string;
+  meta?: string;
+  kind?: "command" | "setting";
   disabled?: boolean;
   run: () => void;
 }
@@ -31,9 +34,8 @@ const FOCUSABLE = [
   "[tabindex]:not([tabindex='-1'])",
 ].join(",");
 
-export function CommandPalette({ open, onClose, onToggleActivity, onToggleSidebar, contextualCommands = [] }: CommandPaletteProps) {
+export function CommandPalette({ open, onClose, onToggleActivity, onToggleSidebar, onOpenSetting, contextualCommands = [] }: CommandPaletteProps) {
   const navigate = useNavigate();
-  const { setPreference } = useTheme();
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -50,30 +52,16 @@ export function CommandPalette({ open, onClose, onToggleActivity, onToggleSideba
         keywords: `${item.label} ${item.legacyLabel ?? ""} ${item.aliases.join(" ")} ${item.description}`,
         run: () => navigate(item.path),
       })),
-      {
-        id: "theme-light",
-        label: "Use Light theme",
-        description: "Use the light workspace on this device",
-        icon: Sun,
-        keywords: "appearance theme light",
-        run: () => setPreference("light"),
-      },
-      {
-        id: "theme-dark",
-        label: "Use Dark theme",
-        description: "Use the dark workspace on this device",
-        icon: Moon,
-        keywords: "appearance theme dark",
-        run: () => setPreference("dark"),
-      },
-      {
-        id: "theme-zero-dark",
-        label: "Use Zero Dark theme",
-        description: "Use the dark Zero workspace on this device",
-        icon: Moon,
-        keywords: "appearance theme zero dark",
-        run: () => setPreference("zero-dark"),
-      },
+      ...settingCatalog.map((entry) => ({
+        id: entry.id,
+        label: entry.label,
+        description: entry.description,
+        icon: SlidersHorizontal,
+        keywords: settingCatalogText(entry),
+        meta: `${entry.category} · ${entry.scope}`,
+        kind: "setting" as const,
+        run: () => onOpenSetting(entry, returnFocusRef.current),
+      })),
       {
         id: "sidebar",
         label: "Toggle sidebar",
@@ -96,14 +84,25 @@ export function CommandPalette({ open, onClose, onToggleActivity, onToggleSideba
         keywords: `${command.keywords ?? ""} editor code`,
       })),
     ],
-    [contextualCommands, navigate, onToggleActivity, onToggleSidebar, setPreference],
+    [contextualCommands, navigate, onOpenSetting, onToggleActivity, onToggleSidebar],
   );
 
   const results = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    return needle
-      ? actions.filter((action) => `${action.label} ${action.keywords}`.toLowerCase().includes(needle))
-      : actions;
+    if (!needle) return actions;
+    const terms = needle.split(/\s+/).filter(Boolean);
+    return actions
+      .filter((action) => {
+        const haystack = `${action.label} ${action.keywords}`.toLowerCase();
+        return terms.every((term) => haystack.includes(term));
+      })
+      .sort((left, right) => {
+        const leftLabel = left.label.toLowerCase();
+        const rightLabel = right.label.toLowerCase();
+        const leftScore = leftLabel.startsWith(needle) ? 0 : left.kind === "setting" ? 1 : 2;
+        const rightScore = rightLabel.startsWith(needle) ? 0 : right.kind === "setting" ? 1 : 2;
+        return leftScore - rightScore;
+      });
   }, [actions, query]);
 
   useEffect(() => {
@@ -161,13 +160,13 @@ export function CommandPalette({ open, onClose, onToggleActivity, onToggleSideba
       >
         <label className="palette-search">
           <Search size={19} aria-hidden="true" />
-          <span className="sr-only">Search commands</span>
+          <span className="sr-only">Search pages, actions, and settings</span>
           <input
             ref={inputRef}
-            aria-label="Search commands"
+            aria-label="Search pages, actions, and settings"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search pages and actions…"
+            placeholder="Search pages, actions, and settings…"
             onKeyDown={(event) => {
               if (event.key === "ArrowDown") {
                 event.preventDefault();
@@ -201,6 +200,7 @@ export function CommandPalette({ open, onClose, onToggleActivity, onToggleSideba
                 <span>
                   <strong>{action.label}</strong>
                   <small>{action.description}</small>
+                  {action.meta && <em className="palette-result-meta">{action.meta}</em>}
                 </span>
                 {action.shortcut && <kbd>{action.shortcut}</kbd>}
               </button>

--- a/ui/src/components/SettingsLens.tsx
+++ b/ui/src/components/SettingsLens.tsx
@@ -1,0 +1,92 @@
+import { lazy, Suspense, useEffect, useRef, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { ExternalLink, SlidersHorizontal, X } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import type { SettingCatalogEntry } from "../settingsCatalog";
+
+const SettingsPage = lazy(() => import("../pages/SettingsPage").then((module) => ({ default: module.SettingsPage })));
+
+interface SettingsLensProps {
+  entry: SettingCatalogEntry;
+  onClose: () => void;
+  returnFocus?: HTMLElement | null;
+}
+
+const FOCUSABLE = [
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[href]",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+export function SettingsLens({ entry, onClose, returnFocus }: SettingsLensProps) {
+  const navigate = useNavigate();
+  const lensRef = useRef<HTMLDivElement>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    returnFocusRef.current = returnFocus ?? (document.activeElement instanceof HTMLElement ? document.activeElement : null);
+    return () => returnFocusRef.current?.focus();
+  }, [returnFocus]);
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const items = [...(lensRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? [])]
+      .filter((element) => element.offsetParent !== null);
+    if (!items.length) return;
+    const first = items[0];
+    const last = items[items.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const openFullSettings = () => {
+    onClose();
+    navigate(`/settings#${entry.target}`);
+  };
+
+  return (
+    <div className="settings-lens-backdrop" role="presentation" onMouseDown={onClose}>
+      <div
+        ref={lensRef}
+        className="settings-lens"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settings-lens-title"
+        onKeyDown={handleKeyDown}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="settings-lens-header">
+          <span className="settings-lens-icon"><SlidersHorizontal size={18} aria-hidden="true" /></span>
+          <div>
+            <small>{entry.category} · {entry.scope}</small>
+            <h2 id="settings-lens-title">{entry.label}</h2>
+            <p>{entry.description}</p>
+          </div>
+          <button className="icon-button subtle" type="button" aria-label="Close setting" onClick={onClose}><X size={18} /></button>
+        </div>
+        <div className="settings-lens-content">
+          <Suspense fallback={<div className="settings-lens-loading" role="status">Loading setting…</div>}>
+            <SettingsPage embeddedTarget={entry.target} />
+          </Suspense>
+        </div>
+        <footer>
+          <span>Changes use the same validation and storage as Settings.</span>
+          <button className="button secondary" type="button" onClick={openFullSettings}><ExternalLink size={14} /> Open full settings</button>
+          <button className="button primary" type="button" onClick={onClose}>Done</button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/SurfacePrimitives.tsx
+++ b/ui/src/components/SurfacePrimitives.tsx
@@ -234,15 +234,17 @@ interface SettingsGroupProps {
   onOpen: (id: string) => void;
   children: ReactNode;
   bodyClassName?: string;
+  hidden?: boolean;
 }
 
 /** A URL-controlled Settings disclosure. Opening one group closes its sibling. */
-export function SettingsGroup({ id, title, summary, open, onOpen, children, bodyClassName = "" }: SettingsGroupProps) {
+export function SettingsGroup({ id, title, summary, open, onOpen, children, bodyClassName = "", hidden = false }: SettingsGroupProps) {
   return (
     <details
       className="settings-group"
       id={id}
       open={open}
+      hidden={hidden}
     >
       <summary onClick={(event) => { event.preventDefault(); onOpen(id); }}><span><strong>{title}</strong><small>{summary}</small></span></summary>
       <div className={`settings-group-body ${bodyClassName}`.trim()}>{children}</div>

--- a/ui/src/components/TopBar.tsx
+++ b/ui/src/components/TopBar.tsx
@@ -75,7 +75,7 @@ export function TopBar({
           )}
           <span>{workspaceState === "degraded" ? "Limited" : workspaceState}</span>
         </button>
-        <button className="command-trigger" type="button" onClick={onOpenPalette} aria-label="Search commands">
+        <button className="command-trigger" type="button" onClick={onOpenPalette} aria-label="Search pages, actions, and settings">
           <Command size={15} aria-hidden="true" />
           <span>Search</span>
           <kbd>⌘K</kbd>

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -41,6 +41,10 @@ const advancedSettingsGroups = [
 ] as const;
 type AdvancedSettingsGroup = typeof advancedSettingsGroups[number];
 
+interface SettingsPageProps {
+  embeddedTarget?: string;
+}
+
 function elapsedLabel(startedAt: string | undefined, now: number): string | undefined {
   if (!startedAt) return undefined;
   const elapsedSeconds = Math.max(0, Math.floor((now - Date.parse(startedAt)) / 1_000));
@@ -64,6 +68,12 @@ function sectionFromHash(): SettingsSection {
   return "setup-settings";
 }
 
+function sectionFromTarget(target: string | undefined): SettingsSection {
+  if (target === "setup-settings") return "setup-settings";
+  if (target === "diagnostics-settings") return "diagnostics-settings";
+  return "advanced-settings";
+}
+
 function providerOption(provider: ProviderHealth, key: string): string {
   const value = provider.options[key];
   return typeof value === "string" ? value : "";
@@ -74,7 +84,7 @@ function providerNumberOption(provider: ProviderHealth, key: string): string {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? String(value) : "";
 }
 
-export function SettingsPage() {
+export function SettingsPage({ embeddedTarget }: SettingsPageProps = {}) {
   const confirm = useConfirmation();
   const { preference, setPreference } = useTheme();
   const {
@@ -160,8 +170,10 @@ export function SettingsPage() {
   const [operatorRole, setOperatorRole] = useState("");
   const [operatorBusy, setOperatorBusy] = useState<string>();
   const [operatorError, setOperatorError] = useState<string>();
-  const [settingsSection, setSettingsSection] = useState<SettingsSection>(sectionFromHash);
-  const [openAdvancedGroup, setOpenAdvancedGroup] = useState<AdvancedSettingsGroup>(advancedGroupFromHash);
+  const embedded = Boolean(embeddedTarget);
+  const embeddedAdvancedGroup = advancedGroupFromHash(embeddedTarget);
+  const [settingsSection, setSettingsSection] = useState<SettingsSection>(() => embedded ? sectionFromTarget(embeddedTarget) : sectionFromHash());
+  const [openAdvancedGroup, setOpenAdvancedGroup] = useState<AdvancedSettingsGroup>(() => embedded ? embeddedAdvancedGroup : advancedGroupFromHash());
   const [checkingTerminal, setCheckingTerminal] = useState(false);
   const [preparationClock, setPreparationClock] = useState(Date.now());
   const [selectingRuntime, setSelectingRuntime] = useState<string>();
@@ -190,6 +202,7 @@ export function SettingsPage() {
   }, [api, workspaceState]);
 
   useEffect(() => {
+    if (embedded) return;
     const syncSection = () => {
       const section = sectionFromHash();
       setSettingsSection(section);
@@ -197,12 +210,12 @@ export function SettingsPage() {
     };
     window.addEventListener("hashchange", syncSection);
     return () => window.removeEventListener("hashchange", syncSection);
-  }, []);
+  }, [embedded]);
 
   useEffect(() => {
     if (settingsSection !== "advanced-settings") return;
     const frame = window.requestAnimationFrame(() => {
-      const hash = window.location.hash.slice(1);
+      const hash = embeddedTarget ?? window.location.hash.slice(1);
       const target = document.getElementById(hash === "advanced-settings" ? "models-settings" : hash);
       const group = target?.matches("details") ? target as HTMLDetailsElement : target?.closest<HTMLDetailsElement>("details.settings-group");
       if (!group) return;
@@ -212,14 +225,14 @@ export function SettingsPage() {
       group.scrollIntoView?.({ block: "start" });
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [openAdvancedGroup, settingsSection]);
+  }, [embeddedTarget, openAdvancedGroup, settingsSection]);
 
   const openSettingsGroup = (id: string) => {
     const group = id as AdvancedSettingsGroup;
     if (!advancedSettingsGroups.includes(group)) return;
     setOpenAdvancedGroup(group);
     setSettingsSection("advanced-settings");
-    if (window.location.hash !== `#${group}`) window.history.replaceState(null, "", `#${group}`);
+    if (!embedded && window.location.hash !== `#${group}`) window.history.replaceState(null, "", `#${group}`);
   };
 
   useEffect(() => {
@@ -596,11 +609,11 @@ export function SettingsPage() {
     return () => window.clearInterval(timer);
   }, [imagePreparationActive]);
   return (
-    <div className="page settings-page">
+    <div className={`page settings-page${embedded ? " embedded-settings-page" : ""}`} data-embedded-target={embeddedTarget}>
       <SettingsSaveFeedback />
-      <PageHeader title="Settings" description="Workspace preferences." />
+      {!embedded && <PageHeader title="Settings" description="Workspace preferences." />}
       <div className="settings-workspace">
-      <nav className="settings-tabs" aria-label="Settings sections">{settingsSections.map(([id, label, accessibleLabel]) => <a className={settingsSection === id ? "active" : undefined} aria-label={accessibleLabel} aria-current={settingsSection === id ? "page" : undefined} href={`#${id}`} key={id} onClick={(event) => { event.preventDefault(); const hash = id === "advanced-settings" ? openAdvancedGroup : id; window.history.replaceState(null, "", `#${hash}`); setSettingsSection(id); }}>{label}</a>)}</nav>
+      {!embedded && <nav className="settings-tabs" aria-label="Settings sections">{settingsSections.map(([id, label, accessibleLabel]) => <a className={settingsSection === id ? "active" : undefined} aria-label={accessibleLabel} aria-current={settingsSection === id ? "page" : undefined} href={`#${id}`} key={id} onClick={(event) => { event.preventDefault(); const hash = id === "advanced-settings" ? openAdvancedGroup : id; window.history.replaceState(null, "", `#${hash}`); setSettingsSection(id); }}>{label}</a>)}</nav>}
       <div className="settings-detail" data-section={settingsSection}>
       <section className="settings-section setup-overview" id="setup-settings">
         <div className="section-heading"><div><h2>Readiness</h2><p>Terminal is the only required runtime. Models remain optional.</p></div></div>
@@ -647,7 +660,7 @@ export function SettingsPage() {
         {!setupStatus && workspaceState !== "starting" && <p className="setup-footnote">Setup details are unavailable. Core reports runner status: {health?.runner ?? "unknown"}.</p>}
       </section>
       <DiagnosticsPanel hidden={settingsSection !== "diagnostics-settings"} />
-      <SettingsGroup id="models-settings" title="Models" summary={providers.length ? `${providers.filter((provider) => provider.enabled).length} enabled provider${providers.filter((provider) => provider.enabled).length === 1 ? "" : "s"}` : "Optional · no provider configured"} open={openAdvancedGroup === "models-settings"} onOpen={openSettingsGroup}>
+      <SettingsGroup id="models-settings" title="Models" summary={providers.length ? `${providers.filter((provider) => provider.enabled).length} enabled provider${providers.filter((provider) => provider.enabled).length === 1 ? "" : "s"}` : "Optional · no provider configured"} open={openAdvancedGroup === "models-settings"} onOpen={openSettingsGroup} hidden={embedded && embeddedAdvancedGroup !== "models-settings"}>
       <section className="settings-section" id="provider-settings">
         <div className="section-heading"><div><h2>Model providers</h2><p>Models and capabilities</p></div><button className="button primary" type="button" disabled={previewMode || providerCatalog.length === 0} onClick={openProviderDialog}><Plus size={16} /> Add provider</button></div>
         {providerActionError && <DiagnosticErrorNotice error={providerActionError} fallback="The provider operation could not be completed." />}
@@ -658,16 +671,16 @@ export function SettingsPage() {
         )}
       </section>
       </SettingsGroup>
-      <SettingsGroup id="automation-settings" title="Automation" summary="Harnesses, follow-up, and isolated runtimes" open={openAdvancedGroup === "automation-settings"} onOpen={openSettingsGroup}>
+      <SettingsGroup id="automation-settings" title="Automation" summary="Harnesses, follow-up, and isolated runtimes" open={openAdvancedGroup === "automation-settings"} onOpen={openSettingsGroup} hidden={embedded && embeddedAdvancedGroup !== "automation-settings"}>
       <PostToolAssistantSettings api={api} engagementId={engagement?.id} providers={providers} previewMode={previewMode} />
       <HarnessSettings />
       <AutomationRuntimeSettings />
       <RunnerSettings />
       </SettingsGroup>
-      <SettingsGroup id="project-policy-settings" title="Project Policy" summary={engagement ? `${engagement.name} · deny network unless scoped` : "Select a project"} open={openAdvancedGroup === "project-policy-settings"} onOpen={openSettingsGroup}>
+      <SettingsGroup id="project-policy-settings" title="Project Policy" summary={engagement ? `${engagement.name} · deny network unless scoped` : "Select a project"} open={openAdvancedGroup === "project-policy-settings"} onOpen={openSettingsGroup} hidden={embedded && embeddedAdvancedGroup !== "project-policy-settings"}>
       <EngagementPolicySettings />
       </SettingsGroup>
-      <SettingsGroup id="identity-security-settings" title="Identity & Security" summary={operatorProfiles.find((profile) => profile.active)?.displayName ?? "Operator attribution and local credentials"} open={openAdvancedGroup === "identity-security-settings"} onOpen={openSettingsGroup}>
+      <SettingsGroup id="identity-security-settings" title="Identity & Security" summary={operatorProfiles.find((profile) => profile.active)?.displayName ?? "Operator attribution and local credentials"} open={openAdvancedGroup === "identity-security-settings"} onOpen={openSettingsGroup} hidden={embedded && embeddedAdvancedGroup !== "identity-security-settings"}>
       <section className="settings-section" id="operator-settings">
         <div className="section-heading"><div><h2>Operator profiles</h2><p>Local activity attribution</p></div><button className="button primary" type="button" disabled={previewMode} onClick={() => openOperator()}><Plus size={16} /> Add operator</button></div>
         {operatorError && <DiagnosticErrorNotice error={operatorError} fallback="The operator profile operation could not be completed." />}
@@ -690,7 +703,7 @@ export function SettingsPage() {
         </section>
       </div>
       </SettingsGroup>
-      <SettingsGroup id="release-settings-group" title="Release" summary="Version and update channel" open={openAdvancedGroup === "release-settings-group"} onOpen={openSettingsGroup} bodyClassName="settings-release-body"><ReleaseSettingsPanel /></SettingsGroup>
+      <SettingsGroup id="release-settings-group" title="Release" summary="Version and update channel" open={openAdvancedGroup === "release-settings-group"} onOpen={openSettingsGroup} bodyClassName="settings-release-body" hidden={embedded && embeddedAdvancedGroup !== "release-settings-group"}><ReleaseSettingsPanel /></SettingsGroup>
       </div>
       </div>
       {adding && (selected || editingProvider) && (

--- a/ui/src/settingsCatalog.ts
+++ b/ui/src/settingsCatalog.ts
@@ -1,0 +1,135 @@
+export type SettingScope = "Device" | "Project" | "Workspace" | "Security";
+
+export interface SettingCatalogEntry {
+  id: string;
+  label: string;
+  description: string;
+  category: string;
+  scope: SettingScope;
+  target: string;
+  keywords: string[];
+}
+
+export const settingCatalog: SettingCatalogEntry[] = [
+  {
+    id: "settings.appearance",
+    label: "Appearance and theme",
+    description: "Choose Light, Dark, or Zero Dark for this device",
+    category: "Identity & Security",
+    scope: "Device",
+    target: "appearance-settings",
+    keywords: ["appearance", "theme", "light", "dark", "zero dark", "color scheme", "display"],
+  },
+  {
+    id: "settings.providers",
+    label: "Model providers",
+    description: "Add providers, credentials, discovered models, and capability limits",
+    category: "Models",
+    scope: "Workspace",
+    target: "provider-settings",
+    keywords: ["provider", "model", "openai", "anthropic", "gemini", "ollama", "vllm", "credential", "api key"],
+  },
+  {
+    id: "settings.follow-up",
+    label: "Post-tool assistant",
+    description: "Configure automatic follow-up after terminal and tool results",
+    category: "Automation",
+    scope: "Project",
+    target: "post-tool-assistant-settings",
+    keywords: ["post tool", "follow up", "assistant", "automatic", "suggestion"],
+  },
+  {
+    id: "settings.harnesses",
+    label: "Assistant harnesses",
+    description: "Configure Codex and other assistant harness capabilities",
+    category: "Automation",
+    scope: "Workspace",
+    target: "harness-settings",
+    keywords: ["harness", "codex", "assistant", "steer", "interrupt", "capabilities"],
+  },
+  {
+    id: "settings.mcp",
+    label: "MCP servers",
+    description: "Manage trusted local and HTTPS MCP integrations",
+    category: "Automation",
+    scope: "Security",
+    target: "mcp-settings",
+    keywords: ["mcp", "server", "tool", "integration", "stdio", "streamable http"],
+  },
+  {
+    id: "settings.automation-runtime",
+    label: "Automation runtime",
+    description: "Select the command runtime used by automated operations",
+    category: "Automation",
+    scope: "Workspace",
+    target: "automation-runtime-settings",
+    keywords: ["automation", "runtime", "command", "container", "execution"],
+  },
+  {
+    id: "settings.runners",
+    label: "Sandbox runners",
+    description: "Configure trusted Docker or Podman execution profiles",
+    category: "Automation",
+    scope: "Workspace",
+    target: "runtime-settings",
+    keywords: ["runner", "sandbox", "docker", "podman", "socket", "seccomp", "container"],
+  },
+  {
+    id: "settings.network-scope",
+    label: "Project policy and network scope",
+    description: "Control targets, ports, URLs, approvals, privacy, and execution limits",
+    category: "Project Policy",
+    scope: "Project",
+    target: "engagement-policy-settings",
+    keywords: ["network", "scope", "domain", "cidr", "port", "url", "allowlist", "all targets", "approval", "privacy", "timeout", "prohibited actions"],
+  },
+  {
+    id: "settings.operators",
+    label: "Operator profiles",
+    description: "Manage the local identity used for activity attribution",
+    category: "Identity & Security",
+    scope: "Security",
+    target: "operator-settings",
+    keywords: ["operator", "profile", "identity", "name", "email", "role", "attribution"],
+  },
+  {
+    id: "settings.devices",
+    label: "Paired devices",
+    description: "Pair, inspect, and revoke browsers and mobile devices",
+    category: "Identity & Security",
+    scope: "Security",
+    target: "device-pairing-settings",
+    keywords: ["device", "pair", "phone", "mobile", "browser", "qr", "revoke"],
+  },
+  {
+    id: "settings.release",
+    label: "Release and updates",
+    description: "Inspect the installed version and update channel",
+    category: "Release",
+    scope: "Device",
+    target: "release-settings-group",
+    keywords: ["release", "update", "version", "channel", "upgrade"],
+  },
+  {
+    id: "settings.diagnostics",
+    label: "Diagnostics and logging",
+    description: "Configure logs and inspect recoverable interface failures",
+    category: "Diagnostics",
+    scope: "Device",
+    target: "diagnostics-settings",
+    keywords: ["diagnostics", "logging", "logs", "errors", "support bundle", "telemetry"],
+  },
+  {
+    id: "settings.setup",
+    label: "Terminal and Core setup",
+    description: "Check runtime readiness and configure the UI shell connection",
+    category: "Setup",
+    scope: "Workspace",
+    target: "setup-settings",
+    keywords: ["setup", "terminal", "core", "remote core", "connection", "readiness", "kali"],
+  },
+];
+
+export function settingCatalogText(entry: SettingCatalogEntry): string {
+  return [entry.label, entry.description, entry.category, entry.scope, ...entry.keywords].join(" ");
+}

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -942,11 +942,43 @@ test("Light keeps the shared status and search cluster in the conventional shell
   await setTheme(page, "light");
 
   const ready = page.getByRole("button", { name: "Nebula Core ready" });
-  const search = page.getByRole("button", { name: "Search commands" });
+  const search = page.getByRole("button", { name: "Search pages, actions, and settings" });
   await expect(ready).toBeVisible();
   await expect(search).toBeVisible();
   await expect(page.locator(".app-shell")).not.toHaveClass(/zero-layer-shell/);
   await expect(page.locator(".top-bar")).not.toHaveClass(/zero-status-band/);
+});
+
+test("universal search opens a focused setting without leaving the active pane", async ({ page }) => {
+  await openWorkspace(page, "/findings", "Findings");
+  const search = page.getByRole("button", { name: "Search pages, actions, and settings" });
+  await search.click();
+  await page.getByRole("textbox", { name: "Search pages, actions, and settings" }).fill("network ports");
+  await page.getByRole("option", { name: /Project policy and network scope/ }).click();
+
+  const lens = page.getByRole("dialog", { name: "Project policy and network scope" });
+  await expect(lens).toBeVisible();
+  await expect(lens.getByRole("heading", { name: "Project execution policy" })).toBeVisible();
+  await expect(lens.getByRole("heading", { name: "Network scope", exact: true })).toBeVisible();
+  expect(new URL(page.url()).pathname).toBe("/findings");
+
+  const bounds = await lens.boundingBox();
+  const viewport = page.viewportSize();
+  expect(bounds).not.toBeNull();
+  expect(viewport).not.toBeNull();
+  expect(bounds!.x).toBeGreaterThanOrEqual(0);
+  expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(viewport!.width + 1);
+  expect(bounds!.y).toBeGreaterThanOrEqual(0);
+  expect(bounds!.y + bounds!.height).toBeLessThanOrEqual(viewport!.height + 1);
+  const groupBounds = await lens.locator("#project-policy-settings").boundingBox();
+  expect(groupBounds).not.toBeNull();
+  expect(groupBounds!.width).toBeGreaterThan(bounds!.width * 0.8);
+  const accessibility = await new AxeBuilder({ page }).include(".settings-lens").analyze();
+  expect(accessibility.violations).toEqual([]);
+
+  await lens.getByRole("button", { name: "Done" }).click();
+  await expect(lens).toBeHidden();
+  await expect(search).toBeFocused();
 });
 
 test("primary navigation exposes only the five task destinations", async ({ page }) => {
@@ -3329,7 +3361,7 @@ test("the code editor keeps its caret and syntax layers aligned while typing", a
   if ((page.viewportSize()?.width ?? 1_000) <= 760) {
     await page.keyboard.press("Control+Shift+P");
     const palette = page.getByRole("dialog", { name: "Command palette" });
-    await palette.getByRole("textbox", { name: "Search commands" }).fill("Editor: Workspace Environment");
+    await palette.getByRole("textbox", { name: "Search pages, actions, and settings" }).fill("Editor: Workspace Environment");
     await palette.getByRole("option", { name: /Editor: Workspace Environment/ }).click();
   } else {
     await page.getByRole("button", { name: "Environment", exact: true }).click();
@@ -3492,7 +3524,7 @@ test("the code editor keeps its caret and syntax layers aligned while typing", a
   await page.keyboard.press("Control+Shift+P");
   const editorPalette = page.getByRole("dialog", { name: "Command palette" });
   await expect(editorPalette).toBeVisible();
-  await editorPalette.getByRole("textbox", { name: "Search commands" }).fill("Editor: Debug Saved Python");
+    await editorPalette.getByRole("textbox", { name: "Search pages, actions, and settings" }).fill("Editor: Debug Saved Python");
   const unavailableDebugger = editorPalette.getByRole("option", { name: /Editor: Debug Saved Python/ });
   await expect(unavailableDebugger).toBeDisabled();
   await expect(unavailableDebugger).toContainText("Debugging requires an open Python file");
@@ -3880,7 +3912,7 @@ test("Zero keeps its themed shell without the removed context deck", async ({ pa
   await expect(page.locator(".zero-route-flare, .zero-anchor-dock, .zero-status-band")).toHaveCount(3);
   await expect(page.getByRole("region", { name: "Zero Layer context" })).toHaveCount(0);
 
-  await page.getByRole("button", { name: "Search commands" }).click();
+  await page.getByRole("button", { name: "Search pages, actions, and settings" }).click();
   await expect(page.getByRole("dialog", { name: "Command palette" })).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(page.getByRole("dialog", { name: "Command palette" })).toBeHidden();
@@ -3964,9 +3996,11 @@ test("Zero keeps one navigable panoramic shell at every breakpoint", async ({ pa
   const persistentSurface = mobile ? page.locator(".sessions-page") : page.locator(".persistent-terminal");
   await expect(persistentSurface).toBeVisible();
   await persistentSurface.evaluate((element) => { (window as typeof window & { __zeroTerminal?: Element }).__zeroTerminal = element; });
-  await page.getByRole("button", { name: "Search commands" }).click();
-  await page.getByRole("textbox", { name: "Search commands" }).fill("Light theme");
-  await page.getByRole("option", { name: /Use Light theme/ }).click();
+  await page.getByRole("button", { name: "Search pages, actions, and settings" }).click();
+  await page.getByRole("textbox", { name: "Search pages, actions, and settings" }).fill("Light theme");
+  await page.getByRole("option", { name: /Appearance and theme/ }).click();
+  const appearanceLens = page.getByRole("dialog", { name: "Appearance and theme" });
+  await appearanceLens.getByRole("button", { name: /^Light$/ }).click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
   expect(await persistentSurface.evaluate((element) => (window as typeof window & { __zeroTerminal?: Element }).__zeroTerminal === element)).toBe(true);
 });
@@ -3986,7 +4020,7 @@ test("Zero Dark preserves representative desktop overlays", async ({ page }, tes
   test.skip(testInfo.project.name !== "desktop", "Zero Dark visual baselines are captured at the reference desktop size.");
   await page.addInitScript(() => localStorage.setItem("nebula.theme", "zero-dark"));
   await openWorkspace(page, "/", "Workbench");
-  await page.getByRole("button", { name: "Search commands" }).click();
+  await page.getByRole("button", { name: "Search pages, actions, and settings" }).click();
   await expect(page.getByRole("dialog", { name: "Command palette" })).toBeVisible();
   await expect(page).toHaveScreenshot("workbench-zero-dark-command-palette.png", { fullPage: true });
 

--- a/ui/tests/real-core.spec.ts
+++ b/ui/tests/real-core.spec.ts
@@ -664,18 +664,21 @@ test("real Core Browser shows durable scope and an honest device-browser handoff
   }
 });
 
-test("real Core persists normalized domains and explicit all-target scope through Settings", async ({ page }) => {
+test("real Core persists network scope changed through universal settings search", async ({ page }) => {
   test.setTimeout(60_000);
-  const core = await startRealCore();
+  const lanAddress = localNetworkIpv4();
+  const core = await startRealCore({ bindHost: "0.0.0.0", browserHost: lanAddress });
   const api = await playwrightRequest.newContext({
     baseURL: `${core.origin}/api/v1/`,
     extraHTTPHeaders: { Authorization: `Bearer ${core.token}` },
   });
   try {
-    await page.goto(`${core.origin}/settings#token=${encodeURIComponent(core.token)}`);
-    await expect(page.getByRole("heading", { name: "Settings", exact: true })).toBeVisible({ timeout: 20_000 });
-    await page.getByRole("link", { name: "Advanced settings", exact: true }).click();
-    await page.locator("details.settings-group > summary", { hasText: "Project Policy" }).click();
+    await page.goto(`${core.origin}/findings#token=${encodeURIComponent(core.token)}`);
+    await expect(page.getByRole("heading", { name: "Findings", exact: true })).toBeVisible({ timeout: 20_000 });
+    await page.getByRole("button", { name: "Search pages, actions, and settings" }).click();
+    await page.getByRole("textbox", { name: "Search pages, actions, and settings" }).fill("network ports");
+    await page.getByRole("option", { name: /Project policy and network scope/ }).click();
+    const lens = page.getByRole("dialog", { name: "Project policy and network scope" });
     const saveScope = page.getByRole("button", { name: "Save scope" });
     await expect(saveScope).toBeEnabled({ timeout: 20_000 });
     await page.getByLabel("Allowed domains").fill("https://www.Google.com/");
@@ -684,7 +687,7 @@ test("real Core persists normalized domains and explicit all-target scope throug
     const confirmation = page.getByRole("dialog", { name: "Allow every network target and port?" });
     await expect(confirmation).toBeVisible();
     await confirmation.getByRole("button", { name: "Allow all targets" }).click();
-    await expect(page.getByRole("status")).toContainText("Network scope updated");
+    await expect(lens.getByRole("status").filter({ hasText: "Network scope updated" })).toBeVisible();
 
     const engagements = await (await api.get("engagements")).json() as Array<{ id: string }>;
     const saved = await api.get(`engagements/${engagements[0].id}/scope`);
@@ -695,15 +698,17 @@ test("real Core persists normalized domains and explicit all-target scope throug
     });
 
     await page.goto("about:blank");
+    await page.goto(`${core.origin}/findings#token=${encodeURIComponent(core.token)}`);
+    await expect(page.getByRole("heading", { name: "Findings", exact: true })).toBeVisible({ timeout: 20_000 });
+    await page.getByRole("button", { name: "Search pages, actions, and settings" }).click();
+    await page.getByRole("textbox", { name: "Search pages, actions, and settings" }).fill("network ports");
     const reloadedScope = page.waitForResponse((response) => response.url().endsWith("/scope") && response.request().method() === "GET");
-    await page.goto(`${core.origin}/settings#token=${encodeURIComponent(core.token)}`);
+    await page.getByRole("option", { name: /Project policy and network scope/ }).click();
     expect(await (await reloadedScope).json()).toMatchObject({ allow_all_targets: true });
-    await expect(page.getByRole("heading", { name: "Settings", exact: true })).toBeVisible({ timeout: 20_000 });
-    await page.getByRole("link", { name: "Advanced settings", exact: true }).click();
-    await page.locator("details.settings-group > summary", { hasText: "Project Policy" }).click();
-    await expect(page.getByLabel("All targets and ports")).toBeChecked();
-    await expect(page.getByLabel("Allowed domains")).toHaveValue("www.google.com");
-    await expect(page.getByLabel("Allowed domains")).toBeDisabled();
+    await expect(lens.getByLabel("All targets and ports")).toBeChecked();
+    await expect(lens.getByLabel("Allowed domains")).toHaveValue("www.google.com");
+    await expect(lens.getByLabel("Allowed domains")).toBeDisabled();
+    expect(new URL(page.url()).hostname).toBe(lanAddress);
   } finally {
     await api.dispose();
     await stopRealCore(core);


### PR DESCRIPTION
## Summary

- make the shared top-bar search and Ctrl/Command-K palette discover individual settings from every pane
- open the existing authoritative controls in a spacious Settings Lens without navigating away
- preserve lazy loading, focus return, responsive full-screen mobile editing, and optional deep links to full Settings
- cover real-Core persistence, LAN production serving, accessibility, and 320-1440 px browser geometry

## Verification

- 347 UI unit tests passed
- production TypeScript/Vite build passed
- desktop Chromium at 1440 and 1024 passed
- mobile Chromium at 320, 390, and 430 passed
- mobile WebKit at 320, 390, and 430 passed
- automated Settings Lens accessibility scan passed
- real-Core network-scope save/reload passed over a non-loopback LAN origin
- lint, diagnostics audit, and diff checks passed

## Device note

Mobile browser checks use Playwright emulation; no physical-device Safari run was available.