### PR TITLE
Fix Grok send-now and assistant recovery

### DIFF
--- a/docs/assistant-research-continuity-contract.md
+++ b/docs/assistant-research-continuity-contract.md
@@ -21,8 +21,9 @@ The real entry point is Workbench > Assistant. The operator can:
    pack, inspect each source, and remove individual items before sending.
 3. Paste, drop, or choose supported images without leaving the composer.
 4. Send a normal turn, type guidance into the same composer while a steerable
-   harness turn is active, or queue plain-text follow-ups while any other active
-   turn finishes.
+   harness turn is active, queue plain-text follow-ups while any other active
+   turn finishes, or use Grok's explicit Send now action to stop the current
+   turn and submit a selected follow-up immediately.
 5. Inspect Core's authoritative context-window and compaction state without
    exposing private reasoning.
 6. Copy or quote a durable message, fork at a message, and export the authoritative
@@ -54,9 +55,9 @@ The real entry point is Workbench > Assistant. The operator can:
 | Draft recovery | An unsent prompt survives refresh and stays isolated by project/session | sessionStorage + URL | unit + Playwright |
 | Context collection | New selections append with exact bytes, source identity, bounded length, and stable deduplication | workspace context until submit; Core after submit | unit + Playwright + real Core |
 | Image attachment | Choose, paste, and drop share the same validation, capability, count, and upload path | Core artifact store | component + Playwright |
-| Create/mutate | Send persists one user/assistant turn; steer mutates only the active advertised harness turn; non-steerable follow-ups are accepted in visible order and handed to Core one at a time | Core database + harness + sessionStorage queue | component + Playwright |
+| Create/mutate | Send persists one user/assistant turn; steer mutates only the active advertised harness turn; non-steerable follow-ups are accepted in visible order and handed to Core one at a time; Grok Send now retains the selected text before interruption and submits it only after Core confirms the prior turn is terminal | Core database + harness + sessionStorage queue | component + Playwright + real Core |
 | Select/use | URL and visible selection identify the same conversation; filters never mutate selection; queue keys do not cross conversations | URL + Core + sessionStorage | Playwright |
-| Stream/interrupt | Output remains ordered; stop remains available; steer uses visible composer text; queued follow-ups do not start until the active request finishes | Core/harness activity + queue state | component + Playwright |
+| Stream/interrupt | Output remains ordered; stop remains available and idempotent; steer uses visible composer text; queued follow-ups do not start until the active request finishes; terminal Core activity detaches stale followers and unlocks the composer | Core/harness activity + queue state | component + Playwright + real Core |
 | Context health | The meter and inspector reflect Core status, estimated usage, compaction, and memory summary | Core context endpoint | component + real Core |
 | Message reuse | Copy is exact; quote creates an editable draft; fork retains durable lineage | Core + transient composer | unit + Playwright + real Core |
 | Export | Export is built from a fresh authoritative transcript and records session identity, citations, and attachment hashes | Core database | unit + Playwright |
@@ -68,7 +69,7 @@ The real entry point is Workbench > Assistant. The operator can:
 
 - Context packs collapse to compact source chips and never push the composer outside
   the visual viewport at 320-430 px widths.
-- Search, context status, attachment removal, copy, quote, export, stop, and send have
+- Search, context status, attachment removal, copy, quote, export, stop, send now, and send have
   screen-reader names and visible keyboard focus.
 - Touch controls remain at least 44 px; long labels, hashes, transcripts, and memory
   summaries wrap without horizontal clipping.

--- a/docs/harness-capability-matrix.json
+++ b/docs/harness-capability-matrix.json
@@ -1,11 +1,12 @@
 {
   "schema_version": "nebula.harness-capability-matrix/v1",
-  "checked_at": "2026-08-21",
+  "checked_at": "2026-08-27",
   "harnesses": {
     "codex_app_server": {
       "verified_version": "0.144.0",
       "capabilities": {
         "streaming": true, "replay": true, "steering": true, "interruption": true,
+        "interrupt_then_submit": false,
         "resumable_sessions": true, "approvals": true, "structured_user_input": true,
         "planning_mode": true, "goal_monitoring": true, "skill_invocation": true,
         "modes": ["default", "plan"], "reasoning_summaries": true,
@@ -18,6 +19,7 @@
       "verified_version": "1.0.5",
       "capabilities": {
         "streaming": true, "replay": true, "steering": false, "interruption": true,
+        "interrupt_then_submit": true,
         "resumable_sessions": true, "approvals": true, "structured_user_input": false,
         "planning_mode": true, "goal_monitoring": false, "skill_invocation": false,
         "modes": ["default", "plan"], "reasoning_summaries": true,

--- a/src/nebula/v3/harnesses.py
+++ b/src/nebula/v3/harnesses.py
@@ -7202,12 +7202,39 @@ class HarnessRuntimeService:
         turn = self.store.get(HarnessTurn, harness_turn_id)
         if turn.status in {
             HarnessTurnStatus.COMPLETE,
+            HarnessTurnStatus.CANCELLED,
             HarnessTurnStatus.FAILED,
             HarnessTurnStatus.INTERRUPTED,
         }:
-            raise HarnessStateError(
-                f"harness turn is already terminal ({turn.status.value})"
-            )
+            # Stop is an operator recovery control. A late click or retry can race
+            # with transport failure and terminal persistence, so acknowledge the
+            # authoritative terminal state instead of surfacing a stale-state
+            # error. If teardown is still in flight, finish releasing the live
+            # connection and owner task without rewriting the saved outcome.
+            active = self._active.get(turn.harness_session_id)
+            if active is not None and active.turn_id == turn.id:
+                try:
+                    await active.connection.interrupt()
+                except Exception as caught_error:
+                    record_caught_exception(
+                        "harnesses",
+                        "harnesses.terminal_turn_stop_interrupt_failed",
+                        "A terminal harness turn still had a live connection during stop recovery.",
+                        caught_error,
+                        stage="turn-stop-recovery",
+                    )
+                task = (
+                    self._chat_turn_tasks.get(turn.id)
+                    if turn.origin == HarnessTurnOrigin.CHAT
+                    else self._mission_tasks.get(turn.run_id or "")
+                )
+                if (
+                    task is not None
+                    and task is not asyncio.current_task()
+                    and not task.done()
+                ):
+                    task.cancel()
+            return self.store.get(HarnessTurn, turn.id)
         cancellation_recorded = bool(
             turn.metadata.get("cancellation_activity_recorded")
         )

--- a/tests/v3/test_harnesses.py
+++ b/tests/v3/test_harnesses.py
@@ -914,7 +914,11 @@ def test_explicit_stop_cancels_detached_work_without_completing_it(tmp_path):
         async def run_turn(
             self, prompt: str, *, model: str
         ) -> AsyncIterator[HarnessEvent]:
-            del prompt, model
+            if self.prompts:
+                async for event in super().run_turn(prompt, model=model):
+                    yield event
+                return
+            self.prompts.append(prompt)
             yield HarnessEvent(type="started")
             await asyncio.Event().wait()
 
@@ -934,7 +938,7 @@ def test_explicit_stop_cancels_detached_work_without_completing_it(tmp_path):
         store, engagement, profile, _, _, runtime = _runtime(tmp_path)
         adapter = BlockingAdapter()
         runtime.adapter_factory = lambda _: adapter
-        _, chat_turn, turn = runtime.prepare_chat(
+        chat, chat_turn, turn = runtime.prepare_chat(
             engagement_id=engagement.id,
             profile_id=profile.id,
             model=None,
@@ -961,6 +965,39 @@ def test_explicit_stop_cancels_detached_work_without_completing_it(tmp_path):
         replay = runtime.activity_events(turn.id)
         assert replay.events[-1].type == "turn_status"
         assert replay.events[-1].item_status == "cancelled"
+
+        stopped_again = await runtime.cancel_turn(
+            turn.id, reason="Late duplicate operator stop"
+        )
+        assert stopped_again.status == HarnessTurnStatus.CANCELLED
+
+        interrupted = store.update(
+            HarnessTurn,
+            turn.id,
+            {"status": HarnessTurnStatus.INTERRUPTED},
+            expected_revision=stopped_again.revision,
+        )
+        recovered_stop = await runtime.cancel_turn(
+            interrupted.id, reason="Stop after transport interruption"
+        )
+        assert recovered_stop.status == HarnessTurnStatus.INTERRUPTED
+
+        _, follow_up_owner, follow_up_turn = runtime.prepare_chat(
+            engagement_id=engagement.id,
+            profile_id=profile.id,
+            model=None,
+            prompt="Handle the replacement direction",
+            chat_session_id=chat.id,
+            harness_session_id=turn.harness_session_id,
+            mcp_server_ids=[],
+        )
+        await runtime.start_chat_turn(follow_up_turn.id)
+        assert (
+            store.get(HarnessTurn, follow_up_turn.id).status
+            == HarnessTurnStatus.COMPLETE
+        )
+        assert store.get(ChatTurn, follow_up_owner.id).status.value == "complete"
+        assert len(adapter.connections[0].prompts) == 2
 
         run = await runtime.start_mission(
             engagement_id=engagement.id,

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -1222,6 +1222,10 @@ kbd { font-size: 11px; }
 .chat-context-meter > small { color: var(--muted); font-size: 11px; }
 .chat-context-meter.status-failed > span { background: var(--red-muted); color: var(--red); }
 .chat-action-status { display: flex; min-height: 28px; align-items: center; justify-content: center; gap: 5px; margin: 4px 12px 0; color: var(--green); font-size: 11px; }
+.chat-recovery-notice { display: grid; gap: 6px; margin: 6px 12px 0; }
+.chat-recovery-notice > .button { justify-self: start; }
+.chat-composer-send-now { flex: 0 0 auto; gap: 5px; white-space: nowrap; }
+.chat-composer footer .chat-composer-send-now-label { flex: 0 0 auto; color: inherit; font-size: inherit; }
 
 .chat-follow-up-queue { margin: 6px 12px 0; overflow: hidden; border: 1px solid var(--border-soft); border-radius: var(--radius-control); background: var(--surface-muted); }
 .chat-follow-up-queue > header, .chat-follow-up-queue > footer { display: flex; min-height: 40px; align-items: center; justify-content: space-between; gap: 10px; padding: 6px 8px 6px 11px; }
@@ -2132,6 +2136,9 @@ button.harness-status-summary:focus-visible { outline: 2px solid var(--focus); o
   .chat-context-meter > span { width: 30px; height: 30px; }
   .chat-context-meter > small { display: none; }
   .chat-composer .button.square { width: 44px; flex: 0 0 44px; padding: 0; }
+  .chat-composer-send-now { width: 44px; height: 44px; flex: 0 0 44px; justify-content: center; padding: 0; }
+  .chat-composer footer .chat-composer-send-now-label { display: none; }
+  .chat-recovery-notice { margin-inline: 6px; }
   .chat-settings-popover { right: auto; bottom: 127px; left: 50%; width: calc(100% - 12px); max-height: min(72%, 520px); border-radius: var(--radius-panel); }
   .chat-settings-fields { grid-template-columns: minmax(0, 1fr); }
   .chat-settings-popover > header { min-height: 44px; }

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -522,6 +522,7 @@ export function SessionsPage() {
   const [uploadingImage, setUploadingImage] = useState(false);
   const [sending, setSending] = useState(false);
   const [loadingHistory, setLoadingHistory] = useState(false);
+  const [reloadingConversation, setReloadingConversation] = useState(false);
   const [chatError, setChatError] = useState<string>();
   const [assistantSettingsOpen, setAssistantSettingsOpen] = useState(false);
   const [discoveringProviderId, setDiscoveringProviderId] = useState<string>();
@@ -866,6 +867,20 @@ export function SessionsPage() {
       globalThis.clearInterval(interval);
     };
   }, [api, coreState, harnessSessionId, runtimeKind]);
+
+  useEffect(() => {
+    if (!harnessActivity || harnessActivity.live) return;
+    const terminal = harnessActivity.turnStatus
+      ? ["complete", "failed", "cancelled", "interrupted"].includes(harnessActivity.turnStatus)
+      : !harnessActivity.busy;
+    if (!terminal) return;
+    detachActiveChatStream();
+    harnessFollowDetachRef.current?.();
+    harnessFollowDetachRef.current = undefined;
+    setHarnessProgress(undefined);
+    setPendingResponse(undefined);
+    setSending(false);
+  }, [harnessActivity]);
 
   useEffect(() => {
     let active = true;
@@ -1608,7 +1623,14 @@ export function SessionsPage() {
             })
               .finally(() => setSending(false));
           },
-          (error) => setChatError(error.message),
+          (error) => {
+            harnessFollowDetachRef.current?.();
+            harnessFollowDetachRef.current = undefined;
+            setHarnessProgress(undefined);
+            setPendingResponse(undefined);
+            setSending(false);
+            setChatError(`${error.message} Reload this conversation to read its authoritative saved state.`);
+          },
         );
         const approval = approvals.find((item) => item.id === pendingTurn.approvalId);
         setPendingResponse(approval ? {
@@ -2115,7 +2137,11 @@ export function SessionsPage() {
       createdAt: new Date().toISOString(),
       status: "queued",
     };
-    setQueuedFollowUps((current) => [...current, item]);
+    const nextQueue = [...queuedFollowUps, item];
+    if (activeFollowUpStorageKey) {
+      writeChatFollowUps(sessionStorage, activeFollowUpStorageKey, nextQueue);
+    }
+    setQueuedFollowUps(nextQueue);
     followUpAutoDrainRef.current = true;
     setDraft("");
     if (activeDraftStorageKey) clearChatDraft(sessionStorage, activeDraftStorageKey);
@@ -2124,6 +2150,40 @@ export function SessionsPage() {
     setChatError(undefined);
     setMessageActionStatus("Follow-up queued; it will send after the active response finishes.");
     return true;
+  };
+
+  const stageImmediateFollowUp = (text: string): ChatFollowUp | undefined => {
+    const validationError = validateChatFollowUpText(text);
+    if (validationError) {
+      setChatError(validationError);
+      return undefined;
+    }
+    if (pendingImages.length || assistantDrafts.length) {
+      setChatError("Send now accepts plain text only. Remove attachments and selected context or wait for the active response to finish.");
+      return undefined;
+    }
+    if (queuedFollowUps.length >= maxChatFollowUps()) {
+      setChatError(`The follow-up queue is full (${maxChatFollowUps()} messages). Remove one before sending now.`);
+      return undefined;
+    }
+    const item: ChatFollowUp = {
+      id: makeId("follow-up-now"),
+      text: text.trim(),
+      createdAt: new Date().toISOString(),
+      status: "queued",
+    };
+    const nextQueue = [item, ...queuedFollowUps];
+    if (activeFollowUpStorageKey) {
+      writeChatFollowUps(sessionStorage, activeFollowUpStorageKey, nextQueue);
+    }
+    setQueuedFollowUps(nextQueue);
+    followUpAutoDrainRef.current = false;
+    setDraft("");
+    if (activeDraftStorageKey) clearChatDraft(sessionStorage, activeDraftStorageKey);
+    setSkillToken(undefined);
+    setHarnessSkillPath("");
+    setChatError(undefined);
+    return item;
   };
 
   const submit = async (event?: FormEvent, queuedFollowUp?: ChatFollowUp) => {
@@ -2671,8 +2731,9 @@ export function SessionsPage() {
     }
   };
 
-  const stopCurrentResponse = async () => {
+  const stopCurrentResponse = async (): Promise<boolean> => {
     followUpAutoDrainRef.current = false;
+    const reloadSessionId = sessionId;
     if (runtimeKind === "harness" && api) {
       const turnId = harnessProgress?.turnId ?? harnessActivity?.turnId
         ?? [...messages].reverse().find((message) => message.state === "streaming")?.harnessTurnId;
@@ -2682,7 +2743,7 @@ export function SessionsPage() {
         } catch (error) {
           void logCaughtDiagnostic("interface.sessions_page.harness_stop", "Could not stop harness turn.", error, "sessions_page");
           setChatError(error instanceof Error ? error.message : "Could not stop the harness turn.");
-          return;
+          return false;
         }
       }
     } else if (api) {
@@ -2693,11 +2754,52 @@ export function SessionsPage() {
         } catch (error) {
           void logCaughtDiagnostic("interface.sessions_page.provider_stop", "Could not stop provider turn.", error, "sessions_page");
           setChatError(error instanceof Error ? error.message : "Could not stop the provider turn.");
-          return;
+          return false;
         }
       }
     }
+    harnessFollowDetachRef.current?.();
+    harnessFollowDetachRef.current = undefined;
     abortRef.current?.abort();
+    setPendingResponse(undefined);
+    setHarnessProgress(undefined);
+    setSending(false);
+    if (runtimeKind === "harness" && reloadSessionId) {
+      await selectSession(reloadSessionId, false);
+    }
+    return true;
+  };
+
+  const sendGrokFollowUpNow = async (queuedId?: string) => {
+    if (harnessControlBusy) return;
+    let item: ChatFollowUp | undefined;
+    if (queuedId) {
+      item = queuedFollowUps.find((candidate) => candidate.id === queuedId);
+      if (!item || item.status === "sending") return;
+      const nextQueue = [item, ...queuedFollowUps.filter((candidate) => candidate.id !== queuedId)];
+      if (activeFollowUpStorageKey) {
+        writeChatFollowUps(sessionStorage, activeFollowUpStorageKey, nextQueue);
+      }
+      setQueuedFollowUps(nextQueue);
+      followUpAutoDrainRef.current = false;
+    } else {
+      item = stageImmediateFollowUp(draft);
+    }
+    if (!item) return;
+
+    setHarnessControlBusy(true);
+    setMessageActionStatus("Stopping the current Grok turn before sending this message…");
+    const stopped = await stopCurrentResponse();
+    setHarnessControlBusy(false);
+    if (!stopped) {
+      setQueuedFollowUps((current) => current.map((candidate) => candidate.id === item?.id
+        ? { ...candidate, status: "failed", detail: "The current Grok turn could not be stopped. Review this message before retrying." }
+        : candidate));
+      return;
+    }
+    followUpAutoDrainRef.current = true;
+    setMessageActionStatus("Current Grok turn stopped; sending your message now.");
+    setQueuedFollowUps((current) => [...current]);
   };
 
   const steerCurrentHarness = async (guidance?: string) => {
@@ -2911,6 +3013,14 @@ export function SessionsPage() {
     && (harnessProgress?.turnId || harnessActivity?.turnId)
     && !harnessControlBusy,
   );
+  const canSendNowCurrentGrok = Boolean(
+    sending
+    && runtimeKind === "harness"
+    && selectedHarness?.kind === "grok_acp"
+    && selectedHarness.capabilities?.interruption !== false
+    && (harnessProgress?.turnId || harnessActivity?.turnId)
+    && !harnessControlBusy,
+  );
   const queueMode = composerBusy && !canSteerCurrentHarness;
   const removeQueuedFollowUp = (id: string) => {
     setQueuedFollowUps((current) => current.filter((item) => item.id !== id));
@@ -2924,6 +3034,12 @@ export function SessionsPage() {
       ? { ...item, status: "queued", detail: undefined }
       : item));
     setChatError(undefined);
+  };
+  const reloadActiveConversation = async () => {
+    if (!sessionId || reloadingConversation) return;
+    setReloadingConversation(true);
+    await selectSession(sessionId, false);
+    setReloadingConversation(false);
   };
   const visibleHarnessProgress: HarnessProgress | undefined = runtimeKind !== "harness" || !harnessSessionId
     ? harnessProgress
@@ -3248,14 +3364,14 @@ export function SessionsPage() {
                 </ThreadPrimitive.Root>
               </AssistantRuntimeProvider>
               {pendingResponse && pendingResponse.request.backend !== "harness" && <div className="chat-inline-approval-actions"><button className="button secondary" type="button" onClick={() => void decideInlineApproval("edit")}>Edit pending request</button></div>}
-              {chatError && <DiagnosticErrorNotice error={chatError} fallback="The chat operation could not be completed." compact />}
+              {chatError && <div className="chat-recovery-notice"><DiagnosticErrorNotice error={chatError} fallback="The chat operation could not be completed." compact />{sessionId && <button className="button quiet" type="button" disabled={reloadingConversation} onClick={() => void reloadActiveConversation()}>{reloadingConversation ? "Reloading…" : "Reload conversation"}</button>}</div>}
               {messageActionStatus && <div className="chat-action-status" role="status" aria-live="polite"><Check size={13} aria-hidden="true" /> {messageActionStatus}</div>}
               {showHarnessStatusRail && harnessActivity && <HarnessStatusRail activity={harnessActivity} pendingRequests={pendingHarnessRequests} />}
               {queuedFollowUps.length > 0 && <section className="chat-follow-up-queue" aria-label="Queued follow-up messages" aria-live="polite">
                 <header><div><ListTodo size={14} aria-hidden="true" /><span><strong>Follow-up queue</strong><small>{queuedFollowUps.length} message{queuedFollowUps.length === 1 ? "" : "s"} · text only · current browser tab</small></span></div><button className="button quiet" type="button" disabled={queuedFollowUps.some((item) => item.status === "sending")} onClick={() => { followUpAutoDrainRef.current = false; followUpDrainIdRef.current = undefined; setQueuedFollowUps([]); setMessageActionStatus("Follow-up queue cleared."); }}>Clear</button></header>
                 <ol>{queuedFollowUps.map((item, index) => <li key={item.id} className={`chat-follow-up-${item.status}`}>
                   <div><span className="chat-follow-up-index">{index + 1}</span><p>{item.text}</p></div>
-                  <div className="chat-follow-up-meta"><span>{item.status === "sending" ? "Sending next" : item.status === "failed" ? "Needs review" : index === 0 && (sending || pendingResponse) ? "After current response" : "Waiting"}</span>{item.detail && <small>{item.detail}</small>}<div>{item.status === "failed" && index === 0 && <button className="button quiet" type="button" onClick={() => retryQueuedFollowUp(item.id)}>Retry</button>}<button className="icon-button subtle" type="button" aria-label={`Remove queued message ${index + 1}`} disabled={item.status === "sending"} onClick={() => removeQueuedFollowUp(item.id)}><X size={14} aria-hidden="true" /></button></div></div>
+                    <div className="chat-follow-up-meta"><span>{item.status === "sending" ? "Sending next" : item.status === "failed" ? "Needs review" : index === 0 && (sending || pendingResponse) ? "After current response" : "Waiting"}</span>{item.detail && <small>{item.detail}</small>}<div>{canSendNowCurrentGrok && item.status === "queued" && <button className="button quiet" type="button" aria-label={`Send queued message ${index + 1} now`} onClick={() => void sendGrokFollowUpNow(item.id)}>Send now</button>}{item.status === "failed" && index === 0 && <button className="button quiet" type="button" onClick={() => retryQueuedFollowUp(item.id)}>Retry</button>}<button className="icon-button subtle" type="button" aria-label={`Remove queued message ${index + 1}`} disabled={item.status === "sending"} onClick={() => removeQueuedFollowUp(item.id)}><X size={14} aria-hidden="true" /></button></div></div>
                 </li>)}</ol>
                 {!sending && !pendingResponse && queuedFollowUps[0]?.status === "queued" && !followUpAutoDrainRef.current && <footer><span>Recovered follow-ups are paused for review.</span><button className="button secondary" type="button" onClick={() => retryQueuedFollowUp(queuedFollowUps[0].id)}>Send next</button></footer>}
               </section>}
@@ -3275,10 +3391,10 @@ export function SessionsPage() {
                 {pendingImages.length > 0 && <div className="chat-image-attachments" role="list" aria-label="Image attachments">{pendingImages.map((image, index) => <div role="listitem" key={`${image.block.artifactId}-${index}`}><img src={image.previewUrl} alt={image.filename} /><button className="icon-button subtle" type="button" aria-label={`Remove ${image.filename}`} onClick={() => removePendingImage(index)}><X size={14} /></button></div>)}</div>}
                 <label className="sr-only" htmlFor="analyst-message">Message the analyst assistant</label>
                 <div className="chat-composer-input" role="combobox" aria-label="Skill suggestions" aria-autocomplete="list" aria-expanded={Boolean(skillToken)} aria-controls={skillToken ? "harness-skill-menu" : undefined} aria-activedescendant={skillToken && matchingHarnessSkills.length ? `harness-skill-option-${skillMenuIndex}` : undefined}>
-                  <textarea ref={composerRef} id="analyst-message" data-selection-actions-disabled="true" value={draft} disabled={!engagement || !runtimeReady || loadingHistory} placeholder={!engagement ? "Create or select a project to chat…" : canSteerCurrentHarness ? "Add guidance while the harness works…" : queueMode ? "Queue the next message while this response finishes…" : runtimeReady ? "Ask about this project…" : "Add a model or harness in Settings…"} rows={1} onFocus={() => setAssistantSettingsOpen(false)} onPaste={pasteComposerImages} onKeyDown={onComposerKeyDown} onChange={(event) => updateComposerDraft(event.target.value, event.target.selectionStart ?? event.target.value.length)} />
+                  <textarea ref={composerRef} id="analyst-message" data-selection-actions-disabled="true" value={draft} disabled={!engagement || !runtimeReady || loadingHistory} placeholder={!engagement ? "Create or select a project to chat…" : canSteerCurrentHarness ? "Add guidance while the harness works…" : canSendNowCurrentGrok ? "Queue a follow-up or send it now…" : queueMode ? "Queue the next message while this response finishes…" : runtimeReady ? "Ask about this project…" : "Add a model or harness in Settings…"} rows={1} onFocus={() => setAssistantSettingsOpen(false)} onPaste={pasteComposerImages} onKeyDown={onComposerKeyDown} onChange={(event) => updateComposerDraft(event.target.value, event.target.selectionStart ?? event.target.value.length)} />
                   {skillToken && <HarnessSkillAutocomplete skills={harnessSkills} token={skillToken} activeIndex={skillMenuIndex} onActiveIndexChange={setSkillMenuIndex} onSelect={selectHarnessSkill} onClose={() => setSkillToken(undefined)} />}
                 </div>
-                <footer><button ref={assistantSettingsButtonRef} className={`button quiet chat-runtime-summary chat-settings-trigger${runtimeReady ? "" : " needs-attention"}`} type="button" aria-label="Assistant settings" aria-expanded={assistantSettingsOpen} aria-controls="assistant-settings-popover" title={runtimeReady ? `${assistantSource}${runtimeConfiguration ? ` · ${runtimeConfiguration}` : ""}` : "Choose an assistant runtime"} onClick={() => setAssistantSettingsOpen((open) => !open)}><Settings2 size={15} aria-hidden="true" /><span><strong>{assistantSource}</strong><small> · {runtimeConfiguration || "Choose a model"}</small></span></button>{sessionId && <button className={`button quiet chat-context-meter status-${activeContextStatus?.status ?? "loading"}`} type="button" aria-label={contextPercent === undefined ? "Open context details" : `Open context details, ${contextPercent} percent of target input used`} title={activeContextStatus?.status === "runtime_managed" ? "Context is managed by the harness runtime" : contextPercent === undefined ? "Read authoritative context status" : `${activeContextStatus?.estimatedInputTokens.toLocaleString()} of ${activeContextStatus?.targetInputTokens.toLocaleString()} target input tokens`} onClick={() => { localStorage.setItem("nebula.session-inspector.open", "true"); setSessionInspectorOpen(true); }}><span aria-hidden="true" style={contextPercent === undefined ? undefined : { "--context-percent": `${contextPercent}%` } as CSSProperties}>{contextPercent === undefined ? "—" : contextPercent}</span><small>context</small></button>}<input ref={imageInputRef} className="sr-only" type="file" aria-label="Choose image attachments" accept="image/png,image/jpeg,image/webp" multiple onChange={(event) => void attachImages(event)} /><button className="button quiet square chat-composer-attachment" type="button" aria-label="Attach images" disabled={composerBusy || !imageInputEnabled || uploadingImage || pendingImages.length >= 4} title={composerBusy ? "Attachments are available after the active response finishes" : imageInputEnabled ? "Choose, paste, or drop PNG, JPEG, or WebP images" : "The selected runtime does not advertise image input"} onClick={() => imageInputRef.current?.click()}>{uploadingImage ? <LoaderCircle className="spin" size={15} /> : <ImagePlus size={15} />}</button>{canSteerCurrentHarness && draft.trim() && <button className="button primary square chat-composer-submit" type="submit" disabled={harnessControlBusy} aria-label="Send guidance now" title="Steer the active harness turn"><Send size={16} /></button>}{queueMode && draft.trim() && <button className="button primary square chat-composer-submit" type="submit" aria-label="Queue follow-up message" title="Queue this text after the active response"><ListTodo size={16} /></button>}{sending && <button className="button secondary square chat-composer-submit" type="button" aria-label="Stop response" disabled={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false} title={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false ? "This harness does not advertise turn interruption" : undefined} onClick={() => void stopCurrentResponse()}><Square size={15} /></button>}{!composerBusy && <button className="button primary square chat-composer-submit" type="submit" disabled={!canSend} aria-label="Send message"><Send size={16} /></button>}</footer>
+                <footer><button ref={assistantSettingsButtonRef} className={`button quiet chat-runtime-summary chat-settings-trigger${runtimeReady ? "" : " needs-attention"}`} type="button" aria-label="Assistant settings" aria-expanded={assistantSettingsOpen} aria-controls="assistant-settings-popover" title={runtimeReady ? `${assistantSource}${runtimeConfiguration ? ` · ${runtimeConfiguration}` : ""}` : "Choose an assistant runtime"} onClick={() => setAssistantSettingsOpen((open) => !open)}><Settings2 size={15} aria-hidden="true" /><span><strong>{assistantSource}</strong><small> · {runtimeConfiguration || "Choose a model"}</small></span></button>{sessionId && <button className={`button quiet chat-context-meter status-${activeContextStatus?.status ?? "loading"}`} type="button" aria-label={contextPercent === undefined ? "Open context details" : `Open context details, ${contextPercent} percent of target input used`} title={activeContextStatus?.status === "runtime_managed" ? "Context is managed by the harness runtime" : contextPercent === undefined ? "Read authoritative context status" : `${activeContextStatus?.estimatedInputTokens.toLocaleString()} of ${activeContextStatus?.targetInputTokens.toLocaleString()} target input tokens`} onClick={() => { localStorage.setItem("nebula.session-inspector.open", "true"); setSessionInspectorOpen(true); }}><span aria-hidden="true" style={contextPercent === undefined ? undefined : { "--context-percent": `${contextPercent}%` } as CSSProperties}>{contextPercent === undefined ? "—" : contextPercent}</span><small>context</small></button>}<input ref={imageInputRef} className="sr-only" type="file" aria-label="Choose image attachments" accept="image/png,image/jpeg,image/webp" multiple onChange={(event) => void attachImages(event)} /><button className="button quiet square chat-composer-attachment" type="button" aria-label="Attach images" disabled={composerBusy || !imageInputEnabled || uploadingImage || pendingImages.length >= 4} title={composerBusy ? "Attachments are available after the active response finishes" : imageInputEnabled ? "Choose, paste, or drop PNG, JPEG, or WebP images" : "The selected runtime does not advertise image input"} onClick={() => imageInputRef.current?.click()}>{uploadingImage ? <LoaderCircle className="spin" size={15} /> : <ImagePlus size={15} />}</button>{canSteerCurrentHarness && draft.trim() && <button className="button primary square chat-composer-submit" type="submit" disabled={harnessControlBusy} aria-label="Send guidance now" title="Steer the active harness turn"><Send size={16} /></button>}{canSendNowCurrentGrok && draft.trim() && <><button className="button quiet square chat-composer-submit" type="submit" aria-label="Queue follow-up message" title="Queue this text after the active response"><ListTodo size={16} /></button><button className="button primary chat-composer-send-now" type="button" aria-label="Send message now" title="Stop the current Grok turn and send this message next" onClick={() => void sendGrokFollowUpNow()}><Send size={15} /><span className="chat-composer-send-now-label">Send now</span></button></>}{queueMode && !canSendNowCurrentGrok && draft.trim() && <button className="button primary square chat-composer-submit" type="submit" aria-label="Queue follow-up message" title="Queue this text after the active response"><ListTodo size={16} /></button>}{sending && <button className="button secondary square chat-composer-submit" type="button" aria-label="Stop response" disabled={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false} title={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false ? "This harness does not advertise turn interruption" : undefined} onClick={() => void stopCurrentResponse()}><Square size={15} /></button>}{!composerBusy && <button className="button primary square chat-composer-submit" type="submit" disabled={!canSend} aria-label="Send message"><Send size={16} /></button>}</footer>
               </form>
               {showHarnessProgress && visibleHarnessProgress && <div className={`chat-harness-progress phase-${visibleHarnessProgress.phase}`} role="status" aria-live="polite"><span className={`status-dot ${visibleHarnessProgress.phase === "failed" || visibleHarnessProgress.phase === "status_unavailable" ? "unavailable" : "pending"}`} /><div><strong>{harnessPhaseLabel(visibleHarnessProgress.phase)}</strong><small>{visibleHarnessProgress.detail}</small>{visibleHarnessProgress.sessionId && <code title={visibleHarnessProgress.sessionId}>Session {visibleHarnessProgress.sessionId.slice(0, 8)}{visibleHarnessProgress.previousSessionId ? " · independent parallel session" : ""}</code>}</div>{canSteerCurrentHarness && <button className="button quiet harness-steer-button" type="button" disabled={harnessControlBusy} onClick={() => composerRef.current?.focus()}><Plus size={13} aria-hidden="true" /> Add guidance</button>}</div>}
             </div>

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -2101,6 +2101,240 @@ test("assistant live guidance steers an active Codex turn with stale saved capab
   await expect(page.getByText("Guidance sent to the active harness turn.")).toBeVisible();
 });
 
+test("assistant live guidance exposes Grok send now as stop and immediate submit", async ({ page }, testInfo) => {
+  test.skip(!["desktop", "narrow", "mobile-chromium-small", "mobile-webkit"].includes(testInfo.project.name), "Covered by the permanent desktop and mobile Assistant lifecycle projects.");
+  const profile = {
+    ...entity,
+    id: "harness-grok-send-now",
+    name: "Grok harness",
+    kind: "grok_acp",
+    connection_mode: "spawn",
+    transport: "stdio",
+    executable: "/usr/bin/grok",
+    endpoint: null,
+    auth_mode: "existing_session",
+    secret_ref: null,
+    default_model: "grok-4.6",
+    enabled: true,
+    privacy: { local_only: true, permits_sensitive_data: true },
+    native_capabilities: { workspace_access: "write", shell: true },
+    capabilities: { models: ["grok-4.6"], checked_at: entity.updated_at, harness_version: "1.0.5", steering: false, interruption: true },
+  };
+  let stopped = false;
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    if (path.endsWith("/providers") && request.method() === "GET") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    if (path.endsWith("/harnesses") && request.method() === "GET") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([profile]) });
+      return;
+    }
+    if (path.endsWith("/harness-sessions") && request.method() === "GET") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    if (path.endsWith("/harness-sessions/grok-send-now-session/activity")) {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({
+        session_id: "grok-send-now-session",
+        session_status: stopped ? "idle" : "running",
+        busy: !stopped,
+        live: !stopped,
+        turn_id: stopped ? null : "grok-send-now-turn-1",
+        turn_status: stopped ? null : "running",
+        turn_origin: stopped ? null : "chat",
+        started_at: stopped ? null : entity.updated_at,
+        last_activity_at: entity.updated_at,
+        detail: stopped ? "This harness session is ready for another turn." : "A harness turn is currently running.",
+      }) });
+      return;
+    }
+    if (path.endsWith("/harness-turns/grok-send-now-turn-1/stop") && request.method() === "POST") {
+      stopped = true;
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({
+        ...entity,
+        id: "grok-send-now-turn-1",
+        status: "cancelled",
+        origin: "chat",
+        harness_session_id: "grok-send-now-session",
+        chat_session_id: "grok-send-now-chat",
+        metadata: {},
+      }) });
+      return;
+    }
+    if (path.endsWith("/chat-sessions") && request.method() === "GET") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([{
+        ...entity,
+        id: "grok-send-now-chat",
+        engagement_id: "scratch-project",
+        title: "Grok send-now conversation",
+        backend: "harness",
+        harness_profile_id: profile.id,
+        harness_session_id: "grok-send-now-session",
+        model: "grok-4.6",
+        metadata: {},
+      }]) });
+      return;
+    }
+    if (path.endsWith("/chat/sessions/grok-send-now-chat/messages")) {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    if (path.endsWith("/chat/sessions/grok-send-now-chat/pending-turn")) {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "null" });
+      return;
+    }
+    await route.fallback();
+  });
+  await page.addInitScript(() => {
+    const nativeFetch = globalThis.fetch.bind(globalThis);
+    let requestNumber = 0;
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (!url.endsWith("/chat/completions")) return nativeFetch(input, init);
+      const request = JSON.parse(String(init?.body ?? "{}")) as { messages?: Array<{ content?: string }> };
+      requestNumber += 1;
+      const current = requestNumber;
+      const requests = (globalThis as typeof globalThis & { __grokSendNowRequests?: unknown[] }).__grokSendNowRequests ??= [];
+      requests.push(request);
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          const enqueue = (frame: unknown) => controller.enqueue(encoder.encode(`data: ${JSON.stringify(frame)}\n\n`));
+          enqueue({ type: "started", harness_profile_id: "harness-grok-send-now", harness_session_id: "grok-send-now-session", harness_turn_id: `grok-send-now-turn-${current}`, session_id: "grok-send-now-chat", model: "grok-4.6" });
+          enqueue({ type: "message_delta", harness_session_id: "grok-send-now-session", harness_turn_id: `grok-send-now-turn-${current}`, model: "grok-4.6", delta: current === 1 ? "Working on the original request." : "The urgent direction completed." });
+          if (current === 1) return;
+          enqueue({ type: "done", session_id: "grok-send-now-chat", harness_profile_id: "harness-grok-send-now", harness_session_id: "grok-send-now-session", harness_turn_id: "grok-send-now-turn-2", model: "grok-4.6", message: { id: "grok-send-now-assistant", role: "assistant", content: "The urgent direction completed." }, usage: { input_tokens: 4, output_tokens: 8, total_tokens: 12 }, finish_reason: "stop", citations: [] });
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        },
+      });
+      return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
+    };
+  });
+
+  await openWorkspace(page, "/?view=chat", "Workbench");
+  await page.getByRole("button", { name: "New chat", exact: true }).click();
+  const composer = page.getByPlaceholder("Ask about this project…");
+  await composer.fill("Start the long Grok task.");
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect(page.getByText("Working on the original request.")).toBeVisible();
+
+  const activeComposer = page.getByPlaceholder("Queue a follow-up or send it now…");
+  await activeComposer.fill("Keep this ordinary follow-up queued.");
+  await activeComposer.press("Enter");
+  await expect(page.getByRole("button", { name: "Send queued message 1 now" })).toBeVisible();
+  await activeComposer.fill("Handle the urgent direction instead.");
+  await expect(page.getByRole("button", { name: "Queue follow-up message" })).toBeVisible();
+  await page.getByRole("button", { name: "Send message now" }).click();
+
+  await expect.poll(() => stopped).toBe(true);
+  await expect.poll(() => page.evaluate(() => (globalThis as typeof globalThis & { __grokSendNowRequests?: Array<{ messages?: Array<{ content?: string }> }> }).__grokSendNowRequests?.length ?? 0)).toBe(3);
+  const requests = await page.evaluate(() => (globalThis as typeof globalThis & { __grokSendNowRequests?: Array<{ messages?: Array<{ content?: string }> }> }).__grokSendNowRequests ?? []);
+  expect(requests.map((request) => request.messages?.at(-1)?.content)).toEqual([
+    "Start the long Grok task.",
+    "Handle the urgent direction instead.",
+    "Keep this ordinary follow-up queued.",
+  ]);
+  await expect(page.getByText("The urgent direction completed.").first()).toBeVisible();
+  await expect(page.getByRole("region", { name: "Queued follow-up messages" })).toHaveCount(0);
+  await expect(page.getByText("Harness is working")).toHaveCount(0);
+  const composerGeometry = await page.locator(".chat-composer").evaluate((element) => ({ scrollWidth: element.scrollWidth, clientWidth: element.clientWidth }));
+  expect(composerGeometry.scrollWidth).toBeLessThanOrEqual(composerGeometry.clientWidth + 1);
+  const accessibility = await new AxeBuilder({ page }).include(".chat-composer").analyze();
+  expect(accessibility.violations).toEqual([]);
+});
+
+test("assistant live guidance releases stale busy UI when Core reports a terminal Grok turn", async ({ page }, testInfo) => {
+  test.skip(!["desktop", "narrow", "mobile-chromium-small", "mobile-webkit"].includes(testInfo.project.name), "Covered by the permanent desktop and mobile Assistant lifecycle projects.");
+  const profile = {
+    ...entity,
+    id: "harness-grok-terminal-recovery",
+    name: "Grok harness",
+    kind: "grok_acp",
+    connection_mode: "spawn",
+    transport: "stdio",
+    executable: "/usr/bin/grok",
+    endpoint: null,
+    auth_mode: "existing_session",
+    secret_ref: null,
+    default_model: "grok-4.6",
+    enabled: true,
+    privacy: { local_only: true, permits_sensitive_data: true },
+    native_capabilities: { workspace_access: "write", shell: true },
+    capabilities: { models: ["grok-4.6"], checked_at: entity.updated_at, harness_version: "1.0.5", steering: false, interruption: true },
+  };
+  let activityReads = 0;
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    if (path.endsWith("/providers") && request.method() === "GET") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    if (path.endsWith("/harnesses") && request.method() === "GET") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([profile]) });
+      return;
+    }
+    if (path.endsWith("/harness-sessions") && request.method() === "GET") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    if (path.endsWith("/harness-sessions/grok-terminal-session/activity")) {
+      activityReads += 1;
+      const terminal = activityReads > 1;
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({
+        session_id: "grok-terminal-session",
+        session_status: terminal ? "interrupted" : "running",
+        busy: !terminal,
+        live: !terminal,
+        turn_id: "grok-terminal-turn",
+        turn_status: terminal ? "interrupted" : "running",
+        turn_origin: "chat",
+        started_at: entity.updated_at,
+        last_activity_at: entity.updated_at,
+        detail: terminal ? "The harness turn was interrupted." : "A harness turn is currently running.",
+      }) });
+      return;
+    }
+    if (path.endsWith("/chat-sessions") && request.method() === "GET") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    await route.fallback();
+  });
+  await page.addInitScript(() => {
+    const nativeFetch = globalThis.fetch.bind(globalThis);
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (!url.endsWith("/chat/completions")) return nativeFetch(input, init);
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          const enqueue = (frame: unknown) => controller.enqueue(encoder.encode(`data: ${JSON.stringify(frame)}\n\n`));
+          enqueue({ type: "started", harness_profile_id: "harness-grok-terminal-recovery", harness_session_id: "grok-terminal-session", harness_turn_id: "grok-terminal-turn", session_id: "grok-terminal-chat", model: "grok-4.6" });
+          enqueue({ type: "message_delta", harness_session_id: "grok-terminal-session", harness_turn_id: "grok-terminal-turn", model: "grok-4.6", delta: "Working before the connection failed." });
+        },
+      });
+      return new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } });
+    };
+  });
+
+  await openWorkspace(page, "/?view=chat", "Workbench");
+  await page.getByRole("button", { name: "New chat", exact: true }).click();
+  const composer = page.getByPlaceholder("Ask about this project…");
+  await composer.fill("Start work that will be interrupted.");
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect(page.getByText("Harness is working")).toBeVisible();
+
+  await expect(page.getByText("Harness is working")).toHaveCount(0, { timeout: 6_000 });
+  await expect(page.getByRole("button", { name: "Stop response" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Send message" })).toBeVisible();
+  await expect(page.getByPlaceholder("Ask about this project…")).toBeEnabled();
+});
+
 test("an idle resumed harness keeps routine telemetry quiet", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "desktop", "Harness status placement needs one desktop interaction run.");
   const harnessSessionId = "c9745e80-1111-4222-8333-444455556666";


### PR DESCRIPTION
## Summary

- expose Grok’s interrupt-and-submit **Send now** action separately from same-turn steering, while preserving ordinary queued follow-ups
- make terminal harness Stop idempotent and reconcile stale Assistant followers/progress without requiring a desktop page refresh
- provide an in-place conversation reload action and document the exact Grok capability boundary

## Verification

- `poetry run pytest tests/v3/test_harnesses.py -q` — 40 passed
- `npm test -- --testTimeout=15000` — 358 passed
- `npm run build` — production bundle passed
- Assistant queue/guidance/send-now/recovery Playwright matrix — 16 passed across desktop, narrow, 320 px mobile Chromium, and mobile WebKit
- updated Grok send-now flow — 4 passed across the same browser/device matrix
- production Assistant real-Core workflow — passed
- `poetry run mypy src/nebula/v3` — passed
- Ruff lint/format and frontend diagnostic audit — passed