### PR TITLE
Hide native browser beneath settings lens

### DIFF
--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -136,6 +136,7 @@ export function AppShell() {
     activityOpen,
     contextualCommands,
     paletteOpen,
+    settingLensOpen: Boolean(settingLens),
     sidebarCollapsed,
     toolbarHost,
     openPalette,
@@ -145,7 +146,7 @@ export function AppShell() {
     setToolbarHost,
     toggleActivity,
     toggleSidebar,
-  }), [activityOpen, contextualCommands, openPalette, paletteOpen, sidebarCollapsed, toggleActivity, toggleSidebar, toolbarHost]);
+  }), [activityOpen, contextualCommands, openPalette, paletteOpen, settingLens, sidebarCollapsed, toggleActivity, toggleSidebar, toolbarHost]);
   return (
     <ReleaseUpdateProvider>
       <WorkbenchEditorProvider>

--- a/ui/src/components/CodeEditorPanel.test.tsx
+++ b/ui/src/components/CodeEditorPanel.test.tsx
@@ -576,6 +576,7 @@ describe("CodeEditorPanel", () => {
     const chrome: ChromeContextValue = {
       activityOpen: false,
       paletteOpen: false,
+      settingLensOpen: false,
       sidebarCollapsed: false,
       toolbarHost: null,
       openPalette: vi.fn(),

--- a/ui/src/components/WorkbenchBrowser.test.tsx
+++ b/ui/src/components/WorkbenchBrowser.test.tsx
@@ -51,6 +51,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 const chrome: ChromeContextValue = {
   activityOpen: false,
   paletteOpen: false,
+  settingLensOpen: false,
   sidebarCollapsed: true,
   toolbarHost: null,
   openPalette: () => undefined,
@@ -174,6 +175,7 @@ async function openPage(finalUrl = "https://docs.example.com/guide") {
 describe("WorkbenchBrowser", () => {
   beforeEach(() => {
     eventMocks.handlers.clear();
+    chrome.settingLensOpen = false;
     runtimeMocks.isTauriRuntime.mockReset();
     runtimeMocks.isTauriRuntime.mockReturnValue(false);
     runtimeMocks.desktopDeviceId.mockReset();
@@ -187,6 +189,28 @@ describe("WorkbenchBrowser", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("hides the native browser while a settings lens is open and restores the active tab", async () => {
+    runtimeMocks.isTauriRuntime.mockReturnValue(true);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
+      return new DOMRect(0, 0, 900, this.classList.contains("browser-toolbar") ? 48 : 600);
+    });
+    renderBrowser();
+    await openPage();
+    await waitFor(() => expect(browserMocks.visible).toHaveBeenLastCalledWith(expect.any(String), "project-1", true));
+
+    chrome.settingLensOpen = true;
+    fireEvent.change(screen.getByLabelText("Address or search"), {
+      target: { value: "https://docs.example.com/hidden" },
+    });
+    await waitFor(() => expect(browserMocks.visible).toHaveBeenLastCalledWith(expect.any(String), "project-1", false));
+
+    chrome.settingLensOpen = false;
+    fireEvent.change(screen.getByLabelText("Address or search"), {
+      target: { value: "https://docs.example.com/restored" },
+    });
+    await waitFor(() => expect(browserMocks.visible).toHaveBeenLastCalledWith(expect.any(String), "project-1", true));
   });
 
   it("opens web addresses externally and can add them directly to Project Sources", async () => {

--- a/ui/src/components/WorkbenchBrowser.tsx
+++ b/ui/src/components/WorkbenchBrowser.tsx
@@ -128,7 +128,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   const [searchParams, setSearchParams] = useSearchParams();
   const confirm = useConfirmation();
   const dialogOpen = useDialogOpen();
-  const { activityOpen, paletteOpen, sidebarCollapsed } = useChrome();
+  const { activityOpen, paletteOpen, settingLensOpen, sidebarCollapsed } = useChrome();
   const desktop = isTauriRuntime();
   const [deviceId, setDeviceId] = useState<string | undefined>(desktop ? undefined : "paired-browser");
   const [tabs, setTabs] = useState<BrowserTab[]>(() => [blankTab()]);
@@ -245,7 +245,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   const scopeDecision = scopeLoading
     ? { state: "unknown" as const, label: "Checking scope", detail: "Loading the durable Project scope." }
     : evaluateBrowserScope(activeTab?.url, scope);
-  const browserVisible = desktop && active && !activityOpen && !paletteOpen && !dialogOpen
+  const browserVisible = desktop && active && !activityOpen && !paletteOpen && !settingLensOpen && !dialogOpen
     && (sidebarCollapsed || !window.matchMedia("(max-width: 760px)").matches);
 
   const bounds = useCallback((): BrowserBounds | undefined => {

--- a/ui/src/pages/KnowledgePage.test.tsx
+++ b/ui/src/pages/KnowledgePage.test.tsx
@@ -26,6 +26,7 @@ vi.mock("../state/WorkspaceContext", () => ({
 const chrome: ChromeContextValue = {
   activityOpen: false,
   paletteOpen: false,
+  settingLensOpen: false,
   sidebarCollapsed: true,
   toolbarHost: null,
   openPalette: () => undefined,

--- a/ui/src/state/ChromeContext.tsx
+++ b/ui/src/state/ChromeContext.tsx
@@ -13,6 +13,7 @@ export interface ContextualCommand {
 export interface ChromeContextValue {
   activityOpen: boolean;
   paletteOpen: boolean;
+  settingLensOpen: boolean;
   sidebarCollapsed: boolean;
   toolbarHost: HTMLElement | null;
   contextualCommands?: ContextualCommand[];


### PR DESCRIPTION
## Summary
- expose settings-lens state through the shared chrome authority
- hide created native browser tabs while the settings lens is open
- restore only the active browser tab after the lens closes
- add a regression for the native visibility transition

## Verification
- npm test: 68 focused component tests passed
- production TypeScript and Vite build passed
- universal settings search passed on desktop, 320px Chromium, and 320px WebKit

## Platform evidence
The Linux test host cannot exercise the packaged macOS Tauri child-window compositor directly. The component regression verifies the native browser visibility boundary used by the macOS browser container.