### PR TITLE
Keep Ask Nebula in the active conversation

### DIFF
--- a/ui/src/state/WorkbenchDraftContext.navigation.test.tsx
+++ b/ui/src/state/WorkbenchDraftContext.navigation.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkbenchDraftProvider, useWorkbenchDrafts } from "./WorkbenchDraftContext";
+
+const state = vi.hoisted(() => ({
+  createHandoff: vi.fn(),
+}));
+
+vi.mock("../api/runtime", () => ({ desktopDeviceId: () => Promise.resolve("device-current") }));
+vi.mock("./WorkspaceContext", () => ({
+  useWorkspace: () => ({
+    api: { createHandoff: state.createHandoff },
+    engagement: { id: "project-1", name: "Project one" },
+  }),
+}));
+
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location">{`${location.pathname}${location.search}`}</output>;
+}
+
+function AskFromAssistant() {
+  const { requestNebulaDraft } = useWorkbenchDrafts();
+  return <button type="button" onClick={() => requestNebulaDraft({
+    text: "Keep this conversation visible",
+    sourceKind: "assistant_message",
+    sourceId: "message-1",
+    sourceLabel: "Assistant response",
+  })}>Ask Nebula</button>;
+}
+
+describe("Ask Nebula conversation navigation", () => {
+  beforeEach(() => {
+    state.createHandoff.mockReset();
+    state.createHandoff.mockResolvedValue({ id: "handoff-1" });
+  });
+
+  it("keeps the active conversation selected before and after the durable handoff is created", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/projects/project-1/workbench?view=chat&session=conversation-1"]}>
+        <WorkbenchDraftProvider>
+          <LocationProbe />
+          <AskFromAssistant />
+        </WorkbenchDraftProvider>
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Ask Nebula" }));
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent("handoff=handoff-1"));
+    const destination = new URL(screen.getByTestId("location").textContent ?? "", "http://nebula.test");
+    expect(destination.pathname).toBe("/projects/project-1/workbench");
+    expect(destination.searchParams.get("view")).toBe("chat");
+    expect(destination.searchParams.get("session")).toBe("conversation-1");
+    expect(destination.searchParams.get("handoff")).toBe("handoff-1");
+    expect(state.createHandoff).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/state/WorkbenchDraftContext.test.ts
+++ b/ui/src/state/WorkbenchDraftContext.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { SelectionActionDraft } from "../components/selection";
-import { ASSISTANT_CONTEXT_CHARACTER_LIMIT, mergeAssistantDraft, selectionHandoffMetadata } from "./WorkbenchDraftContext";
+import {
+  ASSISTANT_CONTEXT_CHARACTER_LIMIT,
+  assistantHandoffSessionId,
+  mergeAssistantDraft,
+  selectionHandoffMetadata,
+} from "./WorkbenchDraftContext";
 
 function draft(text: string, id: string): SelectionActionDraft {
   return {
@@ -51,5 +56,33 @@ describe("selection handoff privacy", () => {
     expect(metadata.sourceHashes["terminal_session:command-1"]).toMatch(/^[a-f0-9]{64}$/);
     expect(JSON.stringify(metadata)).not.toContain(selected.text);
     expect(JSON.stringify(metadata)).not.toContain("secret");
+  });
+});
+
+describe("assistant handoff navigation", () => {
+  it("retains the selected conversation from the same project's Workbench", () => {
+    expect(assistantHandoffSessionId(
+      "project-1",
+      "/projects/project-1/workbench",
+      "?view=chat&session=conversation-1",
+    )).toBe("conversation-1");
+    expect(assistantHandoffSessionId(
+      "project-1",
+      "/projects/project-1/workbench",
+      "?view=notes&session=conversation-1",
+    )).toBe("conversation-1");
+  });
+
+  it("does not carry stale conversation identity across projects or surfaces", () => {
+    expect(assistantHandoffSessionId(
+      "project-1",
+      "/projects/project-2/workbench",
+      "?view=chat&session=conversation-2",
+    )).toBeUndefined();
+    expect(assistantHandoffSessionId(
+      "project-1",
+      "/projects/project-1/findings",
+      "?session=conversation-1",
+    )).toBeUndefined();
   });
 });

--- a/ui/src/state/WorkbenchDraftContext.tsx
+++ b/ui/src/state/WorkbenchDraftContext.tsx
@@ -90,6 +90,23 @@ export interface SelectionHandoffMetadata {
   sourceLabels: Record<string, string>;
 }
 
+/** Keeps the canonical conversation selected when a handoff starts inside Assistant. */
+export function assistantHandoffSessionId(
+  projectId: string,
+  pathname: string,
+  search: string,
+): string | undefined {
+  if (pathname !== projectSurface(projectId, "workbench")) return undefined;
+  return new URLSearchParams(search).get("session") || undefined;
+}
+
+function assistantHandoffPath(projectId: string, sessionId?: string, handoffId?: string): string {
+  const parameters = new URLSearchParams({ view: "chat" });
+  if (sessionId) parameters.set("session", sessionId);
+  if (handoffId) parameters.set("handoff", handoffId);
+  return `${projectSurface(projectId, "workbench")}?${parameters}`;
+}
+
 /** Builds the durable, reference-only portion of a transient selection handoff. */
 export function selectionHandoffMetadata(
   projectId: string,
@@ -200,6 +217,7 @@ export function WorkbenchDraftProvider({ children }: PropsWithChildren) {
     draft: SelectionActionDraft,
     actionId: string,
     view: string,
+    assistantSessionId?: string,
   ) => {
     if (!api || !engagement) return;
     const metadata = selectionHandoffMetadata(engagement.id, draft);
@@ -214,6 +232,10 @@ export function WorkbenchDraftProvider({ children }: PropsWithChildren) {
         transient: true,
       });
       setActiveHandoffIds((current) => [...new Set([...current, envelope.id])]);
+      if (view === "chat") {
+        navigate(assistantHandoffPath(engagement.id, assistantSessionId, envelope.id), { replace: true });
+        return;
+      }
       const parameters = new URLSearchParams({ view, handoff: envelope.id });
       navigate(`${projectSurface(engagement.id, "workbench")}?${parameters}`, { replace: true });
     } catch (error) {
@@ -229,10 +251,13 @@ export function WorkbenchDraftProvider({ children }: PropsWithChildren) {
   const requestNebulaDraft = useCallback((request: NebulaDraftRequest) => {
     const next = toSelectionDraft(request);
     if (!next) return;
+    const currentSessionId = engagement
+      ? assistantHandoffSessionId(engagement.id, location.pathname, location.search)
+      : undefined;
     setAssistantContext((current) => mergeAssistantDraft(current.drafts, next));
-    navigate(engagement ? `${projectSurface(engagement.id, "workbench")}?view=chat` : "/?view=chat");
-    void persistSelectionHandoff(next, "ask_nebula", "chat");
-  }, [engagement, navigate, persistSelectionHandoff]);
+    navigate(engagement ? assistantHandoffPath(engagement.id, currentSessionId) : "/?view=chat");
+    void persistSelectionHandoff(next, "ask_nebula", "chat", currentSessionId);
+  }, [engagement, location.pathname, location.search, navigate, persistSelectionHandoff]);
 
   const requestNoteDraft = useCallback((request: NebulaDraftRequest) => {
     const next = toSelectionDraft(request);
@@ -265,10 +290,13 @@ export function WorkbenchDraftProvider({ children }: PropsWithChildren) {
   }, [api, navigate]);
 
   const openAssistantSelection = useCallback((draft: SelectionActionDraft) => {
+    const currentSessionId = engagement
+      ? assistantHandoffSessionId(engagement.id, location.pathname, location.search)
+      : undefined;
     setAssistantContext((current) => mergeAssistantDraft(current.drafts, draft));
-    navigate(engagement ? `${projectSurface(engagement.id, "workbench")}?view=chat` : "/?view=chat");
-    void persistSelectionHandoff(draft, "ask_nebula", "chat");
-  }, [engagement, navigate, persistSelectionHandoff]);
+    navigate(engagement ? assistantHandoffPath(engagement.id, currentSessionId) : "/?view=chat");
+    void persistSelectionHandoff(draft, "ask_nebula", "chat", currentSessionId);
+  }, [engagement, location.pathname, location.search, navigate, persistSelectionHandoff]);
   const openNoteSelection = useCallback((draft: SelectionActionDraft) => {
     setNoteDraft(draft);
     navigate(engagement ? `${projectSurface(engagement.id, "workbench")}?view=notes` : "/?view=notes");

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -890,6 +890,90 @@ test("assistant context pack stays exact, compact, and accessible", async ({ pag
   expect(accessibility.violations).toEqual([]);
 });
 
+test("assistant context pack preserves the active conversation identity", async ({ page }) => {
+  const sessionId = "chat-selection-preserved";
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    if (path.endsWith("/chat-sessions") && request.method() === "GET") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([{
+        ...entity,
+        id: sessionId,
+        engagement_id: "scratch-project",
+        title: "Selection continuity",
+        backend: "provider",
+        provider_id: null,
+        harness_profile_id: null,
+        harness_session_id: null,
+        model: null,
+        metadata: {},
+      }]) });
+      return;
+    }
+    if (path.endsWith(`/chat/sessions/${sessionId}/messages`)) {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([{
+        ...entity,
+        id: "assistant-selection-preserved",
+        engagement_id: "scratch-project",
+        session_id: sessionId,
+        sequence: 1,
+        role: "assistant",
+        content: "Keep this answer visible while adding it to context.",
+        citations: [],
+        metadata: {},
+      }]) });
+      return;
+    }
+    if (path.endsWith(`/chat/sessions/${sessionId}/pending-turn`)) {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "null" });
+      return;
+    }
+    if (path.endsWith("/handoffs") && request.method() === "POST") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({
+        ...entity,
+        id: "handoff-selection-preserved",
+        engagement_id: "scratch-project",
+        source_refs: [{ project_id: "scratch-project", kind: "conversation", id: "assistant-selection-preserved" }],
+        action_id: "ask_nebula",
+        target_ref: null,
+        origin_device_id: "browser-test",
+        source_hashes: {},
+        source_labels: { "conversation:assistant-selection-preserved": "Assistant response" },
+        transient: true,
+        status: "pending",
+        expires_at: "2026-07-15T12:00:00Z",
+        consumed_at: null,
+        consumed_by_device_id: null,
+      }) });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await openWorkspace(page, `/projects/scratch-project/workbench?view=chat&session=${sessionId}`, "Workbench");
+  const answer = page.getByText("Keep this answer visible while adding it to context.", { exact: true });
+  await expect(answer).toBeVisible();
+  await answer.evaluate((element) => {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const selection = getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    const bounds = element.getBoundingClientRect();
+    element.dispatchEvent(new PointerEvent("pointerup", {
+      bubbles: true,
+      clientX: bounds.left + Math.min(24, bounds.width / 2),
+      clientY: bounds.top + bounds.height / 2,
+    }));
+  });
+  await page.getByRole("button", { name: "Ask Nebula" }).click();
+
+  await expect.poll(() => new URL(page.url()).searchParams.get("session")).toBe(sessionId);
+  await expect.poll(() => new URL(page.url()).searchParams.get("handoff")).toBe("handoff-selection-preserved");
+  await expect(answer).toBeVisible();
+  await expect(page.getByRole("region", { name: "Selected context pack" })).toBeVisible();
+});
+
 test("assistant context pack handoff recovery keeps unsent bytes on the originating device", async ({ page }) => {
   await openWorkspace(
     page,

--- a/ui/tests/real-core.spec.ts
+++ b/ui/tests/real-core.spec.ts
@@ -383,7 +383,26 @@ test("production assistant preserves exact research context and relaunch-safe dr
 
     const assistantUrl = `${core.origin}/?view=chat&session=${encodeURIComponent(completion.session_id)}#token=${encodeURIComponent(core.token)}`;
     await page.goto(assistantUrl);
-    await expect(page.getByText("Real Core retained the exact research context.")).toBeVisible({ timeout: 20_000 });
+    const durableAnswer = page.getByText("Real Core retained the exact research context.");
+    await expect(durableAnswer).toBeVisible({ timeout: 20_000 });
+    await durableAnswer.evaluate((element) => {
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      const selection = getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      const bounds = element.getBoundingClientRect();
+      element.dispatchEvent(new PointerEvent("pointerup", {
+        bubbles: true,
+        clientX: bounds.left + Math.min(24, bounds.width / 2),
+        clientY: bounds.top + bounds.height / 2,
+      }));
+    });
+    await page.getByRole("button", { name: "Ask Nebula" }).click();
+    await expect.poll(() => new URL(page.url()).searchParams.get("session")).toBe(completion.session_id);
+    await expect.poll(() => new URL(page.url()).searchParams.get("handoff")).not.toBeNull();
+    await expect(durableAnswer).toBeVisible();
+    await expect(page.getByRole("region", { name: "Selected context pack" })).toBeVisible();
     await expect(page.getByText("BEGIN UNTRUSTED SELECTED CONTEXT", { exact: false })).toHaveCount(0);
     await page.getByRole("button", { name: /Open context details/ }).click();
     const inspector = page.getByLabel("Session inspector");


### PR DESCRIPTION
## Outcome

Using **Ask Nebula** from a selected Assistant response now adds that response to the context pack without making the active conversation disappear.

## Root cause

Both the immediate Assistant navigation and the asynchronous durable-handoff navigation rebuilt the URL without its canonical `session` identity.

## Changes

- preserve the current conversation when the handoff originates in the same project's Workbench
- use the same destination builder before and after durable handoff creation
- reject stale session carryover across projects and non-Workbench surfaces
- add unit, mounted-router, browser, and real-Core LAN regression coverage

## Verification

- `npm test` — 71 files, 358 tests passed
- `npm run build` — production bundle passed
- desktop Chromium focused Playwright — passed
- mobile Chromium focused Playwright — passed
- mobile WebKit focused Playwright — passed
- real-Core production LAN workflow — passed
