### PR TITLE
Add Security Browser managed-runtime foundation

### DIFF
--- a/docs/SECURITY-BROWSER-CONTRACT.md
+++ b/docs/SECURITY-BROWSER-CONTRACT.md
@@ -1,0 +1,78 @@
+# Security Browser operator contract
+
+This contract is the implementation and release boundary for the first-class
+Security Browser. It describes what an operator must be able to accomplish and
+observe before any individual component or engine can be described as complete.
+
+## Journey and entry point
+
+The real entry point is **Project -> Workbench -> Security Browser**. The primary
+journey is:
+
+1. discover the Security Browser and understand whether desktop execution is ready;
+2. create a guided assessment from an enumerated in-scope target, browser identity,
+   objective, and scan profile;
+3. review the frozen scope revision, risk classes, grants, and request budgets;
+4. start the assessment and observe ordered progress, traffic, coverage, and
+   candidate issues;
+5. take over for login, MFA, CAPTCHA, consent, or an ambiguous browser state, then
+   return control without changing identity;
+6. pause, resume, stop, retry, refresh, reconnect, and background the interface
+   without losing or duplicating acknowledged work;
+7. validate a candidate through a separate bounded grant and promote it only after
+   operator evidence review;
+8. revoke or delete the assessment and clear stale URL selection.
+
+Forking is not part of the first assessment lifecycle. A new objective creates a
+new assessment so scope, identity, evidence, and budgets remain attributable.
+
+## State authorities
+
+| State | Authority |
+| --- | --- |
+| Assessment, steps, coverage, traffic metadata, candidates, evidence | Core database |
+| Selected assessment, tool, and item | URL query parameters |
+| Scope, grants, and budgets | Frozen Core policy revision |
+| Live browser process, profile, raw secret-bearing state | Desktop browser engine |
+| Passwords, cookies, tokens, reusable credentials | Browser profile or OS vault |
+| Device-local layout preferences | Browser storage |
+| Open panels, drafts, selection gestures | React component state |
+| Connection and replay cursor | Core event stream plus durable snapshot fallback |
+
+## Observable invariants
+
+- Manual and autonomous work share one selected identity, traffic history, scope
+  revision, and evidence chain.
+- A successful mutation is followed by the authoritative object appearing in its
+  list and becoming selectable without a reload.
+- Reload, reconnect, backgrounding, browser-worker restart, and receipt retry do
+  not repeat a non-idempotent action.
+- No request leaves the frozen scope or exceeds the assessment or validation
+  grant budget.
+- Secrets never enter model-visible arguments, Core receipts, diagnostics, or
+  assessment events.
+- Approvals, user-input requests, failures, expiring grants, and emergency stop
+  remain visible and actionable; verbose traces stay collapsed by default.
+- Every failure names what failed, what remains usable, and the next valid action.
+- Mobile and LAN clients may monitor and stop, but never claim native commands or
+  silently imply that a desktop-only action executed.
+- Candidate issues are not confirmed Findings until validation and operator review.
+
+## Acceptance layers
+
+| Journey step | Required evidence |
+| --- | --- |
+| Discover and create | Component plus desktop/mobile Playwright |
+| Save and select | Real Core plus URL deep-link/reload |
+| Execute and stream | Managed browser adapter plus real Core event replay |
+| Take over and interrupt | Packaged desktop workflow |
+| Refresh and reconnect | Real Core plus browser-engine restart injection |
+| Failure and retry | Component, real Core, and adapter fault injection |
+| Stop and revoke | Real Core plus native egress/command cancellation |
+| Delete | Real Core plus stale-URL recovery |
+
+Release evidence must use the matrix in
+`.agents/skills/nebula-product-quality/references/quality-gates.md`. A mocked API,
+development bundle, resized desktop viewport, or source inspection is never a
+substitute for a required real-Core, packaged desktop, LAN, mobile-browser, or
+physical-device gate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ from = "src"
 
 [tool.poetry.scripts]
 nebula-core = "nebula.v3.cli:main"
+nebula-browserd = "nebula.v3.browserd:main"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"

--- a/scripts/package_audit.py
+++ b/scripts/package_audit.py
@@ -4,8 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import hmac
 import json
 import os
+import re
 from pathlib import Path
 from typing import Iterable
 
@@ -253,10 +256,13 @@ def inspect_installer_tree(root: Path) -> dict[str, object]:
             "bundled Playwright Chromium manifest is invalid"
         ) from exc
     executables = manifest.get("executables")
+    executable_sha256 = manifest.get("executable_sha256")
     licenses = manifest.get("licenses")
+    sbom = manifest.get("sbom")
+    provenance = manifest.get("provenance")
     if (
         manifest.get("schema") != 1
-        or manifest.get("browser") != "chromium-headless-shell"
+        or manifest.get("browser") != "chromium"
         or not isinstance(manifest.get("playwright_version"), str)
         or not manifest["playwright_version"]
         or not isinstance(manifest.get("target"), str)
@@ -266,9 +272,20 @@ def inspect_installer_tree(root: Path) -> dict[str, object]:
         or not isinstance(executables, list)
         or not executables
         or not all(isinstance(value, str) and value for value in executables)
+        or not isinstance(executable_sha256, dict)
+        or set(executable_sha256) != set(executables)
+        or not all(
+            isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value)
+            for value in executable_sha256.values()
+        )
         or not isinstance(licenses, list)
         or not licenses
         or not all(isinstance(value, str) and value for value in licenses)
+        or not isinstance(sbom, str)
+        or not sbom
+        or not isinstance(provenance, dict)
+        or provenance.get("installer") != "python -m playwright install chromium"
+        or provenance.get("target") != manifest.get("target")
     ):
         raise ArtifactAuditError(
             "bundled Playwright Chromium manifest has an invalid contract"
@@ -284,6 +301,11 @@ def inspect_installer_tree(root: Path) -> dict[str, object]:
             raise ArtifactAuditError(
                 "bundled Playwright Chromium executable is absent or not executable"
             )
+        digest = hashlib.sha256(executable.read_bytes()).hexdigest()
+        if not hmac.compare_digest(digest, executable_sha256[relative]):
+            raise ArtifactAuditError(
+                "bundled Playwright Chromium executable failed its digest check"
+            )
     for relative in licenses:
         license_file = (runtime_root / relative).resolve()
         if (
@@ -294,6 +316,19 @@ def inspect_installer_tree(root: Path) -> dict[str, object]:
             raise ArtifactAuditError(
                 "bundled Playwright Chromium license payload is absent"
             )
+    sbom_path = (runtime_root / sbom).resolve()
+    if (
+        not sbom_path.is_relative_to(runtime_root)
+        or not sbom_path.is_file()
+        or sbom_path.stat().st_size == 0
+    ):
+        raise ArtifactAuditError("bundled Playwright Chromium SBOM is absent")
+    try:
+        sbom_payload = json.loads(sbom_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ArtifactAuditError("bundled Playwright Chromium SBOM is invalid") from exc
+    if sbom_payload.get("spdxVersion") != "SPDX-2.3":
+        raise ArtifactAuditError("bundled Playwright Chromium SBOM is invalid")
     return {
         "status": "ok",
         "tree": str(root),

--- a/scripts/smoke_test_browserd.py
+++ b/scripts/smoke_test_browserd.py
@@ -1,0 +1,113 @@
+"""Exercise the staged full Chromium through browserd's durable action boundary."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import tempfile
+
+
+async def _respond_as_bounded_proxy(
+    reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+) -> None:
+    try:
+        await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5)
+        body = b"<html><head><title>Nebula browserd smoke</title></head><body><button>Ready</button></body></html>"
+        writer.write(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: text/html; charset=utf-8\r\n"
+            + f"Content-Length: {len(body)}\r\n".encode("ascii")
+            + b"Connection: close\r\n\r\n"
+            + body
+        )
+        await writer.drain()
+    except (asyncio.IncompleteReadError, asyncio.TimeoutError):
+        pass
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+async def smoke(runtime_root: Path) -> dict[str, object]:
+    os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(runtime_root)
+    from nebula.v3.browser_engine import BrowserEngineAction
+    from nebula.v3.browserd import BrowserdManager, BrowserdSettings
+    from nebula.v3.domain import BrowserEngineState
+
+    proxy = await asyncio.start_server(
+        _respond_as_bounded_proxy, host="127.0.0.1", port=0
+    )
+    port = int(proxy.sockets[0].getsockname()[1])
+    with tempfile.TemporaryDirectory(prefix="nebula-browserd-smoke-") as temporary:
+        manager = BrowserdManager(
+            BrowserdSettings(
+                token="smoke-only-token",
+                profile_root=Path(temporary) / "profiles",
+                policy_proxy_url=f"http://127.0.0.1:{port}",
+                runtime_root=runtime_root,
+                headless=True,
+            )
+        )
+        try:
+            await manager.start()
+            capability = await manager.readiness()
+            if capability.state != BrowserEngineState.DEGRADED:
+                raise RuntimeError(
+                    f"headless smoke expected degraded readiness, found {capability.state.value}"
+                )
+            identity = await manager.ensure_identity("smoke-identity")
+            action = BrowserEngineAction(
+                action_token="smoke-navigation-once",
+                assessment_id="smoke-assessment",
+                session_id="smoke-session",
+                identity_id=identity.identity_id,
+                tab_id=identity.tab_ids[0],
+                kind="navigate",
+                arguments={"url": "http://browserd-smoke.example.test/"},
+                side_effect="possible",
+            )
+            receipt = await manager.execute(action)
+            if receipt.state != "complete":
+                raise RuntimeError(
+                    f"managed navigation did not complete: {receipt.model_dump_json()}"
+                )
+            duplicate = await manager.execute(action)
+            if duplicate != receipt:
+                raise RuntimeError("duplicate action token did not return its durable receipt")
+            await manager.lifecycle(action.assessment_id, "paused")
+            cancelled = await manager.execute(
+                action.model_copy(update={"action_token": "smoke-after-pause"})
+            )
+            if cancelled.state != "cancelled":
+                raise RuntimeError("paused assessment accepted a new browser action")
+            return {
+                "state": "passed",
+                "engine_state": capability.state.value,
+                "engine_digest": capability.digest,
+                "action_state": receipt.state,
+                "duplicate_receipt": True,
+                "paused_action_state": cancelled.state,
+                "trace_count": len(receipt.trace_ids),
+            }
+        finally:
+            await manager.close()
+            proxy.close()
+            await proxy.wait_closed()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--runtime-root",
+        type=Path,
+        default=Path("ui/src-tauri/resources/playwright-browsers"),
+    )
+    arguments = parser.parse_args()
+    print(json.dumps(asyncio.run(smoke(arguments.runtime_root.resolve())), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stage_playwright_runtime.py
+++ b/scripts/stage_playwright_runtime.py
@@ -1,26 +1,26 @@
 #!/usr/bin/env python3
-"""Stage the locked Playwright Chromium headless shell for native installers."""
+"""Stage the locked full Playwright Chromium runtime for native installers."""
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.metadata
 import json
 import os
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
 
 
 MANIFEST_NAME = "nebula-playwright-runtime.json"
+SBOM_NAME = "nebula-playwright-sbom.spdx.json"
 BROWSER_EXECUTABLE_NAMES = {
     "chrome",
     "chrome.exe",
-    "chrome-headless-shell",
-    "headless_shell",
-    "headless_shell.exe",
 }
 
 
@@ -66,13 +66,21 @@ def _browser_licenses(destination: Path) -> list[Path]:
     )
 
 
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def stage_playwright_runtime(
     destination: Path,
     *,
     target: str,
     run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> dict[str, object]:
-    """Download and verify the headless-only Chromium payload."""
+    """Download and verify full headed Chromium for browserd and headless capture."""
 
     destination = destination.absolute()
     _clear_generated_payload(destination)
@@ -84,7 +92,7 @@ def stage_playwright_runtime(
         "-m",
         "playwright",
         "install",
-        "--only-shell",
+        "--no-shell",
         "chromium",
     ]
     try:
@@ -97,23 +105,76 @@ def stage_playwright_runtime(
     executables = _browser_executables(destination)
     if not executables:
         raise PlaywrightRuntimeStageError(
-            "Playwright did not install an executable Chromium headless shell"
+            "Playwright did not install an executable full Chromium runtime"
         )
     licenses = _browser_licenses(destination)
     if not licenses:
         raise PlaywrightRuntimeStageError(
             "Playwright Chromium did not include its required license payload"
         )
+    playwright_version = importlib.metadata.version("playwright")
+    executable_sha256 = {
+        path.as_posix(): _sha256(destination / path) for path in executables
+    }
+    primary_sha256 = executable_sha256[executables[0].as_posix()]
+    sbom = {
+        "spdxVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": f"Nebula Playwright Chromium {target}",
+        "documentNamespace": (
+            "https://nebula.security/sbom/playwright/"
+            f"{playwright_version}/{target}/{primary_sha256}"
+        ),
+        "creationInfo": {
+            "created": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "creators": ["Tool: scripts/stage_playwright_runtime.py"],
+        },
+        "packages": [
+            {
+                "name": "Chrome for Testing",
+                "SPDXID": "SPDXRef-Package-Chromium",
+                "versionInfo": executables[0].parts[0],
+                "downloadLocation": "NOASSERTION",
+                "filesAnalyzed": True,
+                "licenseConcluded": "BSD-3-Clause",
+                "licenseDeclared": "BSD-3-Clause",
+                "checksums": [
+                    {"algorithm": "SHA256", "checksumValue": primary_sha256}
+                ],
+            },
+            {
+                "name": "Playwright Python",
+                "SPDXID": "SPDXRef-Package-Playwright",
+                "versionInfo": playwright_version,
+                "downloadLocation": "NOASSERTION",
+                "filesAnalyzed": False,
+                "licenseConcluded": "Apache-2.0",
+                "licenseDeclared": "Apache-2.0",
+            },
+        ],
+    }
+    (destination / SBOM_NAME).write_text(
+        json.dumps(sbom, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     files = [path for path in destination.rglob("*") if path.is_file()]
     payload_bytes = sum(path.stat().st_size for path in files)
     manifest: dict[str, object] = {
         "schema": 1,
-        "browser": "chromium-headless-shell",
-        "playwright_version": importlib.metadata.version("playwright"),
+        "browser": "chromium",
+        "playwright_version": playwright_version,
         "target": target,
         "payload_bytes": payload_bytes,
         "executables": [path.as_posix() for path in executables],
+        "executable_sha256": executable_sha256,
         "licenses": [path.as_posix() for path in licenses],
+        "sbom": SBOM_NAME,
+        "provenance": {
+            "installer": "python -m playwright install chromium",
+            "browser_revision": executables[0].parts[0],
+            "target": target,
+        },
     }
     (destination / MANIFEST_NAME).write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n",

--- a/src/nebula/v3/action_registry.py
+++ b/src/nebula/v3/action_registry.py
@@ -28,6 +28,7 @@ CONTENT_KINDS = [
     ResourceKind.TERMINAL_SESSION,
     ResourceKind.TERMINAL_COMMAND,
     ResourceKind.BROWSER_SESSION,
+    ResourceKind.BROWSER_ASSESSMENT,
     ResourceKind.BROWSER_TAB,
     ResourceKind.BROWSER_EXCHANGE,
     ResourceKind.MISSION,

--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -8561,6 +8561,7 @@ def create_app(
                     encoded + "=" * (-len(encoded) % 4)
                 ).decode("utf-8")
             except (ValueError, UnicodeDecodeError):
+                # diagnostic-expected: malformed auth is rejected below.
                 subprotocol_token = None
             break
         if (
@@ -8580,6 +8581,7 @@ def create_app(
         try:
             store.get(BrowserAssessment, assessment_id)
         except NotFoundError:
+            # diagnostic-expected: a missing assessment is a bounded protocol close.
             await websocket.close(code=4404, reason="assessment not found")
             return
         event_protocol = (
@@ -8621,6 +8623,7 @@ def create_app(
                     await websocket.send_json({"kind": "heartbeat", "sequence": cursor})
                     idle_ticks = 0
         except WebSocketDisconnect:
+            # diagnostic-expected: disconnect only detaches this viewer.
             return
 
     @app.post(

--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -77,6 +77,16 @@ from .browser_automation import (
     BrowserCommandCreateRequest,
     BrowserProxyRuleRequest,
 )
+from .browser_assessments import (
+    BrowserAssessmentCreateRequest,
+    BrowserAssessmentService,
+    BrowserAssessmentTransitionRequest,
+    BrowserAssessmentWorkspace,
+    BrowserIssueCandidateCreateRequest,
+    BrowserValidationGrantRequest,
+    BrowserValidationRevokeRequest,
+    BrowserValidationResultRequest,
+)
 from .browser_tools import (
     AUTONOMOUS_BROWSER_TOOLS,
     BrowserAutomationToolPlatform,
@@ -212,12 +222,15 @@ from .domain import (
     ActionResolutionRequest,
     Artifact,
     BrowserAction,
+    BrowserAssessment,
     BrowserCommand,
     BrowserProxyRule,
     BrowserHandoff,
     BrowserIdentity,
+    BrowserIssueCandidate,
     BrowserSession,
     BrowserTrafficExchange,
+    BrowserValidationGrant,
     BrowserWebSocketFrame,
     AutomationApprovalPolicy,
     AutomationProjectPolicy,
@@ -482,6 +495,10 @@ CUSTOM_RESOURCES = {
     "browser_attacks",
     "browser_attack_results",
     "browser_token_analyses",
+    "browser_assessments",
+    "browser_assessment_steps",
+    "browser_issue_candidates",
+    "browser_validation_grants",
 }
 
 API_PREFIX = "/api/v1"
@@ -1197,6 +1214,7 @@ def create_app(
 
     credentials = credential_store or CredentialStore()
     browser_automation = BrowserAutomationService(store)
+    browser_assessments = BrowserAssessmentService(store)
     browser_automation_platform = BrowserAutomationToolPlatform(
         store, browser_automation
     )
@@ -2960,6 +2978,7 @@ def create_app(
             ResourceKind.REPORT: "reports",
             ResourceKind.TERMINAL_COMMAND: "command_executions",
             ResourceKind.BROWSER_SESSION: "browser_sessions",
+            ResourceKind.BROWSER_ASSESSMENT: "browser_assessments",
             ResourceKind.BROWSER_EXCHANGE: "browser_traffic_exchanges",
             ResourceKind.MISSION: "runs",
             ResourceKind.TERMINAL_SESSION: "automation_sessions",
@@ -8417,6 +8436,251 @@ def create_app(
 
     browser_security = BrowserSecurityService(store, artifact_store)
     browser_research = BrowserResearchService(store, browser_security, artifact_store)
+
+    @app.get(
+        f"{API_PREFIX}/engagements/{{engagement_id}}/browser-assessments",
+        response_model=BrowserAssessmentWorkspace,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def browser_assessment_workspace(
+        engagement_id: str,
+    ) -> BrowserAssessmentWorkspace:
+        """Return the authoritative snapshot used for load and stream recovery."""
+
+        return await browser_assessments.workspace(engagement_id)
+
+    @app.post(
+        f"{API_PREFIX}/engagements/{{engagement_id}}/browser-assessments",
+        response_model=BrowserAssessment,
+        status_code=201,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def create_browser_assessment(
+        engagement_id: str,
+        request: BrowserAssessmentCreateRequest,
+        x_nebula_actor: str = Header(default="operator", alias="X-Nebula-Actor"),
+    ) -> BrowserAssessment:
+        return await browser_assessments.create(engagement_id, request, x_nebula_actor)
+
+    @app.get(
+        f"{API_PREFIX}/browser-assessments/{{assessment_id}}",
+        response_model=BrowserAssessment,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def browser_assessment_detail(assessment_id: str) -> BrowserAssessment:
+        return store.get(BrowserAssessment, assessment_id)
+
+    @app.post(
+        f"{API_PREFIX}/browser-assessments/{{assessment_id}}/transition",
+        response_model=BrowserAssessment,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def transition_browser_assessment(
+        assessment_id: str,
+        request: BrowserAssessmentTransitionRequest,
+        x_nebula_actor: str = Header(default="operator", alias="X-Nebula-Actor"),
+    ) -> BrowserAssessment:
+        return await browser_assessments.transition(
+            assessment_id, request, x_nebula_actor
+        )
+
+    @app.post(
+        f"{API_PREFIX}/browser-assessments/{{assessment_id}}/readiness",
+        response_model=BrowserAssessment,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def refresh_browser_assessment_readiness(
+        assessment_id: str,
+        expected_revision: int = Query(ge=1),
+        x_nebula_actor: str = Header(default="operator", alias="X-Nebula-Actor"),
+    ) -> BrowserAssessment:
+        return await browser_assessments.refresh_readiness(
+            assessment_id, expected_revision, x_nebula_actor
+        )
+
+    @app.delete(
+        f"{API_PREFIX}/browser-assessments/{{assessment_id}}",
+        status_code=204,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def delete_browser_assessment(
+        assessment_id: str,
+        expected_revision: int = Query(ge=1),
+    ) -> Response:
+        browser_assessments.delete(assessment_id, expected_revision)
+        return Response(status_code=204)
+
+    @app.get(
+        f"{API_PREFIX}/browser-assessments/{{assessment_id}}/events",
+        response_model=OperationEventList,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def replay_browser_assessment_events(
+        assessment_id: str,
+        after: int = Query(default=0, ge=0),
+        limit: int = Query(default=1000, ge=1, le=10_000),
+    ) -> OperationEventList:
+        store.get(BrowserAssessment, assessment_id)
+        events = store.replay_operation_events(
+            assessment_id, after_sequence=after, limit=limit
+        )
+        return OperationEventList(
+            events=events,
+            next_sequence=events[-1].sequence if events else after,
+        )
+
+    @app.websocket(f"{API_PREFIX}/browser-assessments/{{assessment_id}}/events/ws")
+    async def browser_assessment_event_socket(
+        websocket: WebSocket,
+        assessment_id: str,
+        after: int = Query(default=0, ge=0),
+    ) -> None:
+        supplied: str | None = None
+        authorization = websocket.headers.get("authorization", "")
+        if authorization.lower().startswith("bearer "):
+            supplied = authorization[7:]
+        offered_protocols = [
+            value.strip()
+            for value in websocket.headers.get("sec-websocket-protocol", "").split(",")
+            if value.strip()
+        ]
+        subprotocol_token: str | None = None
+        for protocol in offered_protocols:
+            if not protocol.startswith("nebula.auth."):
+                continue
+            encoded = protocol.removeprefix("nebula.auth.")
+            try:
+                subprotocol_token = base64.urlsafe_b64decode(
+                    encoded + "=" * (-len(encoded) % 4)
+                ).decode("utf-8")
+            except (ValueError, UnicodeDecodeError):
+                subprotocol_token = None
+            break
+        if (
+            supplied
+            and subprotocol_token
+            and not hmac.compare_digest(supplied, subprotocol_token)
+        ):
+            await websocket.close(code=4401, reason="conflicting authentication tokens")
+            return
+        supplied = subprotocol_token or supplied
+        if not allow_unauthenticated and (
+            (not supplied or not hmac.compare_digest(supplied, token))
+            and not _cookie_websocket_authenticated(websocket)
+        ):
+            await websocket.close(code=4401, reason="valid bearer token required")
+            return
+        try:
+            store.get(BrowserAssessment, assessment_id)
+        except NotFoundError:
+            await websocket.close(code=4404, reason="assessment not found")
+            return
+        event_protocol = (
+            "nebula.events.v1" if "nebula.events.v1" in offered_protocols else None
+        )
+        await websocket.accept(subprotocol=event_protocol)
+        cursor = after
+        try:
+            while True:
+                events = store.replay_operation_events(
+                    assessment_id, after_sequence=cursor, limit=1000
+                )
+                for event in events:
+                    await websocket.send_json(
+                        {"kind": "event", "event": event.model_dump(mode="json")}
+                    )
+                    cursor = event.sequence
+                if not events:
+                    await websocket.send_json(
+                        {"kind": "replay_complete", "after_sequence": cursor}
+                    )
+                    break
+            idle_ticks = 0
+            while True:
+                await asyncio.sleep(0.25)
+                events = store.replay_operation_events(
+                    assessment_id, after_sequence=cursor, limit=1000
+                )
+                if events:
+                    idle_ticks = 0
+                    for event in events:
+                        await websocket.send_json(
+                            {"kind": "event", "event": event.model_dump(mode="json")}
+                        )
+                        cursor = event.sequence
+                    continue
+                idle_ticks += 1
+                if idle_ticks >= 80:
+                    await websocket.send_json({"kind": "heartbeat", "sequence": cursor})
+                    idle_ticks = 0
+        except WebSocketDisconnect:
+            return
+
+    @app.post(
+        f"{API_PREFIX}/browser-issue-candidates",
+        response_model=BrowserIssueCandidate,
+        status_code=201,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def create_browser_issue_candidate(
+        request: BrowserIssueCandidateCreateRequest,
+        x_nebula_actor: str = Header(default="engine", alias="X-Nebula-Actor"),
+    ) -> BrowserIssueCandidate:
+        return browser_assessments.create_candidate(request, x_nebula_actor)
+
+    @app.post(
+        f"{API_PREFIX}/browser-issue-candidates/{{candidate_id}}/validation-grant",
+        response_model=BrowserValidationGrant,
+        status_code=201,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def grant_browser_issue_validation(
+        candidate_id: str,
+        request: BrowserValidationGrantRequest,
+        x_nebula_actor: str = Header(default="operator", alias="X-Nebula-Actor"),
+    ) -> BrowserValidationGrant:
+        return browser_assessments.grant_validation(
+            candidate_id, request, x_nebula_actor
+        )
+
+    @app.post(
+        f"{API_PREFIX}/browser-issue-candidates/{{candidate_id}}/validation-revoke",
+        response_model=BrowserValidationGrant,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def revoke_browser_issue_validation(
+        candidate_id: str,
+        request: BrowserValidationRevokeRequest,
+        x_nebula_actor: str = Header(default="operator", alias="X-Nebula-Actor"),
+    ) -> BrowserValidationGrant:
+        return browser_assessments.revoke_validation(
+            candidate_id, request, x_nebula_actor
+        )
+
+    @app.post(
+        f"{API_PREFIX}/browser-issue-candidates/{{candidate_id}}/validation-result",
+        response_model=BrowserIssueCandidate,
+        tags=["security-browser"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def finish_browser_issue_validation(
+        candidate_id: str,
+        request: BrowserValidationResultRequest,
+        x_nebula_actor: str = Header(default="operator", alias="X-Nebula-Actor"),
+    ) -> BrowserIssueCandidate:
+        return browser_assessments.finish_validation(
+            candidate_id, request, x_nebula_actor
+        )
 
     @app.get(
         f"{API_PREFIX}/engagements/{{engagement_id}}/browser-automation",

--- a/src/nebula/v3/browser_assessments.py
+++ b/src/nebula/v3/browser_assessments.py
@@ -1,0 +1,1020 @@
+"""Durable, scope-bound Security Browser assessment workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import timedelta
+from typing import Any, Literal
+
+from pydantic import Field, model_validator
+
+from .browser_engine import BrowserEngineRegistry
+from .browser_security import BrowserWorkflowError
+from .domain import (
+    BrowserAssessment,
+    BrowserAssessmentBudget,
+    BrowserAssessmentPhase,
+    BrowserAssessmentProfile,
+    BrowserAssessmentStatus,
+    BrowserAssessmentStep,
+    BrowserAssessmentStepStatus,
+    BrowserEngineCapability,
+    BrowserEngineState,
+    BrowserIdentity,
+    BrowserIssueCandidate,
+    BrowserIssueValidationStatus,
+    BrowserLoginFlow,
+    BrowserRecipe,
+    BrowserSession,
+    BrowserValidationGrant,
+    Engagement,
+    Evidence,
+    NebulaModel,
+    RiskClass,
+    ScopePolicy,
+    Severity,
+    utc_now,
+)
+from .policy import PolicyEffect, PolicyEngine, PolicyRequest
+from .storage import ConflictError, NebulaStore, NotFoundError
+
+
+class BrowserScanProfileDefinition(NebulaModel):
+    id: BrowserAssessmentProfile
+    name: str
+    summary: str
+    risk_classes: list[RiskClass]
+    required_adapters: list[str]
+    default_budget: BrowserAssessmentBudget
+    validation_locked: bool = False
+
+
+BUILTIN_PROFILES: tuple[BrowserScanProfileDefinition, ...] = (
+    BrowserScanProfileDefinition(
+        id=BrowserAssessmentProfile.EXPLORE,
+        name="Explore",
+        summary="Guided manual exploration and evidence capture without scanner traffic.",
+        risk_classes=[RiskClass.PASSIVE],
+        required_adapters=["managed-chromium"],
+        default_budget=BrowserAssessmentBudget(
+            max_requests=500, max_actions=250, max_duration_seconds=1_800
+        ),
+    ),
+    BrowserScanProfileDefinition(
+        id=BrowserAssessmentProfile.STANDARD,
+        name="Standard",
+        summary="Explore, crawl, and run passive analysis. Recommended for most tests.",
+        risk_classes=[RiskClass.PASSIVE],
+        required_adapters=["managed-chromium", "zap"],
+        default_budget=BrowserAssessmentBudget(),
+    ),
+    BrowserScanProfileDefinition(
+        id=BrowserAssessmentProfile.DEEP,
+        name="Deep",
+        summary="Add bounded active checks after crawling and passive analysis.",
+        risk_classes=[RiskClass.PASSIVE, RiskClass.ACTIVE_SCAN],
+        required_adapters=["managed-chromium", "zap"],
+        default_budget=BrowserAssessmentBudget(
+            max_requests=10_000,
+            max_actions=2_000,
+            max_duration_seconds=14_400,
+            max_concurrency=4,
+        ),
+    ),
+    BrowserScanProfileDefinition(
+        id=BrowserAssessmentProfile.API,
+        name="API",
+        summary="Import and test OpenAPI, Postman, GraphQL, and observed API traffic.",
+        risk_classes=[RiskClass.PASSIVE, RiskClass.ACTIVE_SCAN],
+        required_adapters=["managed-chromium", "zap"],
+        default_budget=BrowserAssessmentBudget(
+            max_requests=8_000,
+            max_actions=1_000,
+            max_duration_seconds=10_800,
+            max_concurrency=4,
+        ),
+    ),
+    BrowserScanProfileDefinition(
+        id=BrowserAssessmentProfile.VALIDATION,
+        name="Validation",
+        summary="Run one explicitly granted issue-validation technique and its controls.",
+        risk_classes=[RiskClass.EXPLOITATION],
+        required_adapters=["managed-chromium"],
+        default_budget=BrowserAssessmentBudget(
+            max_requests=25,
+            max_actions=25,
+            max_duration_seconds=900,
+            max_concurrency=1,
+        ),
+        validation_locked=True,
+    ),
+)
+
+PROFILE_BY_ID = {profile.id: profile for profile in BUILTIN_PROFILES}
+
+
+class BrowserAssessmentWorkspace(NebulaModel):
+    assessments: list[BrowserAssessment]
+    steps: list[BrowserAssessmentStep]
+    login_flows: list[BrowserLoginFlow]
+    recipes: list[BrowserRecipe]
+    candidates: list[BrowserIssueCandidate]
+    validation_grants: list[BrowserValidationGrant]
+    profiles: list[BrowserScanProfileDefinition]
+    engines: list[BrowserEngineCapability]
+
+
+class BrowserAssessmentCreateRequest(NebulaModel):
+    name: str = Field(min_length=1, max_length=200)
+    objective: str = Field(min_length=1, max_length=4_000)
+    profile: BrowserAssessmentProfile = BrowserAssessmentProfile.STANDARD
+    session_id: str = Field(min_length=1, max_length=200)
+    identity_ids: list[str] = Field(min_length=1, max_length=32)
+    primary_identity_id: str = Field(min_length=1, max_length=200)
+    target_urls: list[str] = Field(min_length=1, max_length=100)
+    credential_refs: list[str] = Field(default_factory=list, max_length=32)
+    validation_grant_id: str | None = Field(default=None, max_length=200)
+    budget: BrowserAssessmentBudget | None = None
+
+
+class BrowserAssessmentTransitionRequest(NebulaModel):
+    expected_revision: int = Field(ge=1)
+    action: Literal[
+        "start",
+        "pause",
+        "resume",
+        "takeover",
+        "return_control",
+        "stop",
+        "complete",
+        "fail",
+        "retry",
+        "revoke",
+    ]
+    reason: str | None = Field(default=None, max_length=4_000)
+    recovery_action: str | None = Field(default=None, max_length=1_000)
+    idempotency_key: str = Field(min_length=1, max_length=300)
+
+    @model_validator(mode="after")
+    def assessment_failure_is_actionable(self) -> "BrowserAssessmentTransitionRequest":
+        if self.action == "fail" and (not self.reason or not self.recovery_action):
+            raise ValueError("failed assessments require a reason and recovery action")
+        if self.action in {"pause", "takeover", "revoke"} and not self.reason:
+            raise ValueError(f"{self.action} requires an operator-visible reason")
+        return self
+
+
+class BrowserIssueCandidateCreateRequest(NebulaModel):
+    assessment_id: str = Field(min_length=1, max_length=200)
+    rule_id: str = Field(min_length=1, max_length=200)
+    check_family: str = Field(min_length=1, max_length=200)
+    title: str = Field(min_length=1, max_length=300)
+    cwe: str | None = Field(default=None, pattern=r"^CWE-[1-9][0-9]{0,4}$")
+    target_url: str = Field(min_length=1, max_length=16_384)
+    insertion_point: str | None = Field(default=None, max_length=1_000)
+    severity: Severity
+    confidence: Literal["tentative", "firm", "certain"] = "tentative"
+    control_results: list[dict[str, Any]] = Field(default_factory=list, max_length=100)
+    evidence_ids: list[str] = Field(default_factory=list, max_length=500)
+
+
+class BrowserValidationGrantRequest(NebulaModel):
+    expected_candidate_revision: int = Field(ge=1)
+    technique: str = Field(min_length=1, max_length=1_000)
+    max_requests: int = Field(ge=1, le=10_000)
+    duration_seconds: int = Field(ge=30, le=3_600)
+    idempotency_key: str = Field(min_length=1, max_length=300)
+
+
+class BrowserValidationRevokeRequest(NebulaModel):
+    expected_grant_revision: int = Field(ge=1)
+    reason: str = Field(min_length=1, max_length=1_000)
+    idempotency_key: str = Field(min_length=1, max_length=300)
+
+
+class BrowserValidationResultRequest(NebulaModel):
+    expected_candidate_revision: int = Field(ge=1)
+    expected_grant_revision: int = Field(ge=1)
+    result: Literal["confirmed", "rejected", "inconclusive"]
+    control_results: list[dict[str, Any]] = Field(min_length=1, max_length=100)
+    evidence_ids: list[str] = Field(min_length=1, max_length=500)
+    idempotency_key: str = Field(min_length=1, max_length=300)
+
+
+_TRANSITIONS: dict[
+    str, tuple[set[BrowserAssessmentStatus], BrowserAssessmentStatus]
+] = {
+    "start": ({BrowserAssessmentStatus.READY}, BrowserAssessmentStatus.RUNNING),
+    "pause": ({BrowserAssessmentStatus.RUNNING}, BrowserAssessmentStatus.PAUSED),
+    "resume": ({BrowserAssessmentStatus.PAUSED}, BrowserAssessmentStatus.RUNNING),
+    "takeover": (
+        {BrowserAssessmentStatus.RUNNING},
+        BrowserAssessmentStatus.WAITING_OPERATOR,
+    ),
+    "return_control": (
+        {BrowserAssessmentStatus.WAITING_OPERATOR},
+        BrowserAssessmentStatus.RUNNING,
+    ),
+    "stop": (
+        {
+            BrowserAssessmentStatus.RUNNING,
+            BrowserAssessmentStatus.PAUSED,
+            BrowserAssessmentStatus.WAITING_OPERATOR,
+        },
+        BrowserAssessmentStatus.STOPPED,
+    ),
+    "complete": (
+        {BrowserAssessmentStatus.RUNNING},
+        BrowserAssessmentStatus.COMPLETE,
+    ),
+    "fail": (
+        {
+            BrowserAssessmentStatus.READY,
+            BrowserAssessmentStatus.RUNNING,
+            BrowserAssessmentStatus.PAUSED,
+            BrowserAssessmentStatus.WAITING_OPERATOR,
+        },
+        BrowserAssessmentStatus.FAILED,
+    ),
+    "retry": (
+        {BrowserAssessmentStatus.FAILED, BrowserAssessmentStatus.STOPPED},
+        BrowserAssessmentStatus.READY,
+    ),
+    "revoke": (
+        {
+            BrowserAssessmentStatus.DRAFT,
+            BrowserAssessmentStatus.READY,
+            BrowserAssessmentStatus.RUNNING,
+            BrowserAssessmentStatus.PAUSED,
+            BrowserAssessmentStatus.WAITING_OPERATOR,
+            BrowserAssessmentStatus.STOPPED,
+            BrowserAssessmentStatus.FAILED,
+        },
+        BrowserAssessmentStatus.REVOKED,
+    ),
+}
+
+
+class BrowserAssessmentService:
+    def __init__(
+        self,
+        store: NebulaStore,
+        engines: BrowserEngineRegistry | None = None,
+    ) -> None:
+        self.store = store
+        self.engines = engines or BrowserEngineRegistry()
+        self.policy = PolicyEngine()
+
+    async def workspace(self, engagement_id: str) -> BrowserAssessmentWorkspace:
+        self.store.get(Engagement, engagement_id)
+        return BrowserAssessmentWorkspace(
+            assessments=self.store.list_entities(
+                BrowserAssessment, engagement_id=engagement_id, limit=1_000
+            ),
+            steps=self.store.list_entities(
+                BrowserAssessmentStep, engagement_id=engagement_id, limit=1_000
+            ),
+            login_flows=self.store.list_entities(
+                BrowserLoginFlow, engagement_id=engagement_id, limit=1_000
+            ),
+            recipes=self.store.list_entities(
+                BrowserRecipe, engagement_id=engagement_id, limit=1_000
+            ),
+            candidates=self.store.list_entities(
+                BrowserIssueCandidate, engagement_id=engagement_id, limit=1_000
+            ),
+            validation_grants=self.store.list_entities(
+                BrowserValidationGrant, engagement_id=engagement_id, limit=1_000
+            ),
+            profiles=list(BUILTIN_PROFILES),
+            engines=await self.engines.capabilities(),
+        )
+
+    async def create(
+        self,
+        engagement_id: str,
+        request: BrowserAssessmentCreateRequest,
+        actor_id: str,
+    ) -> BrowserAssessment:
+        scope = self._scope(engagement_id)
+        session = self._owned(BrowserSession, request.session_id, engagement_id)
+        for identity_id in request.identity_ids:
+            identity = self._owned(BrowserIdentity, identity_id, engagement_id)
+            if identity.revoked_at is not None:
+                raise BrowserWorkflowError("a selected browser identity is revoked")
+        if session.identity_id != request.primary_identity_id:
+            raise BrowserWorkflowError(
+                "the assessment primary identity must match its browser session"
+            )
+        profile = PROFILE_BY_ID[request.profile]
+        for target in request.target_urls:
+            for risk in profile.risk_classes:
+                self._require_in_scope(scope, target, risk)
+
+        if request.profile == BrowserAssessmentProfile.VALIDATION:
+            self._validation_grant(
+                request.validation_grant_id, engagement_id, request.target_urls
+            )
+
+        capabilities = await self.engines.capabilities()
+        ready_adapters = {
+            capability.adapter
+            for capability in capabilities
+            if capability.state == BrowserEngineState.READY
+        }
+        missing = [
+            adapter
+            for adapter in profile.required_adapters
+            if adapter not in ready_adapters
+        ]
+        status = (
+            BrowserAssessmentStatus.DRAFT if missing else BrowserAssessmentStatus.READY
+        )
+        assessment = BrowserAssessment(
+            engagement_id=engagement_id,
+            name=request.name,
+            objective=request.objective,
+            profile=request.profile,
+            session_id=session.id,
+            identity_ids=request.identity_ids,
+            primary_identity_id=request.primary_identity_id,
+            target_urls=request.target_urls,
+            scope_policy_id=scope.id,
+            scope_policy_revision=scope.revision,
+            risk_classes=[risk.value for risk in profile.risk_classes],
+            validation_grant_id=request.validation_grant_id,
+            credential_refs=request.credential_refs,
+            status=status,
+            budget=request.budget or profile.default_budget.model_copy(deep=True),
+            engines=capabilities,
+            pause_reason=(
+                f"Prepare required runtime: {', '.join(missing)}" if missing else None
+            ),
+            recovery_action=(
+                "Use Prepare/Retry in preflight. Manual legacy browsing remains available."
+                if missing
+                else None
+            ),
+            created_by=actor_id,
+        )
+        created, _ = self.store.create_with_operation_event(
+            assessment,
+            operation_id=assessment.id,
+            operation_kind="browser_assessment",
+            engagement_id=engagement_id,
+            event_type="browser_assessment.created",
+            event_payload={
+                "assessment_id": assessment.id,
+                "status": assessment.status.value,
+                "profile": assessment.profile.value,
+            },
+            actor_id=actor_id,
+            idempotency_key=f"create:{assessment.id}",
+        )
+        for step in self._initial_steps(created):
+            self.store.create_with_operation_event(
+                step,
+                operation_id=created.id,
+                operation_kind="browser_assessment",
+                engagement_id=engagement_id,
+                event_type="browser_assessment.step.created",
+                event_payload={
+                    "assessment_id": created.id,
+                    "step_id": step.id,
+                    "sequence": step.sequence,
+                    "title": step.title,
+                },
+                actor_id=actor_id,
+                idempotency_key=f"create-step:{step.id}",
+            )
+        return created
+
+    async def refresh_readiness(
+        self, assessment_id: str, expected_revision: int, actor_id: str
+    ) -> BrowserAssessment:
+        assessment = self.store.get(BrowserAssessment, assessment_id)
+        capabilities = await self.engines.capabilities()
+        profile = PROFILE_BY_ID[assessment.profile]
+        ready = {
+            item.adapter
+            for item in capabilities
+            if item.state == BrowserEngineState.READY
+        }
+        missing = [item for item in profile.required_adapters if item not in ready]
+        next_status = (
+            BrowserAssessmentStatus.DRAFT if missing else BrowserAssessmentStatus.READY
+        )
+        if assessment.status not in {
+            BrowserAssessmentStatus.DRAFT,
+            BrowserAssessmentStatus.READY,
+            BrowserAssessmentStatus.FAILED,
+        }:
+            next_status = assessment.status
+        updated, _ = self.store.update_with_operation_event(
+            BrowserAssessment,
+            assessment.id,
+            {
+                "engines": capabilities,
+                "status": next_status,
+                "pause_reason": (
+                    f"Prepare required runtime: {', '.join(missing)}"
+                    if missing
+                    else None
+                ),
+                "failure": None,
+                "recovery_action": (
+                    "Use Prepare/Retry in preflight. Manual legacy browsing remains available."
+                    if missing
+                    else None
+                ),
+            },
+            expected_revision=expected_revision,
+            operation_id=assessment.id,
+            operation_kind="browser_assessment",
+            engagement_id=assessment.engagement_id,
+            event_type="browser_assessment.readiness",
+            event_payload={"status": next_status.value, "missing": missing},
+            actor_id=actor_id,
+        )
+        return updated
+
+    async def transition(
+        self,
+        assessment_id: str,
+        request: BrowserAssessmentTransitionRequest,
+        actor_id: str,
+    ) -> BrowserAssessment:
+        assessment = self.store.get(BrowserAssessment, assessment_id)
+        for event in self.store.replay_operation_events(
+            assessment.id, after_sequence=0, limit=10_000
+        ):
+            if event.idempotency_key != request.idempotency_key:
+                continue
+            if event.event_type != f"browser_assessment.{request.action}":
+                raise BrowserWorkflowError(
+                    "assessment idempotency key was reused for a different action"
+                )
+            return assessment
+        allowed, next_status = _TRANSITIONS[request.action]
+        if assessment.status not in allowed:
+            raise BrowserWorkflowError(
+                f"cannot {request.action} an assessment in {assessment.status.value} state"
+            )
+        if request.action in {"start", "retry"}:
+            self._require_frozen_scope(assessment)
+        managed = await self.engines.adapter("managed-chromium")
+        if request.action in {"start", "pause", "resume", "stop", "complete", "revoke"}:
+            if managed is None:
+                raise BrowserWorkflowError(
+                    "Managed Chromium is unavailable; manual legacy browsing remains usable. Prepare the runtime and retry."
+                )
+            try:
+                if request.action == "start":
+                    await managed.ensure_identity(assessment.primary_identity_id)
+                    await managed.resume(assessment.id)
+                elif request.action == "pause":
+                    await managed.pause(assessment.id)
+                elif request.action == "resume":
+                    await managed.resume(assessment.id)
+                else:
+                    await managed.stop(assessment.id)
+            except Exception as exc:
+                raise BrowserWorkflowError(
+                    "Managed Chromium did not acknowledge the lifecycle change; saved assessment data remains usable. Retry readiness or use the desktop emergency stop."
+                ) from exc
+        changes: dict[str, Any] = {
+            "status": next_status,
+            "pause_reason": None,
+            "failure": None,
+            "recovery_action": None,
+        }
+        now = utc_now()
+        if request.action == "start":
+            changes.update(started_at=now, phase=BrowserAssessmentPhase.DISCOVERY)
+        elif request.action == "pause":
+            changes["pause_reason"] = request.reason
+        elif request.action == "takeover":
+            changes.update(control_owner="operator", pause_reason=request.reason)
+        elif request.action == "return_control":
+            changes["control_owner"] = "nebula"
+        elif request.action in {"stop", "complete", "revoke"}:
+            changes["completed_at"] = now
+            if request.action == "complete":
+                changes.update(phase=BrowserAssessmentPhase.COMPLETE, progress=1)
+            if request.action == "revoke":
+                changes["pause_reason"] = request.reason
+        elif request.action == "fail":
+            changes.update(
+                failure=request.reason,
+                recovery_action=request.recovery_action,
+                pause_reason=request.reason,
+            )
+        updated, _ = self.store.update_with_operation_event(
+            BrowserAssessment,
+            assessment.id,
+            changes,
+            expected_revision=request.expected_revision,
+            operation_id=assessment.id,
+            operation_kind="browser_assessment",
+            engagement_id=assessment.engagement_id,
+            event_type=f"browser_assessment.{request.action}",
+            event_payload={
+                "assessment_id": assessment.id,
+                "from": assessment.status.value,
+                "to": next_status.value,
+                "reason": request.reason,
+            },
+            actor_id=actor_id,
+            idempotency_key=request.idempotency_key,
+        )
+        return updated
+
+    def create_candidate(
+        self, request: BrowserIssueCandidateCreateRequest, actor_id: str
+    ) -> BrowserIssueCandidate:
+        assessment = self.store.get(BrowserAssessment, request.assessment_id)
+        self._require_frozen_scope(assessment)
+        self._require_assessment_target(assessment, request.target_url)
+        self._require_in_scope(
+            self._scope(assessment.engagement_id),
+            request.target_url,
+            RiskClass.PASSIVE,
+        )
+        digest_payload = {
+            "assessment_id": assessment.id,
+            "rule_id": request.rule_id,
+            "target_url": request.target_url,
+            "insertion_point": request.insertion_point,
+        }
+        fingerprint = hashlib.sha256(
+            json.dumps(digest_payload, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+        existing = self.store.list_entities(
+            BrowserIssueCandidate,
+            engagement_id=assessment.engagement_id,
+            limit=1_000,
+        )
+        for candidate in existing:
+            if candidate.deduplication_fingerprint == fingerprint:
+                return candidate
+        candidate = BrowserIssueCandidate(
+            engagement_id=assessment.engagement_id,
+            deduplication_fingerprint=fingerprint,
+            **request.model_dump(),
+        )
+        event_payload = {
+            "assessment_id": assessment.id,
+            "candidate_id": candidate.id,
+            "severity": candidate.severity.value,
+        }
+        try:
+            with self.store.transaction() as transaction:
+                transaction.add(candidate)
+                transaction.update(
+                    BrowserAssessment,
+                    assessment.id,
+                    {"candidate_ids": [*assessment.candidate_ids, candidate.id]},
+                    expected_revision=assessment.revision,
+                )
+                transaction.append_operation_event(
+                    assessment.id,
+                    "browser_assessment",
+                    assessment.engagement_id,
+                    "browser_assessment.candidate.created",
+                    event_payload,
+                    actor_id=actor_id,
+                    idempotency_key=f"candidate:{fingerprint}",
+                )
+        except ConflictError:
+            duplicate = next(
+                (
+                    item
+                    for item in self.store.list_entities(
+                        BrowserIssueCandidate,
+                        engagement_id=assessment.engagement_id,
+                        limit=1_000,
+                    )
+                    if item.deduplication_fingerprint == fingerprint
+                ),
+                None,
+            )
+            if duplicate is not None:
+                return duplicate
+            raise
+        return candidate
+
+    def grant_validation(
+        self,
+        candidate_id: str,
+        request: BrowserValidationGrantRequest,
+        actor_id: str,
+    ) -> BrowserValidationGrant:
+        candidate = self.store.get(BrowserIssueCandidate, candidate_id)
+        assessment = self.store.get(BrowserAssessment, candidate.assessment_id)
+        prior = self._validation_event(
+            assessment.id,
+            request.idempotency_key,
+            "browser_assessment.validation.granted",
+        )
+        if prior is not None:
+            expected = {
+                "candidate_id": candidate.id,
+                "technique": request.technique,
+                "max_requests": request.max_requests,
+                "duration_seconds": request.duration_seconds,
+            }
+            if any(prior.payload.get(key) != value for key, value in expected.items()):
+                raise BrowserWorkflowError(
+                    "validation idempotency key was reused for different authority"
+                )
+            return self.store.get(
+                BrowserValidationGrant, str(prior.payload["grant_id"])
+            )
+        self._require_frozen_scope(assessment)
+        self._require_assessment_target(assessment, candidate.target_url)
+        self._require_in_scope(
+            self._scope(candidate.engagement_id),
+            candidate.target_url,
+            RiskClass.EXPLOITATION,
+        )
+        now = utc_now()
+        prior_grants = [
+            grant
+            for grant in self.store.list_entities(
+                BrowserValidationGrant,
+                engagement_id=candidate.engagement_id,
+                limit=1_000,
+            )
+            if grant.candidate_id == candidate.id and grant.status == "active"
+        ]
+        live_grants = [grant for grant in prior_grants if grant.expires_at > now]
+        if live_grants:
+            raise BrowserWorkflowError(
+                "candidate already has an active validation grant; revoke or consume it before granting another"
+            )
+        if candidate.validation_status in {
+            BrowserIssueValidationStatus.CONFIRMED,
+            BrowserIssueValidationStatus.VALIDATING,
+        }:
+            raise BrowserWorkflowError(
+                f"candidate in {candidate.validation_status.value} state cannot receive another grant"
+            )
+        grant = BrowserValidationGrant(
+            engagement_id=candidate.engagement_id,
+            assessment_id=assessment.id,
+            candidate_id=candidate.id,
+            target_url=candidate.target_url,
+            technique=request.technique,
+            max_requests=request.max_requests,
+            duration_seconds=request.duration_seconds,
+            granted_by=actor_id,
+            granted_at=now,
+            expires_at=now + timedelta(seconds=request.duration_seconds),
+        )
+        event_payload = {
+            "assessment_id": assessment.id,
+            "candidate_id": candidate.id,
+            "grant_id": grant.id,
+            "target_url": grant.target_url,
+            "technique": grant.technique,
+            "max_requests": grant.max_requests,
+            "duration_seconds": grant.duration_seconds,
+            "expires_at": grant.expires_at.isoformat(),
+        }
+        try:
+            with self.store.transaction() as transaction:
+                for expired in prior_grants:
+                    transaction.update(
+                        BrowserValidationGrant,
+                        expired.id,
+                        {"status": "expired"},
+                        expected_revision=expired.revision,
+                    )
+                transaction.add(grant)
+                transaction.update(
+                    BrowserIssueCandidate,
+                    candidate.id,
+                    {
+                        "validation_status": BrowserIssueValidationStatus.QUEUED,
+                        "validation_grant_id": grant.id,
+                    },
+                    expected_revision=request.expected_candidate_revision,
+                )
+                transaction.append_operation_event(
+                    assessment.id,
+                    "browser_assessment",
+                    assessment.engagement_id,
+                    "browser_assessment.validation.granted",
+                    event_payload,
+                    actor_id=actor_id,
+                    idempotency_key=request.idempotency_key,
+                )
+        except ConflictError:
+            prior = self._validation_event(
+                assessment.id,
+                request.idempotency_key,
+                "browser_assessment.validation.granted",
+            )
+            if prior is not None:
+                return self.store.get(
+                    BrowserValidationGrant, str(prior.payload["grant_id"])
+                )
+            raise
+        return grant
+
+    def revoke_validation(
+        self,
+        candidate_id: str,
+        request: BrowserValidationRevokeRequest,
+        actor_id: str,
+    ) -> BrowserValidationGrant:
+        candidate = self.store.get(BrowserIssueCandidate, candidate_id)
+        grant = self.store.get(
+            BrowserValidationGrant, candidate.validation_grant_id or ""
+        )
+        prior = self._validation_event(
+            candidate.assessment_id,
+            request.idempotency_key,
+            "browser_assessment.validation.revoked",
+        )
+        if prior is not None:
+            if (
+                prior.payload.get("grant_id") != grant.id
+                or prior.payload.get("reason") != request.reason
+            ):
+                raise BrowserWorkflowError(
+                    "validation idempotency key was reused for a different revocation"
+                )
+            return self.store.get(BrowserValidationGrant, grant.id)
+        if (
+            grant.candidate_id != candidate.id
+            or grant.assessment_id != candidate.assessment_id
+        ):
+            raise BrowserWorkflowError("validation grant ownership is inconsistent")
+        if grant.status != "active":
+            raise BrowserWorkflowError(f"validation grant is already {grant.status}")
+        now = utc_now()
+        event_payload = {
+            "assessment_id": candidate.assessment_id,
+            "candidate_id": candidate.id,
+            "grant_id": grant.id,
+            "reason": request.reason,
+        }
+        with self.store.transaction() as transaction:
+            updated = transaction.update(
+                BrowserValidationGrant,
+                grant.id,
+                {"status": "revoked", "revoked_at": now},
+                expected_revision=request.expected_grant_revision,
+            )
+            if candidate.validation_status in {
+                BrowserIssueValidationStatus.QUEUED,
+                BrowserIssueValidationStatus.VALIDATING,
+            }:
+                transaction.update(
+                    BrowserIssueCandidate,
+                    candidate.id,
+                    {"validation_status": BrowserIssueValidationStatus.INCONCLUSIVE},
+                    expected_revision=candidate.revision,
+                )
+            transaction.append_operation_event(
+                candidate.assessment_id,
+                "browser_assessment",
+                candidate.engagement_id,
+                "browser_assessment.validation.revoked",
+                event_payload,
+                actor_id=actor_id,
+                idempotency_key=request.idempotency_key,
+            )
+        return updated
+
+    def finish_validation(
+        self,
+        candidate_id: str,
+        request: BrowserValidationResultRequest,
+        actor_id: str,
+    ) -> BrowserIssueCandidate:
+        candidate = self.store.get(BrowserIssueCandidate, candidate_id)
+        grant = self.store.get(
+            BrowserValidationGrant, candidate.validation_grant_id or ""
+        )
+        prior = self._validation_event(
+            candidate.assessment_id,
+            request.idempotency_key,
+            "browser_assessment.validation.completed",
+        )
+        if prior is not None:
+            if (
+                prior.payload.get("candidate_id") != candidate.id
+                or prior.payload.get("result") != request.result
+            ):
+                raise BrowserWorkflowError(
+                    "validation idempotency key was reused for a different result"
+                )
+            return candidate
+        assessment = self.store.get(BrowserAssessment, candidate.assessment_id)
+        self._require_frozen_scope(assessment)
+        self._require_assessment_target(assessment, candidate.target_url)
+        if (
+            grant.candidate_id != candidate.id
+            or grant.assessment_id != candidate.assessment_id
+            or grant.target_url != candidate.target_url
+        ):
+            raise BrowserWorkflowError("validation grant ownership is inconsistent")
+        if grant.status != "active" or grant.expires_at <= utc_now():
+            raise BrowserWorkflowError(
+                "validation grant is expired or revoked; request a new bounded grant"
+            )
+        status = BrowserIssueValidationStatus(request.result)
+        for evidence_id in request.evidence_ids:
+            self._owned(Evidence, evidence_id, candidate.engagement_id)
+        event_payload = {
+            "assessment_id": candidate.assessment_id,
+            "candidate_id": candidate.id,
+            "grant_id": grant.id,
+            "result": status.value,
+            "evidence_ids": request.evidence_ids,
+        }
+        with self.store.transaction() as transaction:
+            updated = transaction.update(
+                BrowserIssueCandidate,
+                candidate.id,
+                {
+                    "validation_status": status,
+                    "control_results": request.control_results,
+                    "evidence_ids": list(
+                        dict.fromkeys([*candidate.evidence_ids, *request.evidence_ids])
+                    ),
+                },
+                expected_revision=request.expected_candidate_revision,
+            )
+            transaction.update(
+                BrowserValidationGrant,
+                grant.id,
+                {"status": "consumed"},
+                expected_revision=request.expected_grant_revision,
+            )
+            transaction.append_operation_event(
+                candidate.assessment_id,
+                "browser_assessment",
+                candidate.engagement_id,
+                "browser_assessment.validation.completed",
+                event_payload,
+                actor_id=actor_id,
+                idempotency_key=request.idempotency_key,
+            )
+        return updated
+
+    def delete(self, assessment_id: str, expected_revision: int) -> None:
+        assessment = self.store.get(BrowserAssessment, assessment_id)
+        if assessment.status not in {
+            BrowserAssessmentStatus.DRAFT,
+            BrowserAssessmentStatus.STOPPED,
+            BrowserAssessmentStatus.COMPLETE,
+            BrowserAssessmentStatus.FAILED,
+            BrowserAssessmentStatus.REVOKED,
+        }:
+            raise BrowserWorkflowError("stop the assessment before deleting it")
+        self.store.delete(
+            BrowserAssessment, assessment.id, expected_revision=expected_revision
+        )
+
+    def _scope(self, engagement_id: str) -> ScopePolicy:
+        engagement = self.store.get(Engagement, engagement_id)
+        if not engagement.scope_policy_id:
+            raise BrowserWorkflowError("Project scope is not configured")
+        scope = self.store.get(ScopePolicy, engagement.scope_policy_id)
+        if scope.engagement_id != engagement_id:
+            raise BrowserWorkflowError("Project scope ownership is invalid")
+        return scope
+
+    def _require_frozen_scope(self, assessment: BrowserAssessment) -> None:
+        scope = self._scope(assessment.engagement_id)
+        if (
+            scope.id != assessment.scope_policy_id
+            or scope.revision != assessment.scope_policy_revision
+        ):
+            raise BrowserWorkflowError(
+                "Project scope changed after preflight; review and create a new frozen assessment"
+            )
+        for target in assessment.target_urls:
+            for risk in assessment.risk_classes:
+                self._require_in_scope(scope, target, RiskClass(risk))
+
+    def _require_in_scope(
+        self, scope: ScopePolicy, target: str, risk: RiskClass
+    ) -> None:
+        decision = self.policy.evaluate(
+            scope,
+            PolicyRequest(
+                tool_name="security_browser",
+                risk_class=risk,
+                target=target,
+                action="browser_assessment",
+                native_scope_authority=True,
+            ),
+        )
+        if decision.effect == PolicyEffect.DENY:
+            raise BrowserWorkflowError(decision.reason)
+
+    @staticmethod
+    def _require_assessment_target(assessment: BrowserAssessment, target: str) -> None:
+        from .browser_automation import BrowserAutomationService
+
+        if not BrowserAutomationService._target_in_lease(
+            target, assessment.target_urls
+        ):
+            raise BrowserWorkflowError(
+                "candidate target is outside the assessment's frozen target corridor"
+            )
+
+    def _validation_event(
+        self, assessment_id: str, idempotency_key: str, event_type: str
+    ) -> Any | None:
+        for event in self.store.replay_operation_events(
+            assessment_id, after_sequence=0, limit=10_000
+        ):
+            if event.idempotency_key != idempotency_key:
+                continue
+            if event.event_type != event_type:
+                raise BrowserWorkflowError(
+                    "validation idempotency key was reused for a different action"
+                )
+            return event
+        return None
+
+    def _owned(self, model: type[Any], entity_id: str, engagement_id: str) -> Any:
+        entity = self.store.get(model, entity_id)
+        if getattr(entity, "engagement_id", None) != engagement_id:
+            raise BrowserWorkflowError("browser entity belongs to another Project")
+        return entity
+
+    def _validation_grant(
+        self,
+        grant_id: str | None,
+        engagement_id: str,
+        targets: list[str],
+    ) -> BrowserValidationGrant:
+        if not grant_id:
+            raise BrowserWorkflowError("Validation requires an issue-specific grant")
+        try:
+            grant = self.store.get(BrowserValidationGrant, grant_id)
+        except NotFoundError as exc:
+            raise BrowserWorkflowError("Validation grant does not exist") from exc
+        if grant.engagement_id != engagement_id or grant.target_url not in targets:
+            raise BrowserWorkflowError("Validation grant does not cover this target")
+        if grant.status != "active" or grant.expires_at <= utc_now():
+            raise BrowserWorkflowError("Validation grant is expired or revoked")
+        return grant
+
+    @staticmethod
+    def _initial_steps(assessment: BrowserAssessment) -> list[BrowserAssessmentStep]:
+        stages: list[tuple[str, str, str]] = [
+            ("Discovery", "Map the selected target with the chosen identity.", "crawl"),
+            (
+                "Evidence baseline",
+                "Capture the initial trace and page state.",
+                "capture",
+            ),
+        ]
+        if assessment.profile != BrowserAssessmentProfile.EXPLORE:
+            stages.append(
+                (
+                    "Passive analysis",
+                    "Analyze observed traffic without mutation.",
+                    "passive_scan",
+                )
+            )
+        if assessment.profile in {
+            BrowserAssessmentProfile.DEEP,
+            BrowserAssessmentProfile.API,
+        }:
+            stages.append(
+                (
+                    "Active checks",
+                    "Run the approved bounded active check families.",
+                    "active_scan",
+                )
+            )
+        if assessment.profile == BrowserAssessmentProfile.VALIDATION:
+            stages = [
+                (
+                    "Issue validation",
+                    "Execute the granted technique and negative controls.",
+                    "validate",
+                )
+            ]
+        return [
+            BrowserAssessmentStep(
+                engagement_id=assessment.engagement_id,
+                assessment_id=assessment.id,
+                sequence=index,
+                title=title,
+                intent=intent,
+                capability=capability,
+                target=assessment.target_urls[0],
+                status=BrowserAssessmentStepStatus.QUEUED,
+            )
+            for index, (title, intent, capability) in enumerate(stages)
+        ]

--- a/src/nebula/v3/browser_engine.py
+++ b/src/nebula/v3/browser_engine.py
@@ -1,0 +1,320 @@
+"""Versioned execution contract for Security Browser desktop adapters.
+
+Core persists normalized readiness and receipts. Secret-bearing browser state and
+the live process remain owned by the loopback-authenticated desktop adapter.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import ipaddress
+import os
+from typing import Any, Literal
+from urllib.parse import urlsplit
+from urllib.parse import quote
+
+import httpx
+from pydantic import Field
+
+from .domain import (
+    BrowserEngineCapability,
+    BrowserEngineState,
+    NebulaModel,
+)
+
+
+BROWSER_ENGINE_CONTRACT_VERSION = "1"
+
+
+class BrowserEngineUnavailableError(RuntimeError):
+    """A normalized local-runtime failure that never includes bearer material."""
+
+
+class BrowserEngineAction(NebulaModel):
+    action_token: str = Field(min_length=1, max_length=300)
+    assessment_id: str = Field(min_length=1, max_length=200)
+    session_id: str = Field(min_length=1, max_length=200)
+    identity_id: str = Field(min_length=1, max_length=200)
+    tab_id: str = Field(min_length=1, max_length=200)
+    kind: Literal[
+        "navigate",
+        "click",
+        "fill",
+        "select",
+        "press",
+        "upload",
+        "wait",
+        "snapshot",
+        "screenshot",
+    ]
+    locator: dict[str, str] = Field(default_factory=dict)
+    arguments: dict[str, Any] = Field(default_factory=dict)
+    expected_page_url: str | None = Field(default=None, max_length=16_384)
+    pre_fingerprint: str | None = Field(default=None, max_length=500)
+    side_effect: Literal["none", "possible", "known"] = "possible"
+
+
+class BrowserEngineReceipt(NebulaModel):
+    action_token: str = Field(min_length=1, max_length=300)
+    state: Literal["complete", "failed", "ambiguous", "cancelled"]
+    page_url: str | None = Field(default=None, max_length=16_384)
+    pre_fingerprint: str | None = Field(default=None, max_length=500)
+    post_fingerprint: str | None = Field(default=None, max_length=500)
+    trace_ids: list[str] = Field(default_factory=list, max_length=100)
+    evidence_ids: list[str] = Field(default_factory=list, max_length=100)
+    failure_code: str | None = Field(default=None, max_length=120)
+    operator_message: str | None = Field(default=None, max_length=1_000)
+    recovery_action: str | None = Field(default=None, max_length=1_000)
+
+
+class BrowserEngineAdapter(ABC):
+    """Conformance boundary implemented by managed Chromium and scanners."""
+
+    contract_version = BROWSER_ENGINE_CONTRACT_VERSION
+
+    @abstractmethod
+    async def readiness(self) -> BrowserEngineCapability:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def ensure_identity(self, identity_id: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def execute(self, action: BrowserEngineAction) -> BrowserEngineReceipt:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def pause(self, assessment_id: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def resume(self, assessment_id: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def stop(self, assessment_id: str) -> None:
+        raise NotImplementedError
+
+
+class LocalBrowserdAdapter(BrowserEngineAdapter):
+    """Authenticated loopback client for the desktop-owned managed Chromium process."""
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str,
+        *,
+        client: httpx.AsyncClient | None = None,
+        timeout_seconds: float = 5.0,
+    ) -> None:
+        parsed = urlsplit(base_url)
+        try:
+            address = ipaddress.ip_address(parsed.hostname or "")
+            port = parsed.port
+        except ValueError as exc:
+            raise ValueError(
+                "browserd URL must use a literal loopback address"
+            ) from exc
+        if (
+            parsed.scheme != "http"
+            or not address.is_loopback
+            or port is None
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError(
+                "browserd URL must be credential-free HTTP on a literal loopback address and explicit port"
+            )
+        if not token or any(character.isspace() for character in token):
+            raise ValueError("browserd authentication token must be opaque")
+        self.base_url = base_url.rstrip("/")
+        self._token = token
+        self._client = client
+        self._timeout = timeout_seconds
+
+    async def _request(
+        self, method: str, path: str, payload: dict[str, Any] | None = None
+    ) -> httpx.Response:
+        headers = {
+            "Authorization": f"Bearer {self._token}",
+            "Accept": "application/json",
+        }
+        if self._client is not None:
+            response = await self._client.request(
+                method,
+                f"{self.base_url}{path}",
+                headers=headers,
+                json=payload,
+                timeout=self._timeout,
+            )
+        else:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                response = await client.request(
+                    method,
+                    f"{self.base_url}{path}",
+                    headers=headers,
+                    json=payload,
+                )
+        return response
+
+    async def readiness(self) -> BrowserEngineCapability:
+        try:
+            response = await self._request("GET", "/v1/readiness")
+            response.raise_for_status()
+            capability = BrowserEngineCapability.model_validate(response.json())
+            if (
+                capability.adapter != "managed-chromium"
+                or capability.contract_version != self.contract_version
+            ):
+                raise ValueError("browserd returned an incompatible adapter contract")
+            return capability
+        except Exception:
+            return BrowserEngineCapability(
+                adapter="managed-chromium",
+                display_name="Managed Chromium",
+                state=BrowserEngineState.UNAVAILABLE,
+                unavailability_reason=(
+                    "The authenticated browserd readiness receipt was unavailable or incompatible. "
+                    "Manual legacy browsing remains usable."
+                ),
+                recovery_action=(
+                    "Restart or prepare the managed browser runtime, then retry preflight."
+                ),
+            )
+
+    async def ensure_identity(self, identity_id: str) -> None:
+        response = await self._request(
+            "POST", "/v1/identities/ensure", {"identity_id": identity_id}
+        )
+        if response.status_code >= 400:
+            raise BrowserEngineUnavailableError(
+                "Managed Chromium could not prepare the selected identity. Retry preparation."
+            )
+
+    async def execute(self, action: BrowserEngineAction) -> BrowserEngineReceipt:
+        try:
+            response = await self._request(
+                "POST", "/v1/actions", action.model_dump(mode="json")
+            )
+            response.raise_for_status()
+            receipt = BrowserEngineReceipt.model_validate(response.json())
+            if receipt.action_token != action.action_token:
+                raise ValueError("browserd returned a receipt for another action")
+            return receipt
+        except Exception:
+            ambiguous = action.side_effect != "none"
+            return BrowserEngineReceipt(
+                action_token=action.action_token,
+                state="ambiguous" if ambiguous else "failed",
+                pre_fingerprint=action.pre_fingerprint,
+                failure_code=(
+                    "browserd_receipt_ambiguous"
+                    if ambiguous
+                    else "browserd_unavailable"
+                ),
+                operator_message=(
+                    "The managed browser action may have occurred, but its durable receipt was not recovered."
+                    if ambiguous
+                    else "The managed browser action did not return an authenticated receipt."
+                ),
+                recovery_action=(
+                    "Review the live page and trace before choosing a new action; Nebula will not replay automatically."
+                    if ambiguous
+                    else "Retry after Managed Chromium reports ready."
+                ),
+            )
+
+    async def _lifecycle(self, assessment_id: str, action: str) -> None:
+        response = await self._request(
+            "POST",
+            f"/v1/assessments/{quote(assessment_id, safe='')}/{action}",
+            {"assessment_id": assessment_id},
+        )
+        if response.status_code >= 400:
+            raise BrowserEngineUnavailableError(
+                f"Managed Chromium could not {action} the assessment. Use emergency stop if it remains active."
+            )
+
+    async def pause(self, assessment_id: str) -> None:
+        await self._lifecycle(assessment_id, "pause")
+
+    async def resume(self, assessment_id: str) -> None:
+        await self._lifecycle(assessment_id, "resume")
+
+    async def stop(self, assessment_id: str) -> None:
+        await self._lifecycle(assessment_id, "stop")
+
+
+class BrowserEngineRegistry:
+    """Process-local adapter catalog; production adapters register at startup."""
+
+    def __init__(self, adapters: list[BrowserEngineAdapter] | None = None) -> None:
+        if adapters is None:
+            endpoint = os.environ.get("NEBULA_BROWSERD_URL")
+            token = os.environ.get("NEBULA_BROWSERD_TOKEN")
+            adapters = (
+                [LocalBrowserdAdapter(endpoint, token)]
+                if endpoint is not None and token is not None
+                else []
+            )
+        self._adapters = list(adapters)
+
+    def register(self, adapter: BrowserEngineAdapter) -> None:
+        self._adapters.append(adapter)
+
+    async def adapter(self, name: str) -> BrowserEngineAdapter | None:
+        for adapter in self._adapters:
+            capability = await adapter.readiness()
+            if (
+                capability.adapter == name
+                and capability.state == BrowserEngineState.READY
+            ):
+                return adapter
+        return None
+
+    async def capabilities(self) -> list[BrowserEngineCapability]:
+        receipts = [await adapter.readiness() for adapter in self._adapters]
+        if not any(receipt.adapter == "managed-chromium" for receipt in receipts):
+            receipts.append(
+                BrowserEngineCapability(
+                    adapter="managed-chromium",
+                    display_name="Managed Chromium",
+                    state=BrowserEngineState.UNAVAILABLE,
+                    unavailability_reason=(
+                        "The project-scoped browserd runtime has not reported ready "
+                        "on this desktop. Manual legacy browsing remains usable."
+                    ),
+                    recovery_action="Prepare the managed browser runtime, then retry preflight.",
+                )
+            )
+        if not any(receipt.adapter == "zap" for receipt in receipts):
+            receipts.append(
+                BrowserEngineCapability(
+                    adapter="zap",
+                    display_name="OWASP ZAP scanner",
+                    state=BrowserEngineState.UNAVAILABLE,
+                    unavailability_reason=(
+                        "The digest-pinned scanner runtime has not been prepared. "
+                        "Manual browsing remains usable without scanning."
+                    ),
+                    recovery_action="Prepare the scanner runtime or choose Explore.",
+                )
+            )
+        receipts.append(
+            BrowserEngineCapability(
+                adapter="legacy-webview",
+                display_name="Legacy system WebView",
+                state=BrowserEngineState.DEGRADED,
+                actions=["manual.navigate", "manual.takeover"],
+                protocols=["http", "https"],
+                unavailability_reason=(
+                    "Legacy mode is manual-only and does not claim autonomous reliability."
+                ),
+                recovery_action="Prepare Managed Chromium for guided execution.",
+            )
+        )
+        return receipts

--- a/src/nebula/v3/browser_engine.py
+++ b/src/nebula/v3/browser_engine.py
@@ -173,6 +173,7 @@ class LocalBrowserdAdapter(BrowserEngineAdapter):
                 raise ValueError("browserd returned an incompatible adapter contract")
             return capability
         except Exception:
+            # diagnostic-expected: converted to an actionable readiness receipt.
             return BrowserEngineCapability(
                 adapter="managed-chromium",
                 display_name="Managed Chromium",
@@ -206,6 +207,7 @@ class LocalBrowserdAdapter(BrowserEngineAdapter):
                 raise ValueError("browserd returned a receipt for another action")
             return receipt
         except Exception:
+            # diagnostic-expected: converted to a non-replayable action receipt.
             ambiguous = action.side_effect != "none"
             return BrowserEngineReceipt(
                 action_token=action.action_token,

--- a/src/nebula/v3/browserd.py
+++ b/src/nebula/v3/browserd.py
@@ -1,0 +1,847 @@
+"""Desktop-owned, loopback-authenticated managed Chromium service.
+
+This process owns live Playwright objects, local profiles, traces, and raw page
+state. Core receives only normalized readiness and action receipts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+import hashlib
+import hmac
+import json
+import os
+from pathlib import Path
+import re
+import sqlite3
+from typing import Any, AsyncIterator, Callable
+from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
+
+from fastapi import Depends, FastAPI, Header, HTTPException, WebSocket
+from fastapi.websockets import WebSocketDisconnect
+from playwright.async_api import async_playwright
+from pydantic import BaseModel, ConfigDict, Field
+import uvicorn
+
+from .browser_engine import (
+    BROWSER_ENGINE_CONTRACT_VERSION,
+    BrowserEngineAction,
+    BrowserEngineReceipt,
+)
+from .domain import BrowserEngineCapability, BrowserEngineState
+
+
+_OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,199}$")
+
+
+def _loopback_http_url(value: str) -> str:
+    import ipaddress
+
+    parsed = urlsplit(value)
+    try:
+        address = ipaddress.ip_address(parsed.hostname or "")
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("URL must use a literal loopback address") from exc
+    if (
+        parsed.scheme != "http"
+        or not address.is_loopback
+        or port is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError(
+            "URL must be credential-free HTTP on a literal loopback address and explicit port"
+        )
+    return value.rstrip("/")
+
+
+def _safe_page_url(value: str) -> str | None:
+    parsed = urlsplit(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+    host = parsed.hostname
+    if ":" in host:
+        host = f"[{host}]"
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    netloc = f"{host}:{port}" if port is not None else host
+    return urlunsplit((parsed.scheme, netloc, parsed.path or "/", "", ""))
+
+
+def _network_url(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError("browser navigation requires an absolute HTTP(S) URL")
+    parsed = urlsplit(value)
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise ValueError("browser navigation contains an invalid port") from exc
+    if (
+        parsed.scheme.lower() not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+    ):
+        raise ValueError(
+            "browser navigation requires a credential-free HTTP(S) URL without a fragment"
+        )
+    return value
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class BrowserdSettings:
+    token: str
+    profile_root: Path
+    policy_proxy_url: str
+    runtime_root: Path
+    upload_root: Path | None = None
+    headless: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.token or any(character.isspace() for character in self.token):
+            raise ValueError("browserd token must be opaque")
+        object.__setattr__(
+            self, "policy_proxy_url", _loopback_http_url(self.policy_proxy_url)
+        )
+        root = self.profile_root.expanduser().resolve(strict=False)
+        runtime = self.runtime_root.expanduser().resolve(strict=False)
+        object.__setattr__(self, "profile_root", root)
+        object.__setattr__(self, "runtime_root", runtime)
+        if self.upload_root is not None:
+            object.__setattr__(
+                self,
+                "upload_root",
+                self.upload_root.expanduser().resolve(strict=False),
+            )
+
+
+class BrowserdIdentityRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    identity_id: str = Field(pattern=_OPAQUE_ID.pattern)
+
+
+class BrowserdIdentityReceipt(BaseModel):
+    identity_id: str
+    tab_ids: list[str]
+    state: str = "ready"
+
+
+class BrowserdLifecycleReceipt(BaseModel):
+    assessment_id: str
+    state: str
+
+
+class ActionLedger:
+    """Local action-token ledger storing hashes and redacted receipts only."""
+
+    def __init__(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(path.parent, 0o700)
+        self.path = path
+        self._lock = asyncio.Lock()
+        with sqlite3.connect(path) as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS browser_actions (
+                    action_token TEXT PRIMARY KEY,
+                    payload_sha256 TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    receipt_json TEXT
+                )
+                """
+            )
+        os.chmod(path, 0o600)
+
+    @staticmethod
+    def payload_digest(action: BrowserEngineAction) -> str:
+        payload = json.dumps(
+            action.model_dump(mode="json"), sort_keys=True, separators=(",", ":")
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    async def claim(self, action: BrowserEngineAction) -> BrowserEngineReceipt | None:
+        digest = self.payload_digest(action)
+        async with self._lock:
+            with sqlite3.connect(self.path) as connection:
+                row = connection.execute(
+                    "SELECT payload_sha256, state, receipt_json FROM browser_actions WHERE action_token = ?",
+                    (action.action_token,),
+                ).fetchone()
+                if row is None:
+                    connection.execute(
+                        "INSERT INTO browser_actions(action_token, payload_sha256, state) VALUES (?, ?, 'executing')",
+                        (action.action_token, digest),
+                    )
+                    return None
+                if not hmac.compare_digest(row[0], digest):
+                    raise ValueError("action token was reused with different arguments")
+                if row[2]:
+                    return BrowserEngineReceipt.model_validate_json(row[2])
+                return BrowserEngineReceipt(
+                    action_token=action.action_token,
+                    state="ambiguous",
+                    pre_fingerprint=action.pre_fingerprint,
+                    failure_code="browserd_interrupted_action",
+                    operator_message=(
+                        "browserd restarted while this action was executing, so completion is ambiguous."
+                    ),
+                    recovery_action=(
+                        "Inspect the live page and trace; do not replay this action automatically."
+                    ),
+                )
+
+    async def finish(self, receipt: BrowserEngineReceipt) -> BrowserEngineReceipt:
+        async with self._lock:
+            with sqlite3.connect(self.path) as connection:
+                result = connection.execute(
+                    "UPDATE browser_actions SET state = ?, receipt_json = ? WHERE action_token = ?",
+                    (
+                        receipt.state,
+                        receipt.model_dump_json(),
+                        receipt.action_token,
+                    ),
+                )
+                if result.rowcount != 1:
+                    raise RuntimeError("action token was not claimed")
+        return receipt
+
+
+class BrowserdManager:
+    """Own Playwright, project identities, tabs, CDP sessions, and trace files."""
+
+    def __init__(
+        self,
+        settings: BrowserdSettings,
+        *,
+        playwright_factory: Callable[[], Any] | None = None,
+    ) -> None:
+        self.settings = settings
+        self._playwright_factory = playwright_factory
+        self._playwright: Any | None = None
+        self._contexts: dict[str, Any] = {}
+        self._tabs: dict[tuple[str, str], Any] = {}
+        self._assessment_states: dict[str, str] = {}
+        self._lock = asyncio.Lock()
+        self._ledger = ActionLedger(settings.profile_root / "browserd-actions.sqlite3")
+        self._capability: BrowserEngineCapability | None = None
+
+    async def start(self) -> None:
+        if self.settings.profile_root.is_symlink():
+            raise RuntimeError("browserd profile root cannot be a symbolic link")
+        self.settings.profile_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(self.settings.profile_root, 0o700)
+        try:
+            if self._playwright_factory is None:
+                self._playwright_factory = async_playwright
+            self._playwright = await self._playwright_factory().start()
+            self._capability = self._verify_runtime()
+        except Exception:
+            self._capability = BrowserEngineCapability(
+                adapter="managed-chromium",
+                display_name="Managed Chromium",
+                state=BrowserEngineState.UNAVAILABLE,
+                unavailability_reason=(
+                    "The verified full-Chromium Playwright runtime could not start."
+                ),
+                recovery_action="Prepare the managed browser runtime and restart browserd.",
+            )
+
+    def _verify_runtime(self) -> BrowserEngineCapability:
+        playwright = self._playwright
+        if playwright is None:
+            raise RuntimeError("Playwright did not finish starting")
+        manifest_path = self.settings.runtime_root / "nebula-playwright-runtime.json"
+        if not manifest_path.is_file():
+            raise RuntimeError("verified browser runtime manifest is missing")
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if (
+            manifest.get("browser") != "chromium"
+            or not isinstance(manifest.get("executables"), list)
+            or not isinstance(manifest.get("executable_sha256"), dict)
+            or not manifest.get("sbom")
+            or not manifest.get("provenance")
+        ):
+            raise RuntimeError("browser runtime manifest is incomplete")
+        executable = Path(playwright.chromium.executable_path).resolve()
+        try:
+            executable.relative_to(self.settings.runtime_root)
+        except ValueError as exc:
+            raise RuntimeError(
+                "Playwright resolved Chromium outside the verified runtime"
+            ) from exc
+        relative = executable.relative_to(self.settings.runtime_root).as_posix()
+        expected = manifest["executable_sha256"].get(relative)
+        actual = _sha256_file(executable)
+        if not expected or not hmac.compare_digest(expected, actual):
+            raise RuntimeError("Chromium executable digest does not match the manifest")
+        state = (
+            BrowserEngineState.DEGRADED
+            if self.settings.headless
+            else BrowserEngineState.READY
+        )
+        return BrowserEngineCapability(
+            adapter="managed-chromium",
+            display_name="Managed Chromium",
+            contract_version=BROWSER_ENGINE_CONTRACT_VERSION,
+            state=state,
+            installed_version=str(manifest.get("playwright_version") or "unknown"),
+            digest=f"sha256:{actual}",
+            actions=[
+                "navigate",
+                "click",
+                "fill",
+                "select",
+                "press",
+                "wait",
+                "snapshot",
+                "screenshot",
+                "trace",
+                "takeover",
+                *(["upload"] if self.settings.upload_root is not None else []),
+            ],
+            protocols=["http", "https", "websocket", "cdp-screencast"],
+            unavailability_reason=(
+                "Headless mode is test-only and cannot satisfy packaged desktop acceptance."
+                if self.settings.headless
+                else None
+            ),
+            recovery_action=(
+                "Restart browserd in headed desktop mode for production qualification."
+                if self.settings.headless
+                else None
+            ),
+        )
+
+    async def close(self) -> None:
+        for context in list(self._contexts.values()):
+            try:
+                await context.close()
+            except Exception:
+                pass
+        self._contexts.clear()
+        self._tabs.clear()
+        if self._playwright is not None:
+            try:
+                await self._playwright.stop()
+            except Exception:
+                pass
+
+    async def readiness(self) -> BrowserEngineCapability:
+        return self._capability or BrowserEngineCapability(
+            adapter="managed-chromium",
+            display_name="Managed Chromium",
+            state=BrowserEngineState.UNAVAILABLE,
+            unavailability_reason="browserd has not completed startup verification.",
+            recovery_action="Wait for browserd startup or restart the managed runtime.",
+        )
+
+    def _identity_path(self, identity_id: str) -> Path:
+        if not _OPAQUE_ID.fullmatch(identity_id):
+            raise ValueError("identity id is invalid")
+        directory = (
+            self.settings.profile_root
+            / hashlib.sha256(identity_id.encode("utf-8")).hexdigest()
+        )
+        resolved = directory.resolve(strict=False)
+        try:
+            resolved.relative_to(self.settings.profile_root)
+        except ValueError as exc:
+            raise ValueError("identity profile escapes the profile root") from exc
+        return resolved
+
+    async def ensure_identity(self, identity_id: str) -> BrowserdIdentityReceipt:
+        capability = await self.readiness()
+        if capability.state == BrowserEngineState.UNAVAILABLE:
+            raise RuntimeError("managed Chromium is unavailable")
+        async with self._lock:
+            context = self._contexts.get(identity_id)
+            if context is None:
+                playwright = self._playwright
+                if playwright is None:
+                    raise RuntimeError("managed Chromium is unavailable")
+                profile = self._identity_path(identity_id)
+                profile.mkdir(parents=True, exist_ok=True, mode=0o700)
+                os.chmod(profile, 0o700)
+                context = await playwright.chromium.launch_persistent_context(
+                    str(profile),
+                    headless=self.settings.headless,
+                    executable_path=playwright.chromium.executable_path,
+                    proxy={"server": self.settings.policy_proxy_url},
+                    args=["--proxy-bypass-list=<-loopback>"],
+                    accept_downloads=True,
+                )
+                await context.tracing.start(
+                    screenshots=True, snapshots=True, sources=False
+                )
+                self._contexts[identity_id] = context
+                pages = list(context.pages) or [await context.new_page()]
+                for page in pages:
+                    tab_id = str(uuid4())
+                    self._tabs[(identity_id, tab_id)] = page
+            tab_ids = [tab_id for (owner, tab_id) in self._tabs if owner == identity_id]
+        return BrowserdIdentityReceipt(identity_id=identity_id, tab_ids=tab_ids)
+
+    async def _page(self, action: BrowserEngineAction) -> Any:
+        await self.ensure_identity(action.identity_id)
+        page = self._tabs.get((action.identity_id, action.tab_id))
+        if page is not None:
+            return page
+        context = self._contexts[action.identity_id]
+        page = list(context.pages)[0] if context.pages else await context.new_page()
+        self._tabs[(action.identity_id, action.tab_id)] = page
+        return page
+
+    @staticmethod
+    async def _fingerprint(page: Any) -> str:
+        title, markup = await asyncio.gather(page.title(), page.content())
+        digest = hashlib.sha256()
+        digest.update(page.url.encode("utf-8", errors="replace"))
+        digest.update(b"\0")
+        digest.update(title.encode("utf-8", errors="replace"))
+        digest.update(b"\0")
+        digest.update(markup.encode("utf-8", errors="replace"))
+        return f"sha256:{digest.hexdigest()}"
+
+    @staticmethod
+    def _locator(page: Any, values: dict[str, str]) -> Any:
+        frame = values.get("frame")
+        root = page.frame_locator(frame) if frame else page
+        if role := values.get("role"):
+            return root.get_by_role(role, name=values.get("name"))
+        if label := values.get("label"):
+            return root.get_by_label(label)
+        if test_id := values.get("test_id"):
+            return root.get_by_test_id(test_id)
+        if text := values.get("text"):
+            return root.get_by_text(text, exact=values.get("exact") == "true")
+        if css := values.get("css"):
+            return root.locator(css)
+        raise ValueError("action requires a role, label, test_id, text, or CSS locator")
+
+    @staticmethod
+    def _credential(reference: str) -> str:
+        if not reference or any(character.isspace() for character in reference):
+            raise ValueError("credential reference is invalid")
+        import keyring
+
+        value = keyring.get_password("nebula.browser.credentials", reference)
+        if value is None:
+            raise ValueError("credential reference is unavailable in the OS vault")
+        return value
+
+    def _upload_path(self, value: object) -> Path:
+        if self.settings.upload_root is None:
+            raise ValueError("host uploads are not configured for browserd")
+        if not isinstance(value, str) or not value:
+            raise ValueError("upload requires one enumerated host file")
+        candidate = Path(value).expanduser().resolve(strict=True)
+        try:
+            candidate.relative_to(self.settings.upload_root)
+        except ValueError as exc:
+            raise ValueError(
+                "upload file is outside the configured host browser"
+            ) from exc
+        if not candidate.is_file() or candidate.is_symlink():
+            raise ValueError("upload target must be a regular non-symlink file")
+        return candidate
+
+    async def execute(self, action: BrowserEngineAction) -> BrowserEngineReceipt:
+        prior = await self._ledger.claim(action)
+        if prior is not None:
+            return prior
+        if self._assessment_states.get(action.assessment_id) in {"paused", "stopped"}:
+            return await self._ledger.finish(
+                BrowserEngineReceipt(
+                    action_token=action.action_token,
+                    state="cancelled",
+                    failure_code="assessment_not_running",
+                    operator_message="The assessment is paused or stopped.",
+                    recovery_action="Resume the assessment or create a new action.",
+                )
+            )
+        page: Any | None = None
+        pre: str | None = None
+        trace_id = str(uuid4())
+        trace_started = False
+        dispatched = False
+        try:
+            page = await self._page(action)
+            if action.expected_page_url and _safe_page_url(page.url) != _safe_page_url(
+                action.expected_page_url
+            ):
+                raise ValueError("page changed before the action could execute")
+            pre = await self._fingerprint(page)
+            if action.pre_fingerprint and not hmac.compare_digest(
+                action.pre_fingerprint, pre
+            ):
+                raise ValueError("page fingerprint changed before action execution")
+            context = self._contexts[action.identity_id]
+            trace_dir = self._identity_path(action.identity_id) / "traces"
+            trace_dir.mkdir(mode=0o700, exist_ok=True)
+            await context.tracing.start_chunk(title=action.action_token)
+            trace_started = True
+            locator = None
+            if action.kind == "navigate":
+                target = _network_url(action.arguments.get("url"))
+                dispatched = True
+                await page.goto(
+                    target,
+                    wait_until=str(
+                        action.arguments.get("wait_until", "domcontentloaded")
+                    ),
+                )
+            elif action.kind == "wait":
+                locator = self._locator(page, action.locator)
+                await locator.wait_for(
+                    state=str(action.arguments.get("state", "visible"))
+                )
+            elif action.kind == "snapshot":
+                await page.locator("html").aria_snapshot()
+            elif action.kind == "screenshot":
+                screenshot_dir = self._identity_path(action.identity_id) / "screenshots"
+                screenshot_dir.mkdir(mode=0o700, exist_ok=True)
+                await page.screenshot(
+                    path=str(screenshot_dir / f"{trace_id}.png"), full_page=True
+                )
+            else:
+                locator = self._locator(page, action.locator)
+                if action.kind == "click":
+                    dispatched = True
+                    await locator.click()
+                elif action.kind == "fill":
+                    credential_ref = action.arguments.get("credential_ref")
+                    input_type = await locator.get_attribute("type")
+                    if input_type == "password" and credential_ref is None:
+                        raise ValueError(
+                            "password fields require an OS-vault credential reference"
+                        )
+                    value = (
+                        self._credential(str(credential_ref))
+                        if credential_ref is not None
+                        else str(action.arguments.get("value", ""))
+                    )
+                    dispatched = True
+                    await locator.fill(value)
+                elif action.kind == "select":
+                    dispatched = True
+                    await locator.select_option(action.arguments.get("value"))
+                elif action.kind == "press":
+                    dispatched = True
+                    await locator.press(str(action.arguments["key"]))
+                elif action.kind == "upload":
+                    upload = self._upload_path(action.arguments.get("path"))
+                    dispatched = True
+                    await locator.set_input_files(str(upload))
+            await context.tracing.stop_chunk(path=str(trace_dir / f"{trace_id}.zip"))
+            trace_started = False
+            post = await self._fingerprint(page)
+            receipt = BrowserEngineReceipt(
+                action_token=action.action_token,
+                state="complete",
+                page_url=_safe_page_url(page.url),
+                pre_fingerprint=pre,
+                post_fingerprint=post,
+                trace_ids=[f"browserd-trace:{trace_id}"],
+                evidence_ids=(
+                    [f"browserd-screenshot:{trace_id}"]
+                    if action.kind == "screenshot"
+                    else []
+                ),
+            )
+        except Exception:
+            if trace_started and action.identity_id in self._contexts:
+                try:
+                    trace_dir = self._identity_path(action.identity_id) / "traces"
+                    await self._contexts[action.identity_id].tracing.stop_chunk(
+                        path=str(trace_dir / f"{trace_id}.zip")
+                    )
+                except Exception:
+                    pass
+            ambiguous = action.side_effect != "none" and dispatched
+            receipt = BrowserEngineReceipt(
+                action_token=action.action_token,
+                state="ambiguous" if ambiguous else "failed",
+                page_url=_safe_page_url(page.url) if page is not None else None,
+                pre_fingerprint=pre or action.pre_fingerprint,
+                trace_ids=([f"browserd-trace:{trace_id}"] if pre is not None else []),
+                failure_code=(
+                    "action_completion_ambiguous"
+                    if ambiguous
+                    else "action_precondition_failed"
+                ),
+                operator_message=(
+                    "The page may have changed before browserd observed completion."
+                    if ambiguous
+                    else "The browser action failed before a side effect was observed."
+                ),
+                recovery_action=(
+                    "Inspect the live page and trace; do not replay automatically."
+                    if ambiguous
+                    else "Refresh the page snapshot and issue a new action token."
+                ),
+            )
+        return await self._ledger.finish(receipt)
+
+    async def lifecycle(
+        self, assessment_id: str, state: str
+    ) -> BrowserdLifecycleReceipt:
+        if not _OPAQUE_ID.fullmatch(assessment_id):
+            raise ValueError("assessment id is invalid")
+        self._assessment_states[assessment_id] = state
+        return BrowserdLifecycleReceipt(assessment_id=assessment_id, state=state)
+
+    async def page_for_screencast(self, identity_id: str, tab_id: str) -> Any:
+        receipt = await self.ensure_identity(identity_id)
+        if tab_id not in receipt.tab_ids:
+            raise ValueError("tab does not belong to the selected identity")
+        return self._tabs[(identity_id, tab_id)]
+
+
+def create_browserd_app(
+    settings: BrowserdSettings,
+    *,
+    manager: BrowserdManager | None = None,
+) -> FastAPI:
+    runtime = manager or BrowserdManager(settings)
+
+    @asynccontextmanager
+    async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+        await runtime.start()
+        try:
+            yield
+        finally:
+            await runtime.close()
+
+    app = FastAPI(title="nebula-browserd", version="1", lifespan=lifespan)
+
+    async def require_auth(
+        authorization: str = Header(default="", alias="Authorization"),
+    ) -> None:
+        supplied = (
+            authorization[7:] if authorization.lower().startswith("bearer ") else ""
+        )
+        if not supplied or not hmac.compare_digest(supplied, settings.token):
+            raise HTTPException(
+                status_code=401, detail="valid browserd bearer token required"
+            )
+
+    @app.get(
+        "/v1/readiness",
+        response_model=BrowserEngineCapability,
+        dependencies=[Depends(require_auth)],
+    )
+    async def readiness() -> BrowserEngineCapability:
+        return await runtime.readiness()
+
+    @app.post(
+        "/v1/identities/ensure",
+        response_model=BrowserdIdentityReceipt,
+        dependencies=[Depends(require_auth)],
+    )
+    async def ensure_identity(
+        request: BrowserdIdentityRequest,
+    ) -> BrowserdIdentityReceipt:
+        return await runtime.ensure_identity(request.identity_id)
+
+    @app.post(
+        "/v1/actions",
+        response_model=BrowserEngineReceipt,
+        dependencies=[Depends(require_auth)],
+    )
+    async def execute(action: BrowserEngineAction) -> BrowserEngineReceipt:
+        return await runtime.execute(action)
+
+    @app.post(
+        "/v1/assessments/{assessment_id}/{action}",
+        response_model=BrowserdLifecycleReceipt,
+        dependencies=[Depends(require_auth)],
+    )
+    async def lifecycle(assessment_id: str, action: str) -> BrowserdLifecycleReceipt:
+        if action not in {"pause", "resume", "stop"}:
+            raise HTTPException(status_code=404, detail="unknown lifecycle action")
+        states = {"pause": "paused", "resume": "running", "stop": "stopped"}
+        return await runtime.lifecycle(assessment_id, states[action])
+
+    @app.websocket("/v1/identities/{identity_id}/tabs/{tab_id}/screencast")
+    async def screencast(websocket: WebSocket, identity_id: str, tab_id: str) -> None:
+        protocols = [
+            value.strip()
+            for value in websocket.headers.get("sec-websocket-protocol", "").split(",")
+            if value.strip()
+        ]
+        supplied = ""
+        for protocol in protocols:
+            if protocol.startswith("nebula.auth."):
+                encoded = protocol.removeprefix("nebula.auth.")
+                try:
+                    supplied = base64.urlsafe_b64decode(
+                        encoded + "=" * (-len(encoded) % 4)
+                    ).decode("utf-8")
+                except (ValueError, UnicodeDecodeError):
+                    supplied = ""
+                break
+        if not supplied or not hmac.compare_digest(supplied, settings.token):
+            await websocket.close(
+                code=4401, reason="valid browserd bearer token required"
+            )
+            return
+        try:
+            page = await runtime.page_for_screencast(identity_id, tab_id)
+        except Exception:
+            await websocket.close(code=4404, reason="managed browser tab not found")
+            return
+        await websocket.accept(
+            subprotocol="nebula.browserd.v1"
+            if "nebula.browserd.v1" in protocols
+            else None
+        )
+        cdp = await page.context.new_cdp_session(page)
+        frames: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=2)
+
+        def on_frame(event: dict[str, Any]) -> None:
+            if frames.full():
+                try:
+                    frames.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            frames.put_nowait(event)
+
+        cdp.on("Page.screencastFrame", on_frame)
+        await cdp.send(
+            "Page.startScreencast",
+            {"format": "jpeg", "quality": 75, "maxWidth": 1920, "maxHeight": 1080},
+        )
+
+        async def send_frames() -> None:
+            while True:
+                frame = await frames.get()
+                await websocket.send_json(
+                    {
+                        "kind": "frame",
+                        "data": frame["data"],
+                        "metadata": frame.get("metadata", {}),
+                    }
+                )
+                await cdp.send(
+                    "Page.screencastFrameAck", {"sessionId": frame["sessionId"]}
+                )
+
+        async def receive_input() -> None:
+            while True:
+                event = await websocket.receive_json()
+                kind = event.get("kind")
+                if kind == "mouse":
+                    await cdp.send(
+                        "Input.dispatchMouseEvent",
+                        {
+                            "type": event.get("type", "mouseMoved"),
+                            "x": float(event["x"]),
+                            "y": float(event["y"]),
+                            "button": event.get("button", "none"),
+                            "clickCount": int(event.get("clickCount", 0)),
+                        },
+                    )
+                elif kind == "key":
+                    await cdp.send(
+                        "Input.dispatchKeyEvent",
+                        {
+                            "type": event.get("type", "keyDown"),
+                            "key": str(event.get("key", "")),
+                            "code": str(event.get("code", "")),
+                            "modifiers": int(event.get("modifiers", 0)),
+                        },
+                    )
+                elif kind == "text":
+                    await cdp.send(
+                        "Input.insertText", {"text": str(event.get("text", ""))}
+                    )
+
+        sender = asyncio.create_task(send_frames())
+        receiver = asyncio.create_task(receive_input())
+        try:
+            done, pending = await asyncio.wait(
+                {sender, receiver}, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in pending:
+                task.cancel()
+            for task in done:
+                task.result()
+        except (WebSocketDisconnect, asyncio.CancelledError):
+            pass
+        finally:
+            sender.cancel()
+            receiver.cancel()
+            try:
+                await cdp.send("Page.stopScreencast")
+            except Exception:
+                pass
+            await cdp.detach()
+
+    return app
+
+
+def settings_from_environment() -> BrowserdSettings:
+    token = os.environ.get("NEBULA_BROWSERD_TOKEN", "")
+    proxy = os.environ.get("NEBULA_BROWSERD_POLICY_PROXY_URL", "")
+    profiles = os.environ.get("NEBULA_BROWSERD_PROFILE_ROOT", "")
+    runtime = os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "")
+    upload_root = os.environ.get("NEBULA_BROWSERD_UPLOAD_ROOT")
+    if not all((token, proxy, profiles, runtime)):
+        raise RuntimeError(
+            "browserd requires token, policy proxy, profile root, and Playwright runtime environment"
+        )
+    return BrowserdSettings(
+        token=token,
+        policy_proxy_url=proxy,
+        profile_root=Path(profiles),
+        runtime_root=Path(runtime),
+        upload_root=Path(upload_root) if upload_root else None,
+        headless=os.environ.get("NEBULA_BROWSERD_HEADLESS") == "1",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Nebula managed Chromium sidecar")
+    parser.add_argument(
+        "--port", type=int, default=int(os.environ.get("NEBULA_BROWSERD_PORT", "4711"))
+    )
+    arguments = parser.parse_args()
+    if not 1 <= arguments.port <= 65535:
+        raise SystemExit("browserd port must be between 1 and 65535")
+    settings = settings_from_environment()
+    uvicorn.run(
+        create_browserd_app(settings),
+        host="127.0.0.1",
+        port=arguments.port,
+        log_level="warning",
+        access_log=False,
+    )
+
+
+__all__ = [
+    "ActionLedger",
+    "BrowserdManager",
+    "BrowserdSettings",
+    "create_browserd_app",
+    "main",
+]

--- a/src/nebula/v3/browserd.py
+++ b/src/nebula/v3/browserd.py
@@ -74,6 +74,7 @@ def _safe_page_url(value: str) -> str | None:
     try:
         port = parsed.port
     except ValueError:
+        # diagnostic-expected: invalid receipt URLs are redacted.
         return None
     netloc = f"{host}:{port}" if port is not None else host
     return urlunsplit((parsed.scheme, netloc, parsed.path or "/", "", ""))
@@ -256,6 +257,7 @@ class BrowserdManager:
             self._playwright = await self._playwright_factory().start()
             self._capability = self._verify_runtime()
         except Exception:
+            # diagnostic-expected: converted to unavailable readiness.
             self._capability = BrowserEngineCapability(
                 adapter="managed-chromium",
                 display_name="Managed Chromium",
@@ -337,6 +339,7 @@ class BrowserdManager:
             try:
                 await context.close()
             except Exception:
+                # diagnostic-expected: shutdown continues through remaining contexts.
                 pass
         self._contexts.clear()
         self._tabs.clear()
@@ -344,6 +347,7 @@ class BrowserdManager:
             try:
                 await self._playwright.stop()
             except Exception:
+                # diagnostic-expected: process shutdown is already in progress.
                 pass
 
     async def readiness(self) -> BrowserEngineCapability:
@@ -569,6 +573,7 @@ class BrowserdManager:
                 ),
             )
         except Exception:
+            # diagnostic-expected: converted to a normalized action receipt.
             if trace_started and action.identity_id in self._contexts:
                 try:
                     trace_dir = self._identity_path(action.identity_id) / "traces"
@@ -576,6 +581,7 @@ class BrowserdManager:
                         path=str(trace_dir / f"{trace_id}.zip")
                     )
                 except Exception:
+                    # diagnostic-expected: primary receipt retains the trace failure.
                     pass
             ambiguous = action.side_effect != "none" and dispatched
             receipt = BrowserEngineReceipt(
@@ -698,6 +704,7 @@ def create_browserd_app(
                         encoded + "=" * (-len(encoded) % 4)
                     ).decode("utf-8")
                 except (ValueError, UnicodeDecodeError):
+                    # diagnostic-expected: malformed auth is rejected below.
                     supplied = ""
                 break
         if not supplied or not hmac.compare_digest(supplied, settings.token):
@@ -708,6 +715,7 @@ def create_browserd_app(
         try:
             page = await runtime.page_for_screencast(identity_id, tab_id)
         except Exception:
+            # diagnostic-expected: missing tabs receive a bounded protocol close.
             await websocket.close(code=4404, reason="managed browser tab not found")
             return
         await websocket.accept(
@@ -723,6 +731,7 @@ def create_browserd_app(
                 try:
                     frames.get_nowait()
                 except asyncio.QueueEmpty:
+                    # diagnostic-expected: another callback drained the bounded queue.
                     pass
             frames.put_nowait(event)
 
@@ -776,7 +785,9 @@ def create_browserd_app(
                         "Input.insertText", {"text": str(event.get("text", ""))}
                     )
 
+        # diagnostic-expected: both pumps are cancelled and drained in finally.
         sender = asyncio.create_task(send_frames())
+        # diagnostic-expected: paired with sender in the same wait set and cleanup.
         receiver = asyncio.create_task(receive_input())
         try:
             done, pending = await asyncio.wait(
@@ -787,13 +798,16 @@ def create_browserd_app(
             for task in done:
                 task.result()
         except (WebSocketDisconnect, asyncio.CancelledError):
+            # diagnostic-expected: normal viewer detach.
             pass
         finally:
             sender.cancel()
             receiver.cancel()
+            await asyncio.gather(sender, receiver, return_exceptions=True)
             try:
                 await cdp.send("Page.stopScreencast")
             except Exception:
+                # diagnostic-expected: the detached target may already be closed.
                 pass
             await cdp.detach()
 

--- a/src/nebula/v3/domain.py
+++ b/src/nebula/v3/domain.py
@@ -47,6 +47,7 @@ class ResourceKind(StringEnum):
     TERMINAL_SESSION = "terminal_session"
     TERMINAL_COMMAND = "terminal_command"
     BROWSER_SESSION = "browser_session"
+    BROWSER_ASSESSMENT = "browser_assessment"
     BROWSER_TAB = "browser_tab"
     BROWSER_EXCHANGE = "browser_exchange"
     MISSION = "mission"
@@ -309,6 +310,63 @@ class BrowserHandoffStatus(StringEnum):
     FAILED = "failed"
     CANCELLED = "cancelled"
     EXPIRED = "expired"
+
+
+class BrowserAssessmentProfile(StringEnum):
+    EXPLORE = "explore"
+    STANDARD = "standard"
+    DEEP = "deep"
+    API = "api"
+    VALIDATION = "validation"
+
+
+class BrowserAssessmentStatus(StringEnum):
+    DRAFT = "draft"
+    READY = "ready"
+    RUNNING = "running"
+    WAITING_OPERATOR = "waiting_operator"
+    PAUSED = "paused"
+    STOPPING = "stopping"
+    STOPPED = "stopped"
+    COMPLETE = "complete"
+    FAILED = "failed"
+    REVOKED = "revoked"
+
+
+class BrowserAssessmentPhase(StringEnum):
+    PREFLIGHT = "preflight"
+    DISCOVERY = "discovery"
+    CRAWL = "crawl"
+    PASSIVE_AUDIT = "passive_audit"
+    ACTIVE_AUDIT = "active_audit"
+    VALIDATION = "validation"
+    REPORTING = "reporting"
+    COMPLETE = "complete"
+
+
+class BrowserAssessmentStepStatus(StringEnum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    WAITING_OPERATOR = "waiting_operator"
+    COMPLETE = "complete"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class BrowserIssueValidationStatus(StringEnum):
+    UNVALIDATED = "unvalidated"
+    QUEUED = "queued"
+    VALIDATING = "validating"
+    CONFIRMED = "confirmed"
+    REJECTED = "rejected"
+    INCONCLUSIVE = "inconclusive"
+
+
+class BrowserEngineState(StringEnum):
+    READY = "ready"
+    DEGRADED = "degraded"
+    PREPARING = "preparing"
+    UNAVAILABLE = "unavailable"
 
 
 class FindingStatus(StringEnum):
@@ -1096,11 +1154,382 @@ class BrowserSession(Entity):
         return self
 
 
+class BrowserEngineCapability(NebulaModel):
+    """Normalized readiness receipt for one desktop browser or scanner adapter."""
+
+    adapter: str = Field(pattern=r"^[a-z][a-z0-9_.-]{1,80}$")
+    display_name: str = Field(min_length=1, max_length=120)
+    contract_version: str = Field(default="1", pattern=r"^[1-9][0-9]*$")
+    state: BrowserEngineState
+    installed_version: str | None = Field(default=None, max_length=120)
+    digest: str | None = Field(default=None, pattern=r"^sha256:[0-9a-f]{64}$")
+    actions: list[str] = Field(default_factory=list, max_length=200)
+    protocols: list[str] = Field(default_factory=list, max_length=40)
+    check_families: list[str] = Field(default_factory=list, max_length=200)
+    unavailability_reason: str | None = Field(default=None, max_length=2_000)
+    recovery_action: str | None = Field(default=None, max_length=500)
+    desktop_only: bool = True
+
+    @model_validator(mode="after")
+    def browser_engine_readiness_is_actionable(self) -> "BrowserEngineCapability":
+        if self.state != BrowserEngineState.READY:
+            if not self.unavailability_reason or not self.recovery_action:
+                raise ValueError(
+                    "unready browser engines require a reason and recovery action"
+                )
+        return self
+
+
+class BrowserAssessmentBudget(NebulaModel):
+    max_requests: int = Field(default=2_000, ge=1, le=1_000_000)
+    max_actions: int = Field(default=500, ge=1, le=100_000)
+    max_duration_seconds: int = Field(default=3_600, ge=60, le=86_400)
+    max_concurrency: int = Field(default=2, ge=1, le=32)
+    requests_used: int = Field(default=0, ge=0)
+    actions_used: int = Field(default=0, ge=0)
+
+    @model_validator(mode="after")
+    def browser_assessment_budget_is_coherent(self) -> "BrowserAssessmentBudget":
+        if self.requests_used > self.max_requests:
+            raise ValueError("assessment request usage exceeds its budget")
+        if self.actions_used > self.max_actions:
+            raise ValueError("assessment action usage exceeds its budget")
+        return self
+
+
+class BrowserAssessmentCoverage(NebulaModel):
+    discovered_urls: int = Field(default=0, ge=0)
+    visited_urls: int = Field(default=0, ge=0)
+    analyzed_exchanges: int = Field(default=0, ge=0)
+    discovered_forms: int = Field(default=0, ge=0)
+    discovered_apis: int = Field(default=0, ge=0)
+    websocket_channels: int = Field(default=0, ge=0)
+
+
+class BrowserAssessment(Entity):
+    """Durable authority for one guided or expert Security Browser assessment."""
+
+    entity_kind: ClassVar[str] = "browser_assessments"
+    engagement_id: str
+    name: str = Field(min_length=1, max_length=200)
+    objective: str = Field(min_length=1, max_length=4_000)
+    profile: BrowserAssessmentProfile = BrowserAssessmentProfile.STANDARD
+    session_id: str = Field(min_length=1, max_length=200)
+    identity_ids: list[str] = Field(min_length=1, max_length=32)
+    primary_identity_id: str = Field(min_length=1, max_length=200)
+    target_urls: list[str] = Field(min_length=1, max_length=100)
+    scope_policy_id: str = Field(min_length=1, max_length=200)
+    scope_policy_revision: int = Field(ge=1)
+    risk_classes: list[str] = Field(default_factory=list, max_length=40)
+    validation_grant_id: str | None = Field(default=None, max_length=200)
+    credential_refs: list[str] = Field(default_factory=list, max_length=32)
+    status: BrowserAssessmentStatus = BrowserAssessmentStatus.DRAFT
+    phase: BrowserAssessmentPhase = BrowserAssessmentPhase.PREFLIGHT
+    progress: float = Field(default=0, ge=0, le=1)
+    budget: BrowserAssessmentBudget = Field(default_factory=BrowserAssessmentBudget)
+    coverage: BrowserAssessmentCoverage = Field(
+        default_factory=BrowserAssessmentCoverage
+    )
+    engines: list[BrowserEngineCapability] = Field(default_factory=list, max_length=16)
+    run_ids: list[str] = Field(default_factory=list, max_length=100)
+    evidence_ids: list[str] = Field(default_factory=list, max_length=1_000)
+    candidate_ids: list[str] = Field(default_factory=list, max_length=1_000)
+    active_step_id: str | None = Field(default=None, max_length=200)
+    control_owner: Literal["nebula", "operator"] = "nebula"
+    pause_reason: str | None = Field(default=None, max_length=2_000)
+    failure: str | None = Field(default=None, max_length=4_000)
+    recovery_action: str | None = Field(default=None, max_length=1_000)
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    last_event_cursor: int = Field(default=0, ge=0)
+    created_by: str = Field(min_length=1, max_length=200)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("target_urls")
+    @classmethod
+    def browser_assessment_targets_are_network_urls(
+        cls, values: list[str]
+    ) -> list[str]:
+        normalized: list[str] = []
+        for value in values:
+            parsed = urlsplit(value)
+            if (
+                parsed.scheme.lower() not in {"http", "https"}
+                or not parsed.hostname
+                or parsed.username is not None
+                or parsed.password is not None
+            ):
+                raise ValueError(
+                    "assessment targets must use credential-free HTTP(S) URLs"
+                )
+            normalized.append(value)
+        return list(dict.fromkeys(normalized))
+
+    @field_validator("credential_refs")
+    @classmethod
+    def browser_assessment_credentials_are_references(
+        cls, values: list[str]
+    ) -> list[str]:
+        if any(
+            not value.strip() or any(char.isspace() for char in value)
+            for value in values
+        ):
+            raise ValueError("assessment credentials must be opaque references")
+        return list(dict.fromkeys(values))
+
+    @field_validator("started_at", "completed_at")
+    @classmethod
+    def browser_assessment_time_is_aware(
+        cls, value: datetime | None
+    ) -> datetime | None:
+        if value is not None and (value.tzinfo is None or value.utcoffset() is None):
+            raise ValueError("assessment timestamps must include a timezone")
+        return value.astimezone(timezone.utc) if value is not None else None
+
+    @model_validator(mode="after")
+    def browser_assessment_is_coherent(self) -> "BrowserAssessment":
+        if self.primary_identity_id not in self.identity_ids:
+            raise ValueError("primary assessment identity must be selected")
+        if (
+            self.profile == BrowserAssessmentProfile.VALIDATION
+            and not self.validation_grant_id
+        ):
+            raise ValueError("validation profile requires an issue-specific grant")
+        if self.failure and not self.recovery_action:
+            raise ValueError("assessment failures require a recovery action")
+        return self
+
+
+class BrowserAssessmentStep(Entity):
+    entity_kind: ClassVar[str] = "browser_assessment_steps"
+    engagement_id: str
+    assessment_id: str = Field(min_length=1, max_length=200)
+    sequence: int = Field(ge=0)
+    title: str = Field(min_length=1, max_length=200)
+    intent: str = Field(min_length=1, max_length=4_000)
+    capability: str = Field(pattern=r"^[a-z][a-z0-9_.-]{1,80}$")
+    target: str = Field(min_length=1, max_length=16_384)
+    status: BrowserAssessmentStepStatus = BrowserAssessmentStepStatus.QUEUED
+    approval_id: str | None = Field(default=None, max_length=200)
+    retry_classification: Literal[
+        "safe_before_side_effect", "never", "operator_review"
+    ] = "safe_before_side_effect"
+    action_token: str | None = Field(default=None, max_length=300)
+    pre_fingerprint: str | None = Field(default=None, max_length=500)
+    post_fingerprint: str | None = Field(default=None, max_length=500)
+    trace_ids: list[str] = Field(default_factory=list, max_length=100)
+    evidence_ids: list[str] = Field(default_factory=list, max_length=100)
+    error: str | None = Field(default=None, max_length=4_000)
+    recovery_action: str | None = Field(default=None, max_length=1_000)
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def browser_assessment_step_is_coherent(self) -> "BrowserAssessmentStep":
+        if self.error and not self.recovery_action:
+            raise ValueError("assessment step failures require a recovery action")
+        if self.post_fingerprint and not self.pre_fingerprint:
+            raise ValueError(
+                "post-action fingerprint requires a pre-action fingerprint"
+            )
+        return self
+
+
+class BrowserLoginFlow(Entity):
+    """Recorded non-secret login workflow bound to a local browser identity."""
+
+    entity_kind: ClassVar[str] = "browser_login_flows"
+    engagement_id: str
+    name: str = Field(min_length=1, max_length=200)
+    session_id: str = Field(min_length=1, max_length=200)
+    identity_id: str = Field(min_length=1, max_length=200)
+    steps: list[dict[str, Any]] = Field(default_factory=list, max_length=100)
+    credential_refs: list[str] = Field(default_factory=list, max_length=32)
+    success_verifier: dict[str, Any] = Field(default_factory=dict)
+    health: Literal["unknown", "healthy", "expired", "failed"] = "unknown"
+    last_validated_at: datetime | None = None
+    failure: str | None = Field(default=None, max_length=4_000)
+    recovery_action: str | None = Field(default=None, max_length=1_000)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("credential_refs")
+    @classmethod
+    def browser_login_credentials_are_references(cls, values: list[str]) -> list[str]:
+        if any(
+            not value.strip() or any(char.isspace() for char in value)
+            for value in values
+        ):
+            raise ValueError("login credentials must be opaque references")
+        return list(dict.fromkeys(values))
+
+    @field_validator("last_validated_at")
+    @classmethod
+    def browser_login_validation_time_is_aware(
+        cls, value: datetime | None
+    ) -> datetime | None:
+        if value is not None and (value.tzinfo is None or value.utcoffset() is None):
+            raise ValueError("login validation timestamps must include a timezone")
+        return value.astimezone(timezone.utc) if value is not None else None
+
+    @model_validator(mode="after")
+    def browser_login_flow_is_non_secret_and_actionable(self) -> "BrowserLoginFlow":
+        bound_credentials = set(self.credential_refs)
+        forbidden_keys = {
+            "password",
+            "secret",
+            "access_token",
+            "refresh_token",
+            "authorization",
+            "cookie",
+        }
+        for step in self.steps:
+            if not isinstance(step, dict):
+                raise ValueError("login flow steps must be structured records")
+            if forbidden_keys.intersection(key.lower() for key in step):
+                raise ValueError(
+                    "login flow steps cannot contain secret-bearing fields"
+                )
+            credential_ref = step.get("credential_ref")
+            if credential_ref is not None and credential_ref not in bound_credentials:
+                raise ValueError("login step credential_ref must be bound to the flow")
+        if self.failure and not self.recovery_action:
+            raise ValueError("login flow failures require a recovery action")
+        return self
+
+
+class BrowserRecipeStage(NebulaModel):
+    id: str = Field(min_length=1, max_length=200)
+    kind: Literal[
+        "crawl",
+        "passive_scan",
+        "active_scan",
+        "request",
+        "fuzz",
+        "compare",
+        "validate",
+        "wait_for_operator",
+        "capture_evidence",
+        "export",
+    ]
+    depends_on: list[str] = Field(default_factory=list, max_length=100)
+    configuration: dict[str, Any] = Field(default_factory=dict)
+    risk_class: str = Field(default="safe", max_length=80)
+    request_budget: int = Field(default=0, ge=0, le=1_000_000)
+
+
+class BrowserRecipe(Entity):
+    entity_kind: ClassVar[str] = "browser_recipes"
+    engagement_id: str
+    name: str = Field(min_length=1, max_length=200)
+    description: str = Field(default="", max_length=4_000)
+    version: int = Field(default=1, ge=1)
+    builtin: bool = False
+    capability_requirements: list[str] = Field(default_factory=list, max_length=100)
+    stages: list[BrowserRecipeStage] = Field(min_length=1, max_length=200)
+    enabled: bool = True
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def browser_recipe_is_a_dag(self) -> "BrowserRecipe":
+        ids = [stage.id for stage in self.stages]
+        if len(ids) != len(set(ids)):
+            raise ValueError("browser recipe stage ids must be unique")
+        known: set[str] = set()
+        for stage in self.stages:
+            if any(dependency not in known for dependency in stage.depends_on):
+                raise ValueError(
+                    "browser recipe dependencies must reference earlier stages"
+                )
+            known.add(stage.id)
+        return self
+
+
+class BrowserIssueCandidate(Entity):
+    entity_kind: ClassVar[str] = "browser_issue_candidates"
+    engagement_id: str
+    assessment_id: str = Field(min_length=1, max_length=200)
+    rule_id: str = Field(min_length=1, max_length=200)
+    check_family: str = Field(min_length=1, max_length=200)
+    title: str = Field(min_length=1, max_length=300)
+    cwe: str | None = Field(default=None, pattern=r"^CWE-[1-9][0-9]{0,4}$")
+    target_url: str = Field(min_length=1, max_length=16_384)
+    insertion_point: str | None = Field(default=None, max_length=1_000)
+    severity: Severity
+    confidence: Literal["tentative", "firm", "certain"] = "tentative"
+    control_results: list[dict[str, Any]] = Field(default_factory=list, max_length=100)
+    evidence_ids: list[str] = Field(default_factory=list, max_length=500)
+    deduplication_fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
+    validation_status: BrowserIssueValidationStatus = (
+        BrowserIssueValidationStatus.UNVALIDATED
+    )
+    validation_grant_id: str | None = Field(default=None, max_length=200)
+    promoted_finding_id: str | None = Field(default=None, max_length=200)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("target_url")
+    @classmethod
+    def browser_candidate_target_is_network_url(cls, value: str) -> str:
+        parsed = urlsplit(value)
+        if (
+            parsed.scheme.lower() not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            raise ValueError("candidate target must be a credential-free HTTP(S) URL")
+        return value
+
+
+class BrowserValidationGrant(Entity):
+    """Issue-specific, target-specific authority for bounded validation traffic."""
+
+    entity_kind: ClassVar[str] = "browser_validation_grants"
+    engagement_id: str
+    assessment_id: str = Field(min_length=1, max_length=200)
+    candidate_id: str = Field(min_length=1, max_length=200)
+    target_url: str = Field(min_length=1, max_length=16_384)
+    technique: str = Field(min_length=1, max_length=1_000)
+    max_requests: int = Field(ge=1, le=10_000)
+    requests_used: int = Field(default=0, ge=0)
+    duration_seconds: int = Field(ge=30, le=3_600)
+    granted_by: str = Field(min_length=1, max_length=200)
+    granted_at: datetime = Field(default_factory=utc_now)
+    expires_at: datetime
+    revoked_at: datetime | None = None
+    status: Literal["active", "revoked", "expired", "consumed"] = "active"
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("target_url")
+    @classmethod
+    def browser_validation_target_is_network_url(cls, value: str) -> str:
+        parsed = urlsplit(value)
+        if (
+            parsed.scheme.lower() not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            raise ValueError("validation target must be a credential-free HTTP(S) URL")
+        return value
+
+    @model_validator(mode="after")
+    def browser_validation_grant_is_coherent(self) -> "BrowserValidationGrant":
+        if self.expires_at <= self.granted_at:
+            raise ValueError("validation grant expiry must follow its grant time")
+        if self.requests_used > self.max_requests:
+            raise ValueError("validation grant request usage exceeds its budget")
+        if self.status == "revoked" and self.revoked_at is None:
+            raise ValueError("revoked validation grants require a revocation time")
+        return self
+
+
 class BrowserTrafficExchange(Entity):
     """Bounded traffic index. Raw bodies live only in integrity-checked artifacts."""
 
     entity_kind: ClassVar[str] = "browser_traffic"
     engagement_id: str
+    assessment_id: str | None = Field(default=None, max_length=200)
     session_id: str = Field(min_length=1, max_length=200)
     tab_id: str = Field(min_length=1, max_length=200)
     identity_id: str = Field(min_length=1, max_length=200)
@@ -1311,6 +1740,7 @@ class BrowserCommand(Entity):
 
     entity_kind: ClassVar[str] = "browser_commands"
     engagement_id: str
+    assessment_id: str | None = Field(default=None, max_length=200)
     run_id: str = Field(min_length=1, max_length=200)
     lease_id: str = Field(min_length=1, max_length=200)
     session_id: str = Field(min_length=1, max_length=200)
@@ -3489,6 +3919,12 @@ ENTITY_MODELS: tuple[type[Entity], ...] = (
     Identity,
     BrowserIdentity,
     BrowserSession,
+    BrowserAssessment,
+    BrowserAssessmentStep,
+    BrowserLoginFlow,
+    BrowserRecipe,
+    BrowserIssueCandidate,
+    BrowserValidationGrant,
     BrowserTrafficExchange,
     BrowserWebSocketFrame,
     BrowserAction,

--- a/src/nebula/v3/relations.py
+++ b/src/nebula/v3/relations.py
@@ -38,6 +38,7 @@ RESOURCE_ENTITY_KINDS: dict[ResourceKind, str] = {
     ResourceKind.REPORT: "reports",
     ResourceKind.TERMINAL_COMMAND: "command_executions",
     ResourceKind.BROWSER_SESSION: "browser_sessions",
+    ResourceKind.BROWSER_ASSESSMENT: "browser_assessments",
     ResourceKind.BROWSER_EXCHANGE: "browser_traffic_exchanges",
     ResourceKind.MISSION: "runs",
     ResourceKind.TERMINAL_SESSION: "automation_sessions",

--- a/src/nebula/v3/search.py
+++ b/src/nebula/v3/search.py
@@ -44,6 +44,7 @@ INDEXED_ENTITY_KINDS = (
     "command_executions",
     "automation_sessions",
     "browser_sessions",
+    "browser_assessments",
     "runs",
     "operator_executions",
     "approvals",
@@ -218,6 +219,27 @@ def project_search_document(
             status,
             "Browser sessions",
             tab_text[:8000],
+        )
+    if kind == "browser_assessments":
+        raw_targets = payload.get("target_urls")
+        targets = raw_targets if isinstance(raw_targets, list) else []
+        safe_targets = " ".join(_safe_url(target) for target in targets)
+        return SearchProjection(
+            ResourceKind.BROWSER_ASSESSMENT,
+            _text(payload.get("name"), 500) or "Security Browser assessment",
+            _text(payload.get("objective")),
+            "Security Browser",
+            " ".join(
+                filter(
+                    None,
+                    [
+                        status,
+                        _text(payload.get("phase"), 100),
+                        _text(payload.get("profile"), 100),
+                        safe_targets,
+                    ],
+                )
+            )[:8000],
         )
     if kind == "runs":
         return SearchProjection(

--- a/src/nebula/v3/storage.py
+++ b/src/nebula/v3/storage.py
@@ -228,6 +228,80 @@ class StoreTransaction:
             self.session.delete(child)
         self.session.flush()
 
+    def append_operation_event(
+        self,
+        operation_id: str,
+        operation_kind: str,
+        engagement_id: str,
+        event_type: str,
+        payload: dict[str, Any] | None = None,
+        *,
+        actor_id: str | None = None,
+        idempotency_key: str | None = None,
+        occurred_at: datetime | None = None,
+    ) -> OperationEvent:
+        """Append a receipt in the same transaction as its authoritative state."""
+
+        if not all((operation_id, operation_kind, engagement_id, event_type)):
+            raise ValueError("operation event identifiers and type are required")
+        existing = None
+        if idempotency_key:
+            existing = self.session.scalar(
+                select(OperationEventRow).where(
+                    OperationEventRow.operation_id == operation_id,
+                    OperationEventRow.idempotency_key == idempotency_key,
+                )
+            )
+        if existing is not None:
+            existing_time = existing.occurred_at
+            if existing_time.tzinfo is None:
+                existing_time = existing_time.replace(tzinfo=timezone.utc)
+            event = OperationEvent(
+                id=existing.id,
+                operation_id=existing.operation_id,
+                operation_kind=existing.operation_kind,
+                engagement_id=existing.engagement_id,
+                sequence=existing.sequence,
+                event_type=existing.event_type,
+                payload=existing.payload,
+                actor_id=existing.actor_id,
+                occurred_at=existing_time,
+                idempotency_key=existing.idempotency_key,
+            )
+            if (
+                event.operation_kind != operation_kind
+                or event.engagement_id != engagement_id
+                or event.event_type != event_type
+                or event.payload != (payload or {})
+                or event.actor_id != actor_id
+            ):
+                raise ConflictError(
+                    "idempotency key was reused for a different operation event"
+                )
+            return event
+        last_sequence = self.session.scalar(
+            select(func.max(OperationEventRow.sequence)).where(
+                OperationEventRow.operation_id == operation_id
+            )
+        )
+        event = OperationEvent(
+            operation_id=operation_id,
+            operation_kind=operation_kind,
+            engagement_id=engagement_id,
+            sequence=int(last_sequence or 0) + 1,
+            event_type=event_type,
+            payload=payload or {},
+            actor_id=actor_id,
+            occurred_at=occurred_at or utc_now(),
+            idempotency_key=idempotency_key,
+        )
+        self.session.add(OperationEventRow(**event.model_dump(mode="python")))
+        try:
+            self.session.flush()
+        except IntegrityError as exc:
+            raise ConflictError("operation event already exists") from exc
+        return event
+
 
 class NebulaStore:
     """Persistence boundary for typed Nebula entities and run events."""

--- a/tests/v3/test_browser_assessments.py
+++ b/tests/v3/test_browser_assessments.py
@@ -1,0 +1,329 @@
+import asyncio
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from nebula.v3.api import create_app
+from nebula.v3.browser_assessments import (
+    BrowserAssessmentCreateRequest,
+    BrowserAssessmentService,
+    BrowserAssessmentTransitionRequest,
+    BrowserIssueCandidateCreateRequest,
+    BrowserValidationGrantRequest,
+    BrowserValidationRevokeRequest,
+)
+from nebula.v3.browser_engine import (
+    BrowserEngineAction,
+    BrowserEngineAdapter,
+    BrowserEngineReceipt,
+    BrowserEngineRegistry,
+)
+from nebula.v3.browser_security import BrowserSecurityService, BrowserWorkflowError
+from nebula.v3.domain import (
+    BrowserAssessment,
+    BrowserAssessmentProfile,
+    BrowserAssessmentStatus,
+    BrowserEngineCapability,
+    BrowserEngineState,
+    BrowserIssueCandidate,
+    BrowserIssueValidationStatus,
+    BrowserRecipe,
+    Engagement,
+    ScopePolicy,
+)
+from nebula.v3.storage import NebulaStore
+
+
+AUTH = {"Authorization": "Bearer test-token"}
+
+
+def project(client: TestClient, store: NebulaStore) -> tuple[Engagement, ScopePolicy]:
+    response = client.post(
+        "/api/v1/engagements", headers=AUTH, json={"name": "Browser lab"}
+    )
+    assert response.status_code == 201, response.text
+    engagement = store.get(Engagement, response.json()["id"])
+    scope = store.get(ScopePolicy, engagement.scope_policy_id)
+    scope = store.update(
+        ScopePolicy,
+        scope.id,
+        {
+            "allowed_domains": ["app.example.test"],
+            "allowed_ports": [443],
+        },
+        expected_revision=scope.revision,
+    )
+    return engagement, scope
+
+
+class ReadyManagedChromium(BrowserEngineAdapter):
+    async def readiness(self) -> BrowserEngineCapability:
+        return BrowserEngineCapability(
+            adapter="managed-chromium",
+            display_name="Managed Chromium",
+            state=BrowserEngineState.READY,
+            installed_version="canary",
+            digest=f"sha256:{'a' * 64}",
+            actions=["navigate", "click", "fill", "snapshot", "trace"],
+            protocols=["http", "https", "websocket"],
+        )
+
+    async def ensure_identity(self, identity_id: str) -> None:
+        assert identity_id
+
+    async def execute(self, action: BrowserEngineAction) -> BrowserEngineReceipt:
+        return BrowserEngineReceipt(action_token=action.action_token, state="complete")
+
+    async def pause(self, assessment_id: str) -> None:
+        assert assessment_id
+
+    async def resume(self, assessment_id: str) -> None:
+        assert assessment_id
+
+    async def stop(self, assessment_id: str) -> None:
+        assert assessment_id
+
+
+def test_assessment_snapshot_is_durable_and_replayable(tmp_path):
+    store = NebulaStore(tmp_path / "nebula.db")
+    client = TestClient(create_app(store, auth_token="test-token"))
+    engagement, scope = project(client, store)
+    browser = client.get(
+        f"/api/v1/engagements/{engagement.id}/browser-workspace", headers=AUTH
+    ).json()
+
+    response = client.post(
+        f"/api/v1/engagements/{engagement.id}/browser-assessments",
+        headers=AUTH,
+        json={
+            "name": "Guided standard",
+            "objective": "Map the authenticated surface and preserve evidence.",
+            "profile": "standard",
+            "session_id": browser["sessions"][0]["id"],
+            "identity_ids": [browser["identities"][0]["id"]],
+            "primary_identity_id": browser["identities"][0]["id"],
+            "target_urls": ["https://app.example.test/"],
+        },
+    )
+    assert response.status_code == 201, response.text
+    assessment = response.json()
+    assert assessment["status"] == "draft"
+    assert assessment["scope_policy_id"] == scope.id
+    assert assessment["scope_policy_revision"] == scope.revision
+    assert (
+        assessment["pause_reason"] == "Prepare required runtime: managed-chromium, zap"
+    )
+    assert all(item["state"] != "ready" for item in assessment["engines"])
+
+    snapshot = client.get(
+        f"/api/v1/engagements/{engagement.id}/browser-assessments", headers=AUTH
+    )
+    assert snapshot.status_code == 200, snapshot.text
+    payload = snapshot.json()
+    assert [item["id"] for item in payload["assessments"]] == [assessment["id"]]
+    assert [item["sequence"] for item in payload["steps"]] == [0, 1, 2]
+    assert [item["id"] for item in payload["profiles"]] == [
+        "explore",
+        "standard",
+        "deep",
+        "api",
+        "validation",
+    ]
+
+    events = client.get(
+        f"/api/v1/browser-assessments/{assessment['id']}/events?after=0",
+        headers=AUTH,
+    )
+    assert events.status_code == 200, events.text
+    event_types = [item["event_type"] for item in events.json()["events"]]
+    assert event_types == [
+        "browser_assessment.created",
+        "browser_assessment.step.created",
+        "browser_assessment.step.created",
+        "browser_assessment.step.created",
+    ]
+
+
+def test_ready_assessment_lifecycle_is_idempotent_and_scope_frozen(tmp_path):
+    store = NebulaStore(tmp_path / "nebula.db")
+    client = TestClient(create_app(store, auth_token="test-token"))
+    engagement, scope = project(client, store)
+    browser = BrowserSecurityService(store).workspace(engagement.id)
+    service = BrowserAssessmentService(
+        store, BrowserEngineRegistry([ReadyManagedChromium()])
+    )
+    request = BrowserAssessmentCreateRequest(
+        name="Explore",
+        objective="Explore the authorized target.",
+        profile=BrowserAssessmentProfile.EXPLORE,
+        session_id=browser.sessions[0].id,
+        identity_ids=[browser.identities[0].id],
+        primary_identity_id=browser.identities[0].id,
+        target_urls=["https://app.example.test/"],
+    )
+    assessment = asyncio.run(service.create(engagement.id, request, "operator"))
+    assert assessment.status == BrowserAssessmentStatus.READY
+
+    start = BrowserAssessmentTransitionRequest(
+        expected_revision=assessment.revision,
+        action="start",
+        idempotency_key="start-once",
+    )
+    running = asyncio.run(service.transition(assessment.id, start, "operator"))
+    assert running.status == BrowserAssessmentStatus.RUNNING
+    duplicate = asyncio.run(service.transition(assessment.id, start, "operator"))
+    assert duplicate.id == running.id
+    assert duplicate.revision == running.revision
+    assert (
+        len(
+            [
+                event
+                for event in store.replay_operation_events(assessment.id, limit=100)
+                if event.event_type == "browser_assessment.start"
+            ]
+        )
+        == 1
+    )
+
+    second = asyncio.run(service.create(engagement.id, request, "operator"))
+    store.update(
+        ScopePolicy,
+        scope.id,
+        {"allowed_domains": []},
+        expected_revision=scope.revision,
+    )
+    with pytest.raises(BrowserWorkflowError, match="scope changed"):
+        asyncio.run(
+            service.transition(
+                second.id,
+                BrowserAssessmentTransitionRequest(
+                    expected_revision=second.revision,
+                    action="start",
+                    idempotency_key="stale-scope-start",
+                ),
+                "operator",
+            )
+        )
+    assert (
+        store.get(BrowserAssessment, second.id).status == BrowserAssessmentStatus.READY
+    )
+
+
+def test_recipe_contract_rejects_arbitrary_script_nodes():
+    with pytest.raises(ValidationError):
+        BrowserRecipe.model_validate(
+            {
+                "engagement_id": "project-1",
+                "name": "Unsafe recipe",
+                "stages": [
+                    {
+                        "id": "script",
+                        "kind": "javascript",
+                        "configuration": {"source": "fetch('https://outside.test')"},
+                    }
+                ],
+            }
+        )
+
+
+def test_validation_authority_is_frozen_idempotent_and_revocable(tmp_path):
+    store = NebulaStore(tmp_path / "nebula.db")
+    client = TestClient(create_app(store, auth_token="test-token"))
+    engagement, _ = project(client, store)
+    browser = BrowserSecurityService(store).workspace(engagement.id)
+    service = BrowserAssessmentService(
+        store, BrowserEngineRegistry([ReadyManagedChromium()])
+    )
+    assessment = asyncio.run(
+        service.create(
+            engagement.id,
+            BrowserAssessmentCreateRequest(
+                name="Portal validation source",
+                objective="Collect candidates inside the frozen portal corridor.",
+                profile=BrowserAssessmentProfile.EXPLORE,
+                session_id=browser.sessions[0].id,
+                identity_ids=[browser.identities[0].id],
+                primary_identity_id=browser.identities[0].id,
+                target_urls=["https://app.example.test/portal"],
+            ),
+            "operator",
+        )
+    )
+
+    with pytest.raises(BrowserWorkflowError, match="frozen target corridor"):
+        service.create_candidate(
+            BrowserIssueCandidateCreateRequest(
+                assessment_id=assessment.id,
+                rule_id="outside-corridor",
+                check_family="routing",
+                title="Outside corridor",
+                target_url="https://app.example.test/admin",
+                severity="low",
+            ),
+            "engine",
+        )
+
+    candidate = service.create_candidate(
+        BrowserIssueCandidateCreateRequest(
+            assessment_id=assessment.id,
+            rule_id="reflected-input",
+            check_family="xss",
+            title="Reflected input",
+            cwe="CWE-79",
+            target_url="https://app.example.test/portal/search?q=marker",
+            insertion_point="query:q",
+            severity="medium",
+            confidence="firm",
+        ),
+        "engine",
+    )
+    request = BrowserValidationGrantRequest(
+        expected_candidate_revision=candidate.revision,
+        technique="Replay one inert marker and one negative encoding control.",
+        max_requests=8,
+        duration_seconds=300,
+        idempotency_key="grant-candidate-once",
+    )
+    grant = service.grant_validation(candidate.id, request, "operator")
+    duplicate = service.grant_validation(candidate.id, request, "operator")
+    assert duplicate.id == grant.id
+    assert (
+        len(
+            [
+                event
+                for event in store.replay_operation_events(assessment.id, limit=100)
+                if event.event_type == "browser_assessment.validation.granted"
+            ]
+        )
+        == 1
+    )
+
+    queued = store.get(BrowserIssueCandidate, candidate.id)
+    assert queued.validation_status == BrowserIssueValidationStatus.QUEUED
+    with pytest.raises(BrowserWorkflowError, match="already has an active"):
+        service.grant_validation(
+            candidate.id,
+            BrowserValidationGrantRequest(
+                expected_candidate_revision=queued.revision,
+                technique="A second technique must not overlap.",
+                max_requests=2,
+                duration_seconds=60,
+                idempotency_key="overlapping-grant",
+            ),
+            "operator",
+        )
+
+    revoke = BrowserValidationRevokeRequest(
+        expected_grant_revision=grant.revision,
+        reason="Operator emergency revocation.",
+        idempotency_key="revoke-grant-once",
+    )
+    revoked = service.revoke_validation(candidate.id, revoke, "operator")
+    assert revoked.status == "revoked"
+    assert revoked.revoked_at is not None
+    assert (
+        store.get(BrowserIssueCandidate, candidate.id).validation_status
+        == BrowserIssueValidationStatus.INCONCLUSIVE
+    )
+    assert service.revoke_validation(candidate.id, revoke, "operator").id == grant.id

--- a/tests/v3/test_browser_engine.py
+++ b/tests/v3/test_browser_engine.py
@@ -1,0 +1,122 @@
+import asyncio
+
+import httpx
+import pytest
+
+from nebula.v3.browser_engine import (
+    BrowserEngineAction,
+    BrowserEngineRegistry,
+    LocalBrowserdAdapter,
+)
+from nebula.v3.domain import BrowserEngineState
+
+
+def test_browserd_adapter_requires_literal_loopback_and_opaque_authentication():
+    with pytest.raises(ValueError, match="literal loopback"):
+        LocalBrowserdAdapter("http://localhost:4711", "opaque-token")
+    with pytest.raises(ValueError, match="literal loopback"):
+        LocalBrowserdAdapter("https://example.test:4711", "opaque-token")
+    with pytest.raises(ValueError, match="opaque"):
+        LocalBrowserdAdapter("http://127.0.0.1:4711", "secret token")
+
+
+def test_browserd_adapter_maps_authenticated_readiness_without_url_secrets():
+    observed: dict[str, str | None] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        observed["url"] = str(request.url)
+        observed["authorization"] = request.headers.get("authorization")
+        return httpx.Response(
+            200,
+            json={
+                "adapter": "managed-chromium",
+                "display_name": "Managed Chromium",
+                "contract_version": "1",
+                "state": "ready",
+                "installed_version": "149.0.0",
+                "digest": f"sha256:{'a' * 64}",
+                "actions": ["navigate", "click", "snapshot", "trace"],
+                "protocols": ["http", "https", "websocket"],
+                "check_families": [],
+                "desktop_only": True,
+            },
+        )
+
+    token = "browserd-secret-token"
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        capability = asyncio.run(
+            LocalBrowserdAdapter(
+                "http://127.0.0.1:4711", token, client=client
+            ).readiness()
+        )
+    finally:
+        asyncio.run(client.aclose())
+    assert capability.state == BrowserEngineState.READY
+    assert observed["authorization"] == f"Bearer {token}"
+    assert token not in str(observed["url"])
+
+
+def test_browserd_adapter_fails_closed_on_contract_drift():
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "adapter": "managed-chromium",
+                "display_name": "Managed Chromium",
+                "contract_version": "2",
+                "state": "ready",
+                "actions": [],
+                "protocols": [],
+                "check_families": [],
+                "desktop_only": True,
+            },
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        capability = asyncio.run(
+            LocalBrowserdAdapter(
+                "http://127.0.0.1:4711", "token", client=client
+            ).readiness()
+        )
+    finally:
+        asyncio.run(client.aclose())
+    assert capability.state == BrowserEngineState.UNAVAILABLE
+    assert "incompatible" in (capability.unavailability_reason or "")
+
+
+def test_browserd_lost_side_effect_receipt_is_ambiguous_and_never_auto_replayed():
+    async def handler(_: httpx.Request) -> httpx.Response:
+        raise httpx.ReadError("receipt connection closed")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    action = BrowserEngineAction(
+        action_token="action-once",
+        assessment_id="assessment-1",
+        session_id="session-1",
+        identity_id="identity-1",
+        tab_id="tab-1",
+        kind="click",
+        locator={"role": "button", "name": "Submit"},
+        side_effect="possible",
+    )
+    try:
+        receipt = asyncio.run(
+            LocalBrowserdAdapter(
+                "http://127.0.0.1:4711", "token", client=client
+            ).execute(action)
+        )
+    finally:
+        asyncio.run(client.aclose())
+    assert receipt.state == "ambiguous"
+    assert receipt.action_token == action.action_token
+    assert "will not replay" in (receipt.recovery_action or "")
+
+
+def test_registry_discovers_configured_browserd_without_exposing_token(monkeypatch):
+    monkeypatch.setenv("NEBULA_BROWSERD_URL", "http://127.0.0.1:4711")
+    monkeypatch.setenv("NEBULA_BROWSERD_TOKEN", "configured-secret")
+    registry = BrowserEngineRegistry()
+    assert len(registry._adapters) == 1
+    assert isinstance(registry._adapters[0], LocalBrowserdAdapter)

--- a/tests/v3/test_browserd.py
+++ b/tests/v3/test_browserd.py
@@ -1,0 +1,231 @@
+import asyncio
+import hashlib
+import json
+
+from fastapi.testclient import TestClient
+import pytest
+
+from nebula.v3.browser_engine import BrowserEngineAction, BrowserEngineReceipt
+from nebula.v3.browserd import (
+    ActionLedger,
+    BrowserdIdentityReceipt,
+    BrowserdLifecycleReceipt,
+    BrowserdManager,
+    BrowserdSettings,
+    create_browserd_app,
+)
+from nebula.v3.domain import BrowserEngineCapability, BrowserEngineState
+
+
+def settings(tmp_path, *, headless: bool = False) -> BrowserdSettings:
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    return BrowserdSettings(
+        token="opaque-browserd-token",
+        profile_root=tmp_path / "profiles",
+        policy_proxy_url="http://127.0.0.1:4911",
+        runtime_root=runtime,
+        headless=headless,
+    )
+
+
+def action(token: str = "action-1", *, url: str = "https://app.example.test/"):
+    return BrowserEngineAction(
+        action_token=token,
+        assessment_id="assessment-1",
+        session_id="session-1",
+        identity_id="identity-1",
+        tab_id="tab-1",
+        kind="navigate",
+        arguments={"url": url},
+        side_effect="possible",
+    )
+
+
+def test_browserd_settings_require_a_literal_loopback_policy_proxy(tmp_path):
+    with pytest.raises(ValueError, match="literal loopback"):
+        BrowserdSettings(
+            token="token",
+            profile_root=tmp_path / "profiles",
+            policy_proxy_url="http://proxy.example.test:4911",
+            runtime_root=tmp_path / "runtime",
+        )
+
+
+def test_browserd_uploads_are_confined_to_an_explicit_host_browser(tmp_path):
+    configured = settings(tmp_path)
+    manager = BrowserdManager(configured)
+    with pytest.raises(ValueError, match="not configured"):
+        manager._upload_path(tmp_path / "outside.txt")
+
+    upload_root = tmp_path / "uploads"
+    upload_root.mkdir()
+    selected = upload_root / "selected.txt"
+    selected.write_text("fixture", encoding="utf-8")
+    bounded = BrowserdManager(
+        BrowserdSettings(
+            token=configured.token,
+            profile_root=configured.profile_root,
+            policy_proxy_url=configured.policy_proxy_url,
+            runtime_root=configured.runtime_root,
+            upload_root=upload_root,
+        )
+    )
+    assert bounded._upload_path(str(selected)) == selected
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+    with pytest.raises(ValueError, match="outside"):
+        bounded._upload_path(str(outside))
+
+
+def test_action_ledger_deduplicates_receipts_and_marks_interrupted_work_ambiguous(
+    tmp_path,
+):
+    async def exercise():
+        ledger = ActionLedger(tmp_path / "ledger" / "actions.sqlite3")
+        proposed = action()
+        assert await ledger.claim(proposed) is None
+        interrupted = await ledger.claim(proposed)
+        assert interrupted is not None
+        assert interrupted.state == "ambiguous"
+        complete = BrowserEngineReceipt(
+            action_token=proposed.action_token,
+            state="complete",
+            page_url="https://app.example.test/",
+        )
+        await ledger.finish(complete)
+        assert await ledger.claim(proposed) == complete
+        with pytest.raises(ValueError, match="different arguments"):
+            await ledger.claim(action(url="https://app.example.test/changed"))
+
+    asyncio.run(exercise())
+
+
+class FakeBrowserdManager:
+    def __init__(self) -> None:
+        self.started = False
+        self.closed = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def readiness(self) -> BrowserEngineCapability:
+        return BrowserEngineCapability(
+            adapter="managed-chromium",
+            display_name="Managed Chromium",
+            state=BrowserEngineState.READY,
+            installed_version="test",
+            digest=f"sha256:{'a' * 64}",
+            actions=["navigate"],
+            protocols=["http", "https"],
+        )
+
+    async def ensure_identity(self, identity_id: str) -> BrowserdIdentityReceipt:
+        return BrowserdIdentityReceipt(identity_id=identity_id, tab_ids=["tab-1"])
+
+    async def execute(self, request: BrowserEngineAction) -> BrowserEngineReceipt:
+        return BrowserEngineReceipt(
+            action_token=request.action_token,
+            state="complete",
+            page_url="https://app.example.test/",
+        )
+
+    async def lifecycle(
+        self, assessment_id: str, state: str
+    ) -> BrowserdLifecycleReceipt:
+        return BrowserdLifecycleReceipt(assessment_id=assessment_id, state=state)
+
+
+def test_browserd_api_is_authenticated_and_exposes_normalized_receipts(tmp_path):
+    configured = settings(tmp_path)
+    manager = FakeBrowserdManager()
+    with TestClient(
+        create_browserd_app(configured, manager=manager)  # type: ignore[arg-type]
+    ) as client:
+        assert client.get("/v1/readiness").status_code == 401
+        headers = {"Authorization": f"Bearer {configured.token}"}
+        readiness = client.get("/v1/readiness", headers=headers)
+        assert readiness.status_code == 200
+        assert readiness.json()["state"] == "ready"
+        identity = client.post(
+            "/v1/identities/ensure",
+            headers=headers,
+            json={"identity_id": "identity-1"},
+        )
+        assert identity.json()["tab_ids"] == ["tab-1"]
+        receipt = client.post(
+            "/v1/actions", headers=headers, json=action().model_dump(mode="json")
+        )
+        assert receipt.status_code == 200
+        assert receipt.json()["action_token"] == "action-1"
+        stopped = client.post(
+            "/v1/assessments/assessment-1/stop", headers=headers, json={}
+        )
+        assert stopped.json() == {
+            "assessment_id": "assessment-1",
+            "state": "stopped",
+        }
+    assert manager.started is True
+    assert manager.closed is True
+
+
+class FakeChromium:
+    def __init__(self, executable_path: str) -> None:
+        self.executable_path = executable_path
+
+
+class FakePlaywright:
+    def __init__(self, executable_path: str) -> None:
+        self.chromium = FakeChromium(executable_path)
+
+    async def stop(self) -> None:
+        return None
+
+
+class FakePlaywrightStarter:
+    def __init__(self, executable_path: str) -> None:
+        self.playwright = FakePlaywright(executable_path)
+
+    async def start(self) -> FakePlaywright:
+        return self.playwright
+
+
+def test_browserd_readiness_requires_manifest_bound_full_chromium(tmp_path):
+    configured = settings(tmp_path)
+    executable = configured.runtime_root / "chromium-test" / "chrome-linux" / "chrome"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"verified full chromium")
+    executable_sha256 = hashlib.sha256(executable.read_bytes()).hexdigest()
+    (configured.runtime_root / "nebula-playwright-runtime.json").write_text(
+        json.dumps(
+            {
+                "browser": "chromium",
+                "playwright_version": "1.61.0",
+                "executables": ["chromium-test/chrome-linux/chrome"],
+                "executable_sha256": {
+                    "chromium-test/chrome-linux/chrome": executable_sha256
+                },
+                "sbom": "nebula-playwright-sbom.spdx.json",
+                "provenance": {"installer": "python -m playwright install chromium"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    manager = BrowserdManager(
+        configured,
+        playwright_factory=lambda: FakePlaywrightStarter(str(executable)),
+    )
+
+    async def exercise():
+        await manager.start()
+        capability = await manager.readiness()
+        await manager.close()
+        return capability
+
+    capability = asyncio.run(exercise())
+    assert capability.state == BrowserEngineState.READY
+    assert capability.digest == f"sha256:{executable_sha256}"
+    assert "cdp-screencast" in capability.protocols

--- a/tests/v3/test_federated_search.py
+++ b/tests/v3/test_federated_search.py
@@ -7,6 +7,7 @@ from nebula.v3.api import create_app
 from nebula.v3.database import EntityRow, SearchDocumentRow
 from nebula.v3.domain import (
     Asset,
+    BrowserAssessment,
     BrowserSession,
     BrowserTabState,
     CommandExecution,
@@ -100,7 +101,19 @@ def test_search_projection_excludes_secrets_outputs_and_url_queries(tmp_path):
         title="Explicit note",
         body="operator saved durable note",
     )
-    store.create_many([command, browser, note])
+    assessment = BrowserAssessment(
+        engagement_id=project.id,
+        name="Portal review",
+        objective="Map authenticated account behavior",
+        session_id="session",
+        identity_ids=["identity"],
+        primary_identity_id="identity",
+        target_urls=["https://example.test/app?token=ASSESSMENT_SECRET#private"],
+        scope_policy_id="scope",
+        scope_policy_revision=1,
+        created_by="operator",
+    )
+    store.create_many([command, browser, note, assessment])
     with store.database.session() as session:
         documents = {row.id: row for row in session.scalars(select(SearchDocumentRow))}
     command_text = f"{documents[command.id].label} {documents[command.id].description} {documents[command.id].content}"
@@ -108,6 +121,13 @@ def test_search_projection_excludes_secrets_outputs_and_url_queries(tmp_path):
     assert "SECRET_OUTPUT" not in command_text
     assert "SECRET_QUERY" not in browser_text
     assert "token=" not in browser_text
+    assessment_text = (
+        f"{documents[assessment.id].label} {documents[assessment.id].description} "
+        f"{documents[assessment.id].content}"
+    )
+    assert "ASSESSMENT_SECRET" not in assessment_text
+    assert "token=" not in assessment_text
+    assert documents[assessment.id].resource_kind == "browser_assessment"
     browser_tab = next(
         row for row in documents.values() if row.resource_kind == "browser_tab"
     )

--- a/tests/v3/test_packaging.py
+++ b/tests/v3/test_packaging.py
@@ -1,4 +1,5 @@
 import ast
+import hashlib
 import json
 import subprocess
 import sys
@@ -40,7 +41,10 @@ def test_nebula3_version_is_synchronized_across_every_package():
 def test_native_launcher_and_admin_command_contract():
     with (ROOT / "pyproject.toml").open("rb") as stream:
         scripts = tomli.load(stream)["tool"]["poetry"]["scripts"]
-    assert scripts == {"nebula-core": "nebula.v3.cli:main"}
+    assert scripts == {
+        "nebula-core": "nebula.v3.cli:main",
+        "nebula-browserd": "nebula.v3.browserd:main",
+    }
 
     linux_launcher = (ROOT / "packaging/linux/nebula").read_text(encoding="utf-8")
     assert 'exec /usr/bin/nebula-ui "$@"' in linux_launcher
@@ -404,13 +408,11 @@ def test_playwright_runtime_staging_keeps_only_verified_generated_payload(tmp_pa
         assert check is True
         assert text is True
         runtime = Path(env["PLAYWRIGHT_BROWSERS_PATH"])
-        executable = (
-            runtime / "chromium_headless_shell-test" / "chrome-linux" / "headless_shell"
-        )
+        executable = runtime / "chromium-test" / "chrome-linux" / "chrome"
         executable.parent.mkdir(parents=True)
         executable.write_bytes(b"browser")
         executable.chmod(0o755)
-        (executable.parent / "LICENSE.headless_shell").write_text(
+        (executable.parent / "LICENSE.chromium").write_text(
             "Chromium license\n",
             encoding="utf-8",
         )
@@ -425,14 +427,10 @@ def test_playwright_runtime_staging_keeps_only_verified_generated_payload(tmp_pa
 
     assert not (destination / "stale-browser").exists()
     assert (destination / ".gitignore").is_file()
-    assert manifest["browser"] == "chromium-headless-shell"
-    assert manifest["executables"] == [
-        "chromium_headless_shell-test/chrome-linux/headless_shell"
-    ]
-    assert manifest["licenses"] == [
-        "chromium_headless_shell-test/chrome-linux/LICENSE.headless_shell"
-    ]
-    assert commands[0][0][-3:] == ["install", "--only-shell", "chromium"]
+    assert manifest["browser"] == "chromium"
+    assert manifest["executables"] == ["chromium-test/chrome-linux/chrome"]
+    assert manifest["licenses"] == ["chromium-test/chrome-linux/LICENSE.chromium"]
+    assert commands[0][0][-3:] == ["install", "--no-shell", "chromium"]
     assert commands[0][1] == str(destination.resolve())
 
 
@@ -553,11 +551,8 @@ def test_artifact_member_audit_rejects_build_residue():
 def test_installer_tree_gate_requires_legal_files_and_rejects_toolchains(tmp_path):
     binary = tmp_path / "usr/bin"
     legal = tmp_path / "usr/share/doc/nebula"
-    playwright = (
-        tmp_path
-        / "usr/lib/nebula/playwright-browsers"
-        / "chromium_headless_shell-test/chrome-linux"
-    )
+    playwright_root = tmp_path / "usr/lib/nebula/playwright-browsers"
+    playwright = playwright_root / "chromium-test/chrome-linux"
     binary.mkdir(parents=True)
     legal.mkdir(parents=True)
     playwright.mkdir(parents=True)
@@ -565,11 +560,16 @@ def test_installer_tree_gate_requires_legal_files_and_rejects_toolchains(tmp_pat
         (binary / name).write_bytes(b"binary")
     (legal / "LICENSE").write_text("BSD\n", encoding="utf-8")
     (legal / "THIRD_PARTY_NOTICES.txt").write_text("Notices\n", encoding="utf-8")
-    browser = playwright / "headless_shell"
+    browser = playwright / "chrome"
     browser.write_bytes(b"browser")
     browser.chmod(0o755)
-    (playwright / "LICENSE.headless_shell").write_text(
+    browser_sha256 = hashlib.sha256(b"browser").hexdigest()
+    (playwright / "LICENSE.chromium").write_text(
         "Chromium license\n",
+        encoding="utf-8",
+    )
+    (playwright_root / "nebula-playwright-sbom.spdx.json").write_text(
+        json.dumps({"spdxVersion": "SPDX-2.3"}),
         encoding="utf-8",
     )
     (
@@ -578,16 +578,21 @@ def test_installer_tree_gate_requires_legal_files_and_rejects_toolchains(tmp_pat
         json.dumps(
             {
                 "schema": 1,
-                "browser": "chromium-headless-shell",
+                "browser": "chromium",
                 "playwright_version": "1.61.0",
                 "target": "x86_64-unknown-linux-gnu",
                 "payload_bytes": 7,
-                "executables": [
-                    "chromium_headless_shell-test/chrome-linux/headless_shell"
-                ],
-                "licenses": [
-                    "chromium_headless_shell-test/chrome-linux/LICENSE.headless_shell"
-                ],
+                "executables": ["chromium-test/chrome-linux/chrome"],
+                "executable_sha256": {
+                    "chromium-test/chrome-linux/chrome": browser_sha256
+                },
+                "licenses": ["chromium-test/chrome-linux/LICENSE.chromium"],
+                "sbom": "nebula-playwright-sbom.spdx.json",
+                "provenance": {
+                    "installer": "python -m playwright install chromium",
+                    "browser_revision": "chromium-test",
+                    "target": "x86_64-unknown-linux-gnu",
+                },
             }
         ),
         encoding="utf-8",

--- a/ui/src/api/assessmentEvents.ts
+++ b/ui/src/api/assessmentEvents.ts
@@ -1,0 +1,113 @@
+import { websocketAuthProtocol, type StreamState } from "./events";
+import { logCaughtDiagnostic } from "../diagnostics";
+
+export interface AssessmentEvent {
+  id: string;
+  sequence: number;
+  eventType: string;
+  occurredAt: string;
+  payload: Record<string, unknown>;
+}
+
+interface AssessmentEventStreamOptions {
+  apiBaseUrl: string;
+  assessmentId: string;
+  token?: string;
+  after?: number;
+  onEvent: (event: AssessmentEvent) => void;
+  onStateChange?: (state: StreamState) => void;
+}
+
+function endpoint(options: AssessmentEventStreamOptions, after: number): string {
+  const url = new URL(
+    `${options.apiBaseUrl.replace(/\/$/, "")}/browser-assessments/${encodeURIComponent(options.assessmentId)}/events/ws`,
+  );
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  url.searchParams.set("after", String(after));
+  return url.toString();
+}
+
+function parseFrame(value: unknown): AssessmentEvent | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const frame = value as Record<string, unknown>;
+  if (frame.kind !== "event" || !frame.event || typeof frame.event !== "object") return undefined;
+  const event = frame.event as Record<string, unknown>;
+  if (!Number.isSafeInteger(event.sequence)) return undefined;
+  return {
+    id: String(event.id ?? `assessment-event-${event.sequence}`),
+    sequence: Number(event.sequence),
+    eventType: String(event.event_type ?? "browser_assessment.updated"),
+    occurredAt: String(event.occurred_at ?? new Date().toISOString()),
+    payload: event.payload && typeof event.payload === "object"
+      ? event.payload as Record<string, unknown>
+      : {},
+  };
+}
+
+/** Cursored assessment stream. Reconnect resumes after the last acknowledged event. */
+export class AssessmentEventStream {
+  private readonly options: AssessmentEventStreamOptions;
+  private socket?: WebSocket;
+  private timer?: ReturnType<typeof setTimeout>;
+  private stopped = true;
+  private attempt = 0;
+  private cursor: number;
+
+  constructor(options: AssessmentEventStreamOptions) {
+    this.options = options;
+    this.cursor = options.after ?? 0;
+  }
+
+  connect(): void {
+    this.stopped = false;
+    this.open(false);
+  }
+
+  disconnect(): void {
+    this.stopped = true;
+    if (this.timer) clearTimeout(this.timer);
+    this.socket?.close(1000, "Assessment workspace closed");
+    this.options.onStateChange?.("closed");
+  }
+
+  private open(reconnecting: boolean): void {
+    if (typeof WebSocket === "undefined") {
+      this.options.onStateChange?.("unsupported");
+      return;
+    }
+    this.options.onStateChange?.(reconnecting ? "reconnecting" : "connecting");
+    const protocols = ["nebula.events.v1"];
+    if (this.options.token) protocols.push(websocketAuthProtocol(this.options.token));
+    const socket = new WebSocket(endpoint(this.options, this.cursor), protocols);
+    this.socket = socket;
+    socket.addEventListener("open", () => {
+      this.attempt = 0;
+      this.options.onStateChange?.("open");
+    });
+    socket.addEventListener("message", (message) => {
+      try {
+        const event = parseFrame(JSON.parse(String(message.data)));
+        if (!event || event.sequence <= this.cursor) return;
+        this.cursor = event.sequence;
+        this.options.onEvent(event);
+      } catch (caught) {
+        void logCaughtDiagnostic(
+          "interface.security_browser.assessment_event_invalid",
+          "A Security Browser assessment event could not be read.",
+          caught,
+          "security_browser",
+        );
+      }
+    });
+    socket.addEventListener("close", (event) => {
+      if (this.stopped || event.code === 1000) {
+        this.options.onStateChange?.("closed");
+        return;
+      }
+      this.options.onStateChange?.("reconnecting");
+      const delay = Math.min(500 * 2 ** this.attempt, 15_000);
+      this.attempt += 1;
+      this.timer = setTimeout(() => this.open(true), delay);
+    });
+  }
+}

--- a/ui/src/api/client.test.ts
+++ b/ui/src/api/client.test.ts
@@ -1713,4 +1713,44 @@ describe("ApiClient", () => {
       "http://127.0.0.1:8765/api/v1/engagements/project%2Fone/workspace/source-control/diff?path=src%2Fscanner.py&staged=false",
     );
   });
+
+  it("serializes a bounded issue-validation grant and maps its authority receipt", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
+      id: "grant-1",
+      revision: 1,
+      assessment_id: "assessment-1",
+      candidate_id: "candidate/one",
+      target_url: "https://app.example.test/search",
+      technique: "Replay one inert marker and one negative encoding control.",
+      max_requests: 8,
+      requests_used: 0,
+      duration_seconds: 300,
+      expires_at: "2026-08-28T12:05:00Z",
+      status: "active",
+      created_at: "2026-08-28T12:00:00Z",
+      updated_at: "2026-08-28T12:00:00Z",
+    }), { status: 201, headers: { "content-type": "application/json" } }));
+    const client = new ApiClient({ baseUrl: "http://127.0.0.1:8765", fetch: fetchMock });
+
+    const grant = await client.grantSecurityBrowserCandidateValidation({
+      id: "candidate/one", revision: 4, assessmentId: "assessment-1", ruleId: "reflected-input",
+      checkFamily: "xss", title: "Reflected input", targetUrl: "https://app.example.test/search",
+      severity: "medium", confidence: "firm", evidenceIds: ["evidence-1"], validationStatus: "unvalidated",
+    }, {
+      technique: "Replay one inert marker and one negative encoding control.",
+      maxRequests: 8,
+      durationSeconds: 300,
+    });
+
+    expect(grant).toMatchObject({ id: "grant-1", maxRequests: 8, durationSeconds: 300, status: "active" });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8765/api/v1/browser-issue-candidates/candidate%2Fone/validation-grant");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      expected_candidate_revision: 4,
+      technique: "Replay one inert marker and one negative encoding control.",
+      max_requests: 8,
+      duration_seconds: 300,
+      idempotency_key: "validation-grant:candidate/one:4",
+    });
+  });
 });

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -46,6 +46,13 @@ import type {
   ScopeImportApplyResult,
   ScopeImportCreateRequest,
   SecurityBrowserAction,
+  SecurityBrowserAssessment,
+  SecurityBrowserAssessmentProfile,
+  SecurityBrowserAssessmentWorkspace,
+  SecurityBrowserEngineCapability,
+  SecurityBrowserIssueCandidate,
+  SecurityBrowserValidationGrant,
+  SecurityBrowserScanProfile,
   SecurityBrowserAutomationStatus,
   SecurityBrowserAutomationLease,
   SecurityBrowserCommand,
@@ -738,6 +745,127 @@ interface WireBrowserWorkspace {
   frames: WireBrowserWebSocketFrame[];
   actions: WireBrowserAction[];
   handoffs: WireBrowserHandoff[];
+}
+
+interface WireBrowserEngineCapability {
+  adapter: string;
+  display_name: string;
+  contract_version: string;
+  state: SecurityBrowserEngineCapability["state"];
+  installed_version?: string | null;
+  digest?: string | null;
+  actions: string[];
+  protocols: string[];
+  check_families: string[];
+  unavailability_reason?: string | null;
+  recovery_action?: string | null;
+  desktop_only: boolean;
+}
+
+interface WireBrowserAssessment extends WireEntity {
+  engagement_id: string;
+  name: string;
+  objective: string;
+  profile: SecurityBrowserAssessmentProfile;
+  session_id: string;
+  identity_ids: string[];
+  primary_identity_id: string;
+  target_urls: string[];
+  scope_policy_id: string;
+  scope_policy_revision: number;
+  risk_classes: string[];
+  validation_grant_id?: string | null;
+  status: SecurityBrowserAssessment["status"];
+  phase: SecurityBrowserAssessment["phase"];
+  progress: number;
+  budget: {
+    max_requests: number;
+    max_actions: number;
+    max_duration_seconds: number;
+    max_concurrency: number;
+    requests_used: number;
+    actions_used: number;
+  };
+  coverage: {
+    discovered_urls: number;
+    visited_urls: number;
+    analyzed_exchanges: number;
+    discovered_forms: number;
+    discovered_apis: number;
+    websocket_channels: number;
+  };
+  engines: WireBrowserEngineCapability[];
+  evidence_ids: string[];
+  candidate_ids: string[];
+  active_step_id?: string | null;
+  control_owner: "nebula" | "operator";
+  pause_reason?: string | null;
+  failure?: string | null;
+  recovery_action?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+}
+
+interface WireBrowserAssessmentStep extends WireEntity {
+  assessment_id: string;
+  sequence: number;
+  title: string;
+  intent: string;
+  capability: string;
+  target: string;
+  status: SecurityBrowserAssessmentWorkspace["steps"][number]["status"];
+  retry_classification: SecurityBrowserAssessmentWorkspace["steps"][number]["retryClassification"];
+  trace_ids: string[];
+  evidence_ids: string[];
+  error?: string | null;
+  recovery_action?: string | null;
+}
+
+interface WireBrowserScanProfile {
+  id: SecurityBrowserAssessmentProfile;
+  name: string;
+  summary: string;
+  risk_classes: string[];
+  required_adapters: string[];
+  default_budget: WireBrowserAssessment["budget"];
+  validation_locked: boolean;
+}
+
+interface WireBrowserIssueCandidate extends WireEntity {
+  assessment_id: string;
+  rule_id: string;
+  check_family: string;
+  title: string;
+  cwe?: string | null;
+  target_url: string;
+  insertion_point?: string | null;
+  severity: SecurityBrowserIssueCandidate["severity"];
+  confidence: SecurityBrowserIssueCandidate["confidence"];
+  evidence_ids: string[];
+  validation_status: SecurityBrowserIssueCandidate["validationStatus"];
+  validation_grant_id?: string | null;
+  promoted_finding_id?: string | null;
+}
+
+interface WireBrowserValidationGrant extends WireEntity {
+  assessment_id: string;
+  candidate_id: string;
+  target_url: string;
+  technique: string;
+  max_requests: number;
+  requests_used: number;
+  duration_seconds: number;
+  expires_at: string;
+  status: SecurityBrowserValidationGrant["status"];
+}
+
+interface WireBrowserAssessmentWorkspace {
+  assessments: WireBrowserAssessment[];
+  steps: WireBrowserAssessmentStep[];
+  profiles: WireBrowserScanProfile[];
+  engines: WireBrowserEngineCapability[];
+  candidates: WireBrowserIssueCandidate[];
+  validation_grants: WireBrowserValidationGrant[];
 }
 
 interface WireAgentRun extends WireEntity {
@@ -3644,6 +3772,147 @@ function mapBrowserWorkspace(value: WireBrowserWorkspace): SecurityBrowserWorksp
     frames: value.frames.map(mapBrowserWebSocketFrame),
     actions: value.actions.map(mapBrowserAction),
     handoffs: value.handoffs.map(mapBrowserHandoff),
+  };
+}
+
+function mapBrowserEngineCapability(value: WireBrowserEngineCapability): SecurityBrowserEngineCapability {
+  return {
+    adapter: value.adapter,
+    displayName: value.display_name,
+    contractVersion: value.contract_version,
+    state: value.state,
+    installedVersion: value.installed_version ?? undefined,
+    digest: value.digest ?? undefined,
+    actions: value.actions,
+    protocols: value.protocols,
+    checkFamilies: value.check_families,
+    unavailabilityReason: value.unavailability_reason ?? undefined,
+    recoveryAction: value.recovery_action ?? undefined,
+    desktopOnly: value.desktop_only,
+  };
+}
+
+function mapBrowserBudget(value: WireBrowserAssessment["budget"]): SecurityBrowserAssessment["budget"] {
+  return {
+    maxRequests: value.max_requests,
+    maxActions: value.max_actions,
+    maxDurationSeconds: value.max_duration_seconds,
+    maxConcurrency: value.max_concurrency,
+    requestsUsed: value.requests_used,
+    actionsUsed: value.actions_used,
+  };
+}
+
+function mapBrowserAssessment(value: WireBrowserAssessment): SecurityBrowserAssessment {
+  return {
+    id: value.id,
+    revision: value.revision,
+    engagementId: value.engagement_id,
+    name: value.name,
+    objective: value.objective,
+    profile: value.profile,
+    sessionId: value.session_id,
+    identityIds: value.identity_ids,
+    primaryIdentityId: value.primary_identity_id,
+    targetUrls: value.target_urls,
+    scopePolicyId: value.scope_policy_id,
+    scopePolicyRevision: value.scope_policy_revision,
+    riskClasses: value.risk_classes,
+    validationGrantId: value.validation_grant_id ?? undefined,
+    status: value.status,
+    phase: value.phase,
+    progress: value.progress,
+    budget: mapBrowserBudget(value.budget),
+    coverage: {
+      discoveredUrls: value.coverage.discovered_urls,
+      visitedUrls: value.coverage.visited_urls,
+      analyzedExchanges: value.coverage.analyzed_exchanges,
+      discoveredForms: value.coverage.discovered_forms,
+      discoveredApis: value.coverage.discovered_apis,
+      websocketChannels: value.coverage.websocket_channels,
+    },
+    engines: value.engines.map(mapBrowserEngineCapability),
+    evidenceIds: value.evidence_ids,
+    candidateIds: value.candidate_ids,
+    activeStepId: value.active_step_id ?? undefined,
+    controlOwner: value.control_owner,
+    pauseReason: value.pause_reason ?? undefined,
+    failure: value.failure ?? undefined,
+    recoveryAction: value.recovery_action ?? undefined,
+    startedAt: value.started_at ?? undefined,
+    completedAt: value.completed_at ?? undefined,
+    createdAt: value.created_at,
+    updatedAt: value.updated_at,
+  };
+}
+
+function mapBrowserCandidate(value: WireBrowserIssueCandidate): SecurityBrowserIssueCandidate {
+  return {
+    id: value.id,
+    revision: value.revision,
+    assessmentId: value.assessment_id,
+    ruleId: value.rule_id,
+    checkFamily: value.check_family,
+    title: value.title,
+    cwe: value.cwe ?? undefined,
+    targetUrl: value.target_url,
+    insertionPoint: value.insertion_point ?? undefined,
+    severity: value.severity,
+    confidence: value.confidence,
+    evidenceIds: value.evidence_ids,
+    validationStatus: value.validation_status,
+    validationGrantId: value.validation_grant_id ?? undefined,
+    promotedFindingId: value.promoted_finding_id ?? undefined,
+  };
+}
+
+function mapBrowserValidationGrant(value: WireBrowserValidationGrant): SecurityBrowserValidationGrant {
+  return {
+    id: value.id,
+    revision: value.revision,
+    assessmentId: value.assessment_id,
+    candidateId: value.candidate_id,
+    targetUrl: value.target_url,
+    technique: value.technique,
+    maxRequests: value.max_requests,
+    requestsUsed: value.requests_used,
+    durationSeconds: value.duration_seconds,
+    expiresAt: value.expires_at,
+    status: value.status,
+  };
+}
+
+function mapBrowserAssessmentWorkspace(value: WireBrowserAssessmentWorkspace): SecurityBrowserAssessmentWorkspace {
+  return {
+    assessments: value.assessments.map(mapBrowserAssessment),
+    steps: value.steps.map((item) => ({
+      id: item.id,
+      revision: item.revision,
+      assessmentId: item.assessment_id,
+      sequence: item.sequence,
+      title: item.title,
+      intent: item.intent,
+      capability: item.capability,
+      target: item.target,
+      status: item.status,
+      retryClassification: item.retry_classification,
+      traceIds: item.trace_ids,
+      evidenceIds: item.evidence_ids,
+      error: item.error ?? undefined,
+      recoveryAction: item.recovery_action ?? undefined,
+    })),
+    profiles: value.profiles.map((profile): SecurityBrowserScanProfile => ({
+      id: profile.id,
+      name: profile.name,
+      summary: profile.summary,
+      riskClasses: profile.risk_classes,
+      requiredAdapters: profile.required_adapters,
+      defaultBudget: mapBrowserBudget(profile.default_budget),
+      validationLocked: profile.validation_locked,
+    })),
+    engines: value.engines.map(mapBrowserEngineCapability),
+    candidates: value.candidates.map(mapBrowserCandidate),
+    validationGrants: value.validation_grants.map(mapBrowserValidationGrant),
   };
 }
 
@@ -7466,6 +7735,158 @@ export class ApiClient {
       `engagements/${encodeURIComponent(engagementId)}/browser-workspace`,
       { signal },
     ).then(mapBrowserWorkspace);
+  }
+
+  getSecurityBrowserAssessments(
+    engagementId: string,
+    signal?: AbortSignal,
+  ): Promise<SecurityBrowserAssessmentWorkspace> {
+    return this.request<WireBrowserAssessmentWorkspace>(
+      `engagements/${encodeURIComponent(engagementId)}/browser-assessments`,
+      { signal },
+    ).then(mapBrowserAssessmentWorkspace);
+  }
+
+  createSecurityBrowserAssessment(
+    engagementId: string,
+    body: {
+      name: string;
+      objective: string;
+      profile: SecurityBrowserAssessmentProfile;
+      sessionId: string;
+      identityIds: string[];
+      primaryIdentityId: string;
+      targetUrls: string[];
+      credentialRefs?: string[];
+      validationGrantId?: string;
+      budget?: SecurityBrowserAssessment["budget"];
+    },
+  ): Promise<SecurityBrowserAssessment> {
+    return this.request<WireBrowserAssessment>(
+      `engagements/${encodeURIComponent(engagementId)}/browser-assessments`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: body.name,
+          objective: body.objective,
+          profile: body.profile,
+          session_id: body.sessionId,
+          identity_ids: body.identityIds,
+          primary_identity_id: body.primaryIdentityId,
+          target_urls: body.targetUrls,
+          credential_refs: body.credentialRefs ?? [],
+          validation_grant_id: body.validationGrantId,
+          budget: body.budget ? {
+            max_requests: body.budget.maxRequests,
+            max_actions: body.budget.maxActions,
+            max_duration_seconds: body.budget.maxDurationSeconds,
+            max_concurrency: body.budget.maxConcurrency,
+            requests_used: body.budget.requestsUsed,
+            actions_used: body.budget.actionsUsed,
+          } : undefined,
+        }),
+      },
+    ).then(mapBrowserAssessment);
+  }
+
+  transitionSecurityBrowserAssessment(
+    assessment: SecurityBrowserAssessment,
+    action: "start" | "pause" | "resume" | "takeover" | "return_control" | "stop" | "complete" | "fail" | "retry" | "revoke",
+    options?: { reason?: string; recoveryAction?: string },
+  ): Promise<SecurityBrowserAssessment> {
+    return this.request<WireBrowserAssessment>(
+      `browser-assessments/${encodeURIComponent(assessment.id)}/transition`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          expected_revision: assessment.revision,
+          action,
+          reason: options?.reason,
+          recovery_action: options?.recoveryAction,
+          idempotency_key: `${action}:${assessment.id}:${assessment.revision}`,
+        }),
+      },
+    ).then(mapBrowserAssessment);
+  }
+
+  refreshSecurityBrowserAssessmentReadiness(
+    assessment: SecurityBrowserAssessment,
+  ): Promise<SecurityBrowserAssessment> {
+    return this.request<WireBrowserAssessment>(
+      `browser-assessments/${encodeURIComponent(assessment.id)}/readiness?expected_revision=${assessment.revision}`,
+      { method: "POST" },
+    ).then(mapBrowserAssessment);
+  }
+
+  deleteSecurityBrowserAssessment(
+    assessment: SecurityBrowserAssessment,
+  ): Promise<void> {
+    return this.request<void>(
+      `browser-assessments/${encodeURIComponent(assessment.id)}?expected_revision=${assessment.revision}`,
+      { method: "DELETE" },
+    );
+  }
+
+  grantSecurityBrowserCandidateValidation(
+    candidate: SecurityBrowserIssueCandidate,
+    body: { technique: string; maxRequests: number; durationSeconds: number },
+  ): Promise<SecurityBrowserValidationGrant> {
+    return this.request<WireBrowserValidationGrant>(
+      `browser-issue-candidates/${encodeURIComponent(candidate.id)}/validation-grant`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          expected_candidate_revision: candidate.revision,
+          technique: body.technique,
+          max_requests: body.maxRequests,
+          duration_seconds: body.durationSeconds,
+          idempotency_key: `validation-grant:${candidate.id}:${candidate.revision}`,
+        }),
+      },
+    ).then(mapBrowserValidationGrant);
+  }
+
+  revokeSecurityBrowserCandidateValidation(
+    candidate: SecurityBrowserIssueCandidate,
+    grant: SecurityBrowserValidationGrant,
+    reason: string,
+  ): Promise<SecurityBrowserValidationGrant> {
+    return this.request<WireBrowserValidationGrant>(
+      `browser-issue-candidates/${encodeURIComponent(candidate.id)}/validation-revoke`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          expected_grant_revision: grant.revision,
+          reason,
+          idempotency_key: `validation-revoke:${grant.id}:${grant.revision}`,
+        }),
+      },
+    ).then(mapBrowserValidationGrant);
+  }
+
+  completeSecurityBrowserCandidateValidation(
+    candidate: SecurityBrowserIssueCandidate,
+    grant: SecurityBrowserValidationGrant,
+    body: {
+      result: "confirmed" | "rejected" | "inconclusive";
+      controlResults: Array<Record<string, unknown>>;
+      evidenceIds: string[];
+    },
+  ): Promise<SecurityBrowserIssueCandidate> {
+    return this.request<WireBrowserIssueCandidate>(
+      `browser-issue-candidates/${encodeURIComponent(candidate.id)}/validation-result`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          expected_candidate_revision: candidate.revision,
+          expected_grant_revision: grant.revision,
+          result: body.result,
+          control_results: body.controlResults,
+          evidence_ids: body.evidenceIds,
+          idempotency_key: `validation-result:${grant.id}:${grant.revision}`,
+        }),
+      },
+    ).then(mapBrowserCandidate);
   }
 
   getSecurityBrowserResearch(

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -4,7 +4,8 @@ export type ResourceKind =
   | "project" | "conversation" | "note" | "source" | "library_item"
   | "workspace_file" | "asset" | "evidence" | "finding" | "report"
   | "terminal_session" | "terminal_command" | "browser_session" | "browser_tab"
-  | "browser_exchange" | "mission" | "execution" | "approval" | "receipt" | "artifact";
+  | "browser_assessment" | "browser_exchange" | "mission" | "execution"
+  | "approval" | "receipt" | "artifact";
 
 export interface ResourceRef {
   projectId?: Identifier;
@@ -520,6 +521,144 @@ export interface SecurityBrowserWorkspace {
   frames: SecurityBrowserWebSocketFrame[];
   actions: SecurityBrowserAction[];
   handoffs: SecurityBrowserHandoff[];
+}
+
+export type SecurityBrowserAssessmentProfile = "explore" | "standard" | "deep" | "api" | "validation";
+export type SecurityBrowserAssessmentStatus = "draft" | "ready" | "running" | "waiting_operator" | "paused" | "stopping" | "stopped" | "complete" | "failed" | "revoked";
+
+export interface SecurityBrowserEngineCapability {
+  adapter: string;
+  displayName: string;
+  contractVersion: string;
+  state: "ready" | "degraded" | "preparing" | "unavailable";
+  installedVersion?: string;
+  digest?: string;
+  actions: string[];
+  protocols: string[];
+  checkFamilies: string[];
+  unavailabilityReason?: string;
+  recoveryAction?: string;
+  desktopOnly: boolean;
+}
+
+export interface SecurityBrowserAssessmentBudget {
+  maxRequests: number;
+  maxActions: number;
+  maxDurationSeconds: number;
+  maxConcurrency: number;
+  requestsUsed: number;
+  actionsUsed: number;
+}
+
+export interface SecurityBrowserAssessmentCoverage {
+  discoveredUrls: number;
+  visitedUrls: number;
+  analyzedExchanges: number;
+  discoveredForms: number;
+  discoveredApis: number;
+  websocketChannels: number;
+}
+
+export interface SecurityBrowserAssessment {
+  id: Identifier;
+  revision: number;
+  engagementId: Identifier;
+  name: string;
+  objective: string;
+  profile: SecurityBrowserAssessmentProfile;
+  sessionId: Identifier;
+  identityIds: Identifier[];
+  primaryIdentityId: Identifier;
+  targetUrls: string[];
+  scopePolicyId: Identifier;
+  scopePolicyRevision: number;
+  riskClasses: string[];
+  validationGrantId?: Identifier;
+  status: SecurityBrowserAssessmentStatus;
+  phase: "preflight" | "discovery" | "crawl" | "passive_audit" | "active_audit" | "validation" | "reporting" | "complete";
+  progress: number;
+  budget: SecurityBrowserAssessmentBudget;
+  coverage: SecurityBrowserAssessmentCoverage;
+  engines: SecurityBrowserEngineCapability[];
+  evidenceIds: Identifier[];
+  candidateIds: Identifier[];
+  activeStepId?: Identifier;
+  controlOwner: "nebula" | "operator";
+  pauseReason?: string;
+  failure?: string;
+  recoveryAction?: string;
+  startedAt?: string;
+  completedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SecurityBrowserAssessmentStep {
+  id: Identifier;
+  revision: number;
+  assessmentId: Identifier;
+  sequence: number;
+  title: string;
+  intent: string;
+  capability: string;
+  target: string;
+  status: "queued" | "running" | "waiting_operator" | "complete" | "failed" | "cancelled";
+  retryClassification: "safe_before_side_effect" | "never" | "operator_review";
+  traceIds: Identifier[];
+  evidenceIds: Identifier[];
+  error?: string;
+  recoveryAction?: string;
+}
+
+export interface SecurityBrowserScanProfile {
+  id: SecurityBrowserAssessmentProfile;
+  name: string;
+  summary: string;
+  riskClasses: string[];
+  requiredAdapters: string[];
+  defaultBudget: SecurityBrowserAssessmentBudget;
+  validationLocked: boolean;
+}
+
+export interface SecurityBrowserIssueCandidate {
+  id: Identifier;
+  revision: number;
+  assessmentId: Identifier;
+  ruleId: string;
+  checkFamily: string;
+  title: string;
+  cwe?: string;
+  targetUrl: string;
+  insertionPoint?: string;
+  severity: "info" | "low" | "medium" | "high" | "critical";
+  confidence: "tentative" | "firm" | "certain";
+  evidenceIds: Identifier[];
+  validationStatus: "unvalidated" | "queued" | "validating" | "confirmed" | "rejected" | "inconclusive";
+  validationGrantId?: Identifier;
+  promotedFindingId?: Identifier;
+}
+
+export interface SecurityBrowserValidationGrant {
+  id: Identifier;
+  revision: number;
+  assessmentId: Identifier;
+  candidateId: Identifier;
+  targetUrl: string;
+  technique: string;
+  maxRequests: number;
+  requestsUsed: number;
+  durationSeconds: number;
+  expiresAt: string;
+  status: "active" | "revoked" | "expired" | "consumed";
+}
+
+export interface SecurityBrowserAssessmentWorkspace {
+  assessments: SecurityBrowserAssessment[];
+  steps: SecurityBrowserAssessmentStep[];
+  profiles: SecurityBrowserScanProfile[];
+  engines: SecurityBrowserEngineCapability[];
+  candidates: SecurityBrowserIssueCandidate[];
+  validationGrants: SecurityBrowserValidationGrant[];
 }
 
 export interface SecurityBrowserSiteNode {

--- a/ui/src/base.css
+++ b/ui/src/base.css
@@ -260,20 +260,20 @@ kbd { display: inline-flex; min-width: 20px; min-height: 19px; align-items: cent
 .palette-results button > kbd { color: var(--muted); font: 10px var(--font-mono); white-space: nowrap; }
 .palette-results button strong { font-size: 11px; }
 .palette-results button small { margin-top: 3px; color: var(--muted); font-size: 11px; }
-.palette-result-meta { margin-top: 5px; color: var(--blue); font-size: 10px; font-style: normal; font-weight: var(--weight-semibold); letter-spacing: .015em; }
+.palette-result-meta { margin-top: 5px; color: var(--blue); font-size: 11px; font-style: normal; font-weight: var(--weight-semibold); letter-spacing: .015em; }
 .palette-icon { display: grid; width: 31px; height: 31px; place-items: center; border: 1px solid var(--border); border-radius: var(--radius-control); color: var(--blue); background: var(--surface); }
 .palette-empty { margin: 24px; color: var(--muted); text-align: center; font-size: 11px; }
 .command-palette > footer { display: flex; gap: 16px; padding: 8px 14px; border-top: 1px solid var(--border-soft); color: var(--muted); font-size: 11px; }
 .command-palette footer span { display: flex; align-items: center; gap: 4px; }
 
 .settings-lens-backdrop { position: fixed; z-index: 110; inset: 0; display: grid; place-items: center; padding: 24px; background: var(--overlay-scrim); backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
-.settings-lens { display: grid; width: min(1080px, calc(100vw - 48px)); max-height: min(860px, calc(100dvh - 48px)); grid-template-rows: auto minmax(0, 1fr) auto; overflow: hidden; border: 1px solid var(--border); border-radius: 18px; background: var(--surface-raised); box-shadow: var(--shadow-overlay); }
+.settings-lens { display: grid; width: min(1080px, calc(100vw - 48px)); max-height: min(860px, calc(100dvh - 48px)); grid-template-rows: auto minmax(0, 1fr) auto; overflow: hidden; border: 1px solid var(--border); border-radius: 16px; background: var(--surface-raised); box-shadow: var(--shadow-overlay); }
 .settings-lens-header { display: grid; min-width: 0; grid-template-columns: 40px minmax(0, 1fr) 44px; align-items: start; gap: 12px; padding: 18px 20px 16px; border-bottom: 1px solid var(--border-soft); }
 .settings-lens-header > div { min-width: 0; }
-.settings-lens-header small { color: var(--blue); font-size: 10px; font-weight: var(--weight-bold); text-transform: uppercase; letter-spacing: .045em; }
-.settings-lens-header h2 { margin: 4px 0 3px; color: var(--text-strong); font-size: 18px; }
+.settings-lens-header small { color: var(--blue); font-size: 11px; font-weight: var(--weight-bold); text-transform: uppercase; letter-spacing: .045em; }
+.settings-lens-header h2 { margin: 4px 0 3px; color: var(--text-strong); font-size: 20px; }
 .settings-lens-header p { margin: 0; color: var(--muted); font-size: 11px; line-height: 1.45; }
-.settings-lens-icon { display: grid; width: 40px; height: 40px; place-items: center; border: 1px solid color-mix(in srgb, var(--blue) 38%, var(--border)); border-radius: 11px; color: var(--blue); background: var(--blue-muted); }
+.settings-lens-icon { display: grid; width: 40px; height: 40px; place-items: center; border: 1px solid color-mix(in srgb, var(--blue) 38%, var(--border)); border-radius: 10px; color: var(--blue); background: var(--blue-muted); }
 .settings-lens-content { min-height: 0; padding: 20px; overflow: auto; overscroll-behavior: contain; }
 .settings-lens-loading { display: grid; min-height: 240px; place-items: center; color: var(--muted); font-size: 12px; }
 .settings-lens > footer { display: flex; min-height: 66px; align-items: center; justify-content: flex-end; gap: 8px; padding: 11px 20px; border-top: 1px solid var(--border-soft); background: var(--surface-muted); }

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -658,13 +658,139 @@ kbd { font-size: 11px; }
 .browser-selection-error { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--red); font-size: 11px; line-height: 1.45; }
 .browser-selection-assistant > footer { justify-content: space-between; gap: 10px; color: var(--muted); font-size: 11px; }
 .browser-unavailable { min-height: 590px; }
-.workbench-browser.research-open > .browser-surface { margin-right: min(430px, 42vw); }
-.browser-research-panel { position: absolute; z-index: 6; top: 86px; right: 0; bottom: 0; display: flex; width: min(430px, 42vw); min-width: 340px; flex-direction: column; overflow: hidden; border-left: 1px solid var(--border); color: var(--text); background: var(--surface-raised); box-shadow: var(--shadow-lg); }
+.workbench-browser.research-open > .browser-surface { margin-right: min(920px, 68vw); }
+.browser-research-panel { position: absolute; z-index: 6; top: 86px; right: 0; bottom: 0; display: flex; width: min(920px, 68vw); min-width: 640px; max-width: calc(100% - 320px); flex-direction: column; overflow: hidden; border-left: 1px solid var(--border); color: var(--text); background: var(--surface-raised); box-shadow: var(--shadow-lg); }
 .browser-research-panel > header { display: flex; min-height: 58px; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 10px 10px 14px; border-bottom: 1px solid var(--border-soft); }
 .browser-research-panel > header > div { display: grid; min-width: 0; gap: 3px; }
 .browser-research-panel > header strong { font-size: 13px; }
 .browser-research-panel > header small { overflow: hidden; color: var(--muted); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
 .browser-research-panel > header > button { display: inline-grid; width: 36px; height: 36px; place-items: center; border: 0; border-radius: var(--radius-control); color: var(--muted); background: transparent; cursor: pointer; }
+.security-browser-header-actions { display: flex; align-items: center; gap: 6px; }
+.security-browser-header-actions > button { display: inline-grid; width: 40px; height: 40px; place-items: center; border: 0; border-radius: var(--radius-control); color: var(--muted); background: transparent; cursor: pointer; }
+.security-browser-stream { padding: 3px 7px; border-radius: 999px; color: var(--muted); background: var(--surface-muted); font-size: 11px; text-transform: capitalize; }
+.security-browser-stream.stream-open { color: var(--green); background: var(--green-muted); }
+.security-browser-stream.stream-reconnecting, .security-browser-stream.stream-connecting { color: var(--yellow); background: var(--yellow-muted); }
+.security-browser-error { display: flex; min-height: 44px; align-items: center; gap: 8px; padding: 7px 10px; color: var(--red); background: var(--red-muted); font-size: 11px; line-height: 1.4; }
+.security-browser-error > span { min-width: 0; flex: 1; overflow-wrap: anywhere; }
+.security-browser-error button { display: inline-flex; min-height: 32px; flex: 0 0 auto; align-items: center; gap: 5px; border: 0; color: var(--red); background: transparent; cursor: pointer; }
+.security-browser-layout { display: grid; min-width: 0; min-height: 0; flex: 1; grid-template-columns: 224px minmax(0, 1fr); overflow: hidden; }
+.security-browser-assessment-rail { display: flex; min-width: 0; min-height: 0; flex-direction: column; gap: 10px; padding: 10px; overflow: hidden; border-right: 1px solid var(--border-soft); background: var(--surface); }
+.security-browser-assessment-rail > .button { min-height: 42px; justify-content: center; }
+.security-browser-assessment-rail > p { margin: 0; padding: 8px; border-left: 2px solid var(--blue); color: var(--muted); background: var(--canvas); font-size: 11px; line-height: 1.45; }
+.security-browser-assessment-list { display: grid; min-height: 0; align-content: start; gap: 5px; overflow: auto; }
+.security-browser-assessment-list > button { display: grid; min-width: 0; gap: 4px; padding: 9px; border: 1px solid transparent; border-radius: var(--radius-control); color: var(--text); background: transparent; text-align: left; cursor: pointer; }
+.security-browser-assessment-list > button:hover { background: var(--surface-muted); }
+.security-browser-assessment-list > button.selected { border-color: color-mix(in srgb, var(--blue) 48%, var(--border)); background: var(--blue-muted); }
+.security-browser-assessment-list > button strong, .security-browser-assessment-list > button small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.security-browser-assessment-list > button small, .security-browser-assessment-list > button > span:last-child { color: var(--muted); font-size: 11px; }
+.security-browser-loading { display: flex; align-items: center; gap: 6px; padding: 12px 4px; color: var(--muted); font-size: 11px; }
+.security-browser-empty, .security-browser-welcome { display: grid; justify-items: center; gap: 7px; padding: 24px 12px; color: var(--muted); text-align: center; }
+.security-browser-empty strong, .security-browser-welcome h2 { margin: 0; color: var(--text); }
+.security-browser-empty span, .security-browser-welcome p { margin: 0; font-size: 11px; line-height: 1.5; }
+.security-browser-main { display: flex; min-width: 0; min-height: 0; flex-direction: column; overflow: hidden; }
+.security-browser-run-summary { display: grid; gap: 9px; padding: 12px; border-bottom: 1px solid var(--border); background: var(--surface); }
+.security-browser-run-summary > header { display: flex; min-width: 0; align-items: flex-start; justify-content: space-between; gap: 10px; }
+.security-browser-run-summary > header > div:first-child { display: grid; min-width: 0; gap: 4px; }
+.security-browser-run-summary h2 { margin: 0; font-size: 15px; }
+.security-browser-run-summary p { margin: 0; color: var(--muted); font-size: 11px; line-height: 1.45; }
+.security-browser-status { justify-self: start; padding: 2px 6px; border-radius: 999px; color: var(--yellow); background: var(--yellow-muted); font-size: 11px; font-weight: var(--weight-bold); text-transform: uppercase; }
+.security-browser-status.status-ready, .security-browser-status.status-complete { color: var(--green); background: var(--green-muted); }
+.security-browser-status.status-running { color: var(--blue); background: var(--blue-muted); }
+.security-browser-status.status-failed, .security-browser-status.status-revoked { color: var(--red); background: var(--red-muted); }
+.security-browser-run-controls { display: flex; flex: 0 0 auto; flex-wrap: wrap; justify-content: flex-end; gap: 6px; }
+.security-browser-run-controls .button { min-height: 36px; }
+.security-browser-callout { display: flex; align-items: flex-start; gap: 7px; padding: 8px; border-radius: var(--radius-control); font-size: 11px; line-height: 1.4; }
+.security-browser-callout.warning { color: var(--yellow); background: var(--yellow-muted); }
+.security-browser-callout > div { display: grid; gap: 2px; }
+.security-browser-callout span, .security-browser-callout small { color: var(--text); }
+.security-browser-metrics { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 6px; }
+.security-browser-metrics > div { display: grid; gap: 3px; padding: 7px; border: 1px solid var(--border-soft); border-radius: var(--radius-control); background: var(--canvas); }
+.security-browser-metrics span { color: var(--muted); font-size: 11px; }
+.security-browser-metrics strong { overflow: hidden; font-size: 11px; text-overflow: ellipsis; text-transform: capitalize; white-space: nowrap; }
+.security-browser-progress { height: 5px; overflow: hidden; border-radius: 999px; background: var(--surface-muted); }
+.security-browser-progress > span { display: block; height: 100%; background: var(--blue); }
+.security-browser-run-summary details { font-size: 11px; }
+.security-browser-run-summary summary { color: var(--blue); cursor: pointer; }
+.security-browser-run-summary ol { display: grid; gap: 5px; margin: 8px 0 0; padding: 0; list-style: none; }
+.security-browser-run-summary li { display: flex; align-items: flex-start; gap: 7px; padding: 6px; border: 1px solid var(--border-soft); border-radius: var(--radius-control); }
+.security-browser-run-summary li > div { display: grid; min-width: 0; gap: 2px; }
+.security-browser-run-summary li small { color: var(--muted); }
+.security-browser-run-summary li em { color: var(--red); font-style: normal; }
+.security-browser-candidates { display: grid; gap: 8px; padding-top: 2px; border-top: 1px solid var(--border-soft); }
+.security-browser-candidates > header { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
+.security-browser-candidates > header > div { display: grid; gap: 2px; }
+.security-browser-candidates h3, .security-browser-candidates p, .security-browser-candidate-detail h4 { margin: 0; }
+.security-browser-candidates h3 { font-size: 13px; }
+.security-browser-candidates > header > span { display: grid; min-width: 24px; height: 24px; place-items: center; border-radius: 999px; color: var(--blue); background: var(--blue-muted); font: 11px var(--font-mono); }
+.security-browser-candidate-layout { display: grid; grid-template-columns: minmax(180px, 2fr) minmax(280px, 3fr); gap: 8px; }
+.security-browser-candidate-list { display: grid; align-content: start; gap: 5px; }
+.security-browser-candidate-list > button { display: grid; min-width: 0; gap: 4px; padding: 8px; border: 1px solid var(--border-soft); border-radius: var(--radius-control); color: var(--text); background: var(--canvas); text-align: left; cursor: pointer; }
+.security-browser-candidate-list > button.selected { border-color: var(--blue); background: var(--blue-muted); }
+.security-browser-candidate-list > button strong, .security-browser-candidate-list > button small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.security-browser-candidate-list > button small { color: var(--muted); font-size: 11px; text-transform: capitalize; }
+.security-browser-candidate-detail { display: grid; gap: 9px; padding: 10px; border: 1px solid var(--border); border-radius: var(--radius-control); background: var(--canvas); }
+.security-browser-candidate-detail > header { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; }
+.security-browser-candidate-detail > header > div { display: grid; min-width: 0; gap: 4px; }
+.security-browser-candidate-detail > header button { display: grid; width: 36px; height: 36px; flex: 0 0 auto; place-items: center; border: 0; border-radius: var(--radius-control); color: var(--muted); background: transparent; cursor: pointer; }
+.security-browser-candidate-detail dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px; margin: 0; }
+.security-browser-candidate-detail dl > div { display: grid; min-width: 0; gap: 2px; }
+.security-browser-candidate-detail dt { color: var(--muted); font-size: 11px; }
+.security-browser-candidate-detail dd { margin: 0; overflow-wrap: anywhere; font-size: 11px; }
+.security-browser-candidate-detail code, .security-browser-traffic-preview code { font-family: var(--font-mono); font-size: 11px; }
+.security-browser-validation-form { display: grid; gap: 8px; }
+.security-browser-grant-status { display: grid; gap: 8px; }
+.security-browser-grant-status > .button { min-height: 42px; justify-self: start; }
+.security-browser-validation-form > label, .security-browser-validation-budget label { display: grid; gap: 5px; color: var(--muted); font-size: 11px; }
+.security-browser-validation-form :where(textarea, input) { width: 100%; min-height: 42px; padding: 8px 9px; border: 1px solid var(--border); border-radius: var(--radius-control); color: var(--text); background: var(--surface); font: 12px/1.45 var(--font-ui); }
+.security-browser-validation-form textarea { resize: vertical; }
+.security-browser-validation-budget { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 7px; }
+.security-browser-traffic-preview { display: grid; gap: 3px; padding: 8px; border-left: 2px solid var(--blue); background: var(--surface); font-size: 11px; line-height: 1.45; }
+.security-browser-validation-form > .button { min-height: 42px; justify-self: start; }
+.security-browser-step { flex: 0 0 auto; color: var(--muted); font-size: 11px; text-transform: uppercase; }
+.security-browser-step.step-running { color: var(--blue); }
+.security-browser-step.step-complete { color: var(--green); }
+.security-browser-step.step-failed { color: var(--red); }
+.security-browser-delete { display: inline-flex; justify-self: end; min-height: 30px; align-items: center; gap: 5px; border: 0; color: var(--muted); background: transparent; font-size: 11px; cursor: pointer; }
+.security-browser-tool-dock { display: flex; min-width: 0; min-height: 240px; flex: 1; flex-direction: column; overflow: hidden; }
+.security-browser-tool-dock > nav { display: flex; flex: 0 0 auto; overflow-x: auto; border-bottom: 1px solid var(--border-soft); scrollbar-width: thin; }
+.security-browser-tool-dock > nav button { display: flex; min-width: max-content; min-height: 44px; flex: 0 0 auto; align-items: center; justify-content: center; gap: 4px; padding: 0 10px; border: 0; border-bottom: 2px solid transparent; color: var(--muted); background: transparent; font-size: 11px; cursor: pointer; }
+.security-browser-tool-dock > nav button.active { border-bottom-color: var(--blue); color: var(--text); background: var(--surface-muted); }
+.security-browser-tool-dock > nav button > span { display: inline-grid; min-width: 17px; height: 17px; place-items: center; border-radius: 999px; background: var(--canvas); font: 11px var(--font-mono); }
+.security-browser-tool-dock > nav button > small { color: var(--muted); font-size: 11px; }
+.security-browser-tool-content { display: flex; min-width: 0; min-height: 0; flex: 1; flex-direction: column; overflow: hidden; }
+.security-browser-wizard-backdrop { position: absolute; z-index: 10; inset: 0; display: grid; place-items: center; padding: 18px; background: color-mix(in srgb, var(--canvas) 78%, transparent); backdrop-filter: blur(5px); }
+.security-browser-wizard { display: grid; width: min(660px, 100%); max-height: 100%; overflow: auto; border: 1px solid var(--border); border-radius: var(--radius-panel); background: var(--surface-raised); box-shadow: var(--shadow-xl); }
+.security-browser-wizard > header, .security-browser-wizard > footer { display: flex; min-height: 58px; align-items: center; justify-content: space-between; gap: 10px; padding: 10px 14px; }
+.security-browser-wizard > header { border-bottom: 1px solid var(--border-soft); }
+.security-browser-wizard > footer { border-top: 1px solid var(--border-soft); }
+.security-browser-wizard > header > div { display: grid; gap: 2px; }
+.security-browser-wizard > header span { color: var(--muted); font-size: 11px; text-transform: uppercase; }
+.security-browser-wizard > header button { display: inline-grid; width: 40px; height: 40px; place-items: center; border: 0; border-radius: var(--radius-control); color: var(--muted); background: transparent; cursor: pointer; }
+.security-browser-wizard-steps { display: grid; grid-template-columns: repeat(5, 1fr); gap: 4px; padding: 10px 14px 0; }
+.security-browser-wizard-steps span { display: grid; height: 24px; place-items: center; border-radius: 999px; color: var(--muted); background: var(--surface-muted); font: 11px var(--font-mono); }
+.security-browser-wizard-steps span.active { color: var(--blue); background: var(--blue-muted); }
+.security-browser-wizard-page { display: grid; align-content: start; gap: 12px; min-height: 340px; padding: 18px 20px; }
+.security-browser-wizard-page h3, .security-browser-wizard-page p { margin: 0; }
+.security-browser-wizard-page p { color: var(--muted); font-size: 12px; line-height: 1.5; }
+.security-browser-wizard-kicker { color: var(--blue); font-size: 11px; font-weight: var(--weight-bold); text-transform: uppercase; }
+.security-browser-wizard-page > label { display: grid; gap: 6px; color: var(--muted); font-size: 11px; }
+.security-browser-wizard-page :where(select, textarea) { width: 100%; min-height: 42px; padding: 8px 9px; border: 1px solid var(--border); border-radius: var(--radius-control); color: var(--text); background: var(--canvas); font: 12px/1.45 var(--font-sans); }
+.security-browser-wizard-page textarea { resize: vertical; }
+.security-browser-wizard-page dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 7px; margin: 0; }
+.security-browser-wizard-page dl div { min-width: 0; padding: 9px; border: 1px solid var(--border-soft); border-radius: var(--radius-control); background: var(--canvas); }
+.security-browser-wizard-page dt { color: var(--muted); font-size: 11px; }
+.security-browser-wizard-page dd { margin: 3px 0 0; overflow-wrap: anywhere; font-size: 11px; }
+.security-browser-profile-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 7px; }
+.security-browser-profile-grid button { display: grid; min-height: 94px; align-content: start; gap: 5px; padding: 10px; border: 1px solid var(--border); border-radius: var(--radius-control); color: var(--text); background: var(--canvas); text-align: left; cursor: pointer; }
+.security-browser-profile-grid button.selected { border-color: var(--blue); background: var(--blue-muted); }
+.security-browser-profile-grid button:disabled { opacity: .62; cursor: not-allowed; }
+.security-browser-profile-grid span, .security-browser-profile-grid small { color: var(--muted); font-size: 11px; line-height: 1.4; }
+.security-browser-engine-review { display: grid; gap: 6px; }
+.security-browser-engine-review > div { display: flex; align-items: flex-start; gap: 7px; padding: 8px; border: 1px solid var(--border-soft); border-radius: var(--radius-control); }
+.security-browser-engine-review > div > div { display: grid; gap: 2px; }
+.security-browser-engine-review small { color: var(--muted); font-size: 11px; line-height: 1.4; }
+.security-browser-engine-review .engine-ready > span { color: var(--green); }
+.security-browser-engine-review :not(.engine-ready) > span { color: var(--yellow); }
 .browser-research-panel > nav { display: flex; flex: 0 0 auto; overflow-x: auto; border-bottom: 1px solid var(--border-soft); scrollbar-width: thin; }
 .browser-research-panel > nav button { display: flex; min-width: max-content; min-height: 42px; flex: 0 0 auto; align-items: center; justify-content: center; gap: 4px; padding: 0 9px; border: 0; border-bottom: 2px solid transparent; color: var(--muted); background: transparent; font-size: 11px; cursor: pointer; }
 .browser-research-panel > nav button.active { border-bottom-color: var(--blue); color: var(--text); background: var(--surface-muted); }
@@ -778,8 +904,13 @@ kbd { font-size: 11px; }
 .browser-automation-mobile-note { padding: 7px; border-left: 2px solid var(--blue); background: var(--canvas); }
 @media (max-width: 760px) { .browser-ca-card dl, .browser-automation-card dl { grid-template-columns: 1fr; } .browser-automation-form .resource-form-grid, .browser-suite-form { grid-template-columns: 1fr; } .browser-suite-actions .button, .browser-suite-select { min-height: 44px; } .browser-result-list > li { grid-template-columns: auto minmax(0, 1fr); } .browser-result-list > li > span { grid-column: 1 / -1; } }
 .browser-web-research-bar { display: flex; min-height: 45px; align-items: center; gap: 10px; padding: 5px 8px; border-bottom: 1px solid var(--border-soft); color: var(--muted); font-size: 11px; }
-.web-browser-fallback .browser-research-panel { top: 45px; width: min(430px, 100%); }
-.web-browser-fallback.research-open > .browser-surface { margin-right: min(430px, 42vw); }
+.web-browser-fallback .browser-research-panel { top: 45px; width: min(920px, 100%); }
+.web-browser-fallback.research-open > .browser-surface { margin-right: min(920px, 68vw); }
+@media (max-width: 1100px) {
+  .workbench-browser.research-open > .browser-surface, .web-browser-fallback.research-open > .browser-surface { margin-right: 0; visibility: hidden; }
+  .browser-research-panel { width: 100%; min-width: 0; max-width: none; border-left: 0; }
+  .security-browser-layout { grid-template-columns: 210px minmax(0, 1fr); }
+}
 @media (max-width: 760px) {
   .browser-selection-assistant > header span { display: grid; gap: 2px; }
   .browser-selection-assistant > footer { align-items: stretch; flex-direction: column; }
@@ -789,6 +920,19 @@ kbd { font-size: 11px; }
   .web-browser-fallback .browser-research-panel { top: 45px; }
   .browser-research-panel > nav button { min-height: 44px; }
   .browser-web-research-bar > span { display: none; }
+  .security-browser-layout { display: flex; flex-direction: column; overflow: auto; }
+  .security-browser-assessment-rail { min-height: 210px; max-height: 42%; border-right: 0; border-bottom: 1px solid var(--border); }
+  .security-browser-main { min-height: 520px; overflow: visible; }
+  .security-browser-run-summary > header { flex-direction: column; }
+  .security-browser-run-controls { width: 100%; justify-content: stretch; }
+  .security-browser-run-controls .button { min-height: 44px; flex: 1; justify-content: center; }
+  .security-browser-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .security-browser-candidate-layout, .security-browser-candidate-detail dl, .security-browser-validation-budget { grid-template-columns: 1fr; }
+  .security-browser-wizard-backdrop { padding: 0; }
+  .security-browser-wizard { width: 100%; height: 100%; max-height: none; border: 0; border-radius: 0; }
+  .security-browser-wizard-page { min-height: 0; }
+  .security-browser-profile-grid, .security-browser-wizard-page dl { grid-template-columns: 1fr; }
+  .security-browser-wizard > footer .button { min-height: 44px; }
 }
 .persistent-terminal[hidden] { display: none !important; }
 .persistent-code-editor[hidden] { display: none !important; }
@@ -1421,12 +1565,12 @@ button.harness-status-summary:focus-visible { outline: 2px solid var(--focus); o
 .resource-lineage { display: grid; gap: 8px; margin: 0; padding: 0; list-style: none; }
 .resource-lineage li { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 9px; padding: 9px 10px; border: 1px solid var(--border-soft); border-radius: var(--radius-control); }
 .resource-lineage li > span { display: grid; min-width: 0; }
-.resource-lineage small { color: var(--muted); font-size: 10px; }
+.resource-lineage small { color: var(--muted); font-size: 11px; }
 .resource-lineage strong { overflow: hidden; color: var(--text); font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
-.resource-lineage time { color: var(--muted); font-size: 10px; }
+.resource-lineage time { color: var(--muted); font-size: 11px; }
 .resource-action-menu { position: relative; display: flex; justify-content: flex-end; margin-bottom: 10px; }
 .resource-action-menu > [role="menu"] { position: absolute; z-index: 4; top: calc(100% + 5px); right: 0; display: grid; min-width: 190px; padding: 5px; border: 1px solid var(--border-strong); border-radius: var(--radius-control); background: var(--surface-raised); box-shadow: var(--shadow-float); }
-.resource-action-menu [role="menuitem"] { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 36px; padding: 7px 9px; border: 0; border-radius: 6px; background: transparent; color: var(--text); text-align: left; }
+.resource-action-menu [role="menuitem"] { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 36px; padding: 7px 9px; border: 0; border-radius: 8px; background: transparent; color: var(--text); text-align: left; }
 .resource-action-menu [role="menuitem"]:hover:not(:disabled), .resource-action-menu [role="menuitem"]:focus-visible { background: var(--surface-hover); }
 .resource-action-menu [role="menuitem"]:disabled { color: var(--muted); opacity: .7; }
 .artifact-actions { display: flex; gap: 10px; }

--- a/ui/src/components/SecurityBrowserWorkspacePanel.test.tsx
+++ b/ui/src/components/SecurityBrowserWorkspacePanel.test.tsx
@@ -1,0 +1,242 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "../api/client";
+import type {
+  SecurityBrowserAssessmentWorkspace,
+  SecurityBrowserIdentity,
+  SecurityBrowserSession,
+} from "../api/types";
+import { SecurityBrowserWorkspacePanel } from "./SecurityBrowserWorkspacePanel";
+
+vi.mock("../api/assessmentEvents", () => ({
+  AssessmentEventStream: class {
+    connect() {}
+    disconnect() {}
+  },
+}));
+
+const identity: SecurityBrowserIdentity = {
+  id: "identity-1",
+  name: "Member",
+  description: "Member account",
+  color: "#7c6cff",
+  storagePartition: "browser-00000000-0000-0000-0000-000000000001",
+  ephemeral: false,
+  isDefault: true,
+  revision: 1,
+};
+
+const session: SecurityBrowserSession = {
+  id: "session-1",
+  name: "Primary session",
+  identityId: identity.id,
+  status: "active",
+  captureMode: "headers",
+  proxyEnabled: false,
+  proxyTrustAcknowledged: false,
+  tabs: [],
+  upstreamProxyEnabled: false,
+  interceptionEnabled: false,
+  lastSeenAt: "2026-08-28T00:00:00Z",
+  revision: 1,
+};
+
+const budget = {
+  maxRequests: 2_000,
+  maxActions: 500,
+  maxDurationSeconds: 3_600,
+  maxConcurrency: 2,
+  requestsUsed: 0,
+  actionsUsed: 0,
+};
+
+function workspace(): SecurityBrowserAssessmentWorkspace {
+  return {
+    assessments: [],
+    steps: [],
+    candidates: [],
+    validationGrants: [],
+    engines: [
+      {
+        adapter: "managed-chromium",
+        displayName: "Managed Chromium",
+        contractVersion: "1",
+        state: "ready",
+        installedVersion: "149.0.7827.55",
+        digest: `sha256:${"a".repeat(64)}`,
+        actions: ["navigate", "click"],
+        protocols: ["http", "https", "websocket"],
+        checkFamilies: [],
+        desktopOnly: true,
+      },
+      {
+        adapter: "zap",
+        displayName: "OWASP ZAP scanner",
+        contractVersion: "1",
+        state: "unavailable",
+        actions: [],
+        protocols: [],
+        checkFamilies: [],
+        unavailabilityReason: "Scanner runtime is not prepared.",
+        recoveryAction: "Prepare the scanner runtime.",
+        desktopOnly: true,
+      },
+    ],
+    profiles: [
+      { id: "explore", name: "Explore", summary: "Manual exploration.", riskClasses: ["passive"], requiredAdapters: ["managed-chromium"], defaultBudget: budget, validationLocked: false },
+      { id: "standard", name: "Standard", summary: "Crawl and passive analysis.", riskClasses: ["passive"], requiredAdapters: ["managed-chromium", "zap"], defaultBudget: budget, validationLocked: false },
+      { id: "deep", name: "Deep", summary: "Bounded active checks.", riskClasses: ["passive", "active_scan"], requiredAdapters: ["managed-chromium", "zap"], defaultBudget: budget, validationLocked: false },
+      { id: "api", name: "API", summary: "API import and testing.", riskClasses: ["passive", "active_scan"], requiredAdapters: ["managed-chromium", "zap"], defaultBudget: budget, validationLocked: false },
+      { id: "validation", name: "Validation", summary: "Issue validation.", riskClasses: ["exploitation"], requiredAdapters: ["managed-chromium"], defaultBudget: budget, validationLocked: true },
+    ],
+  };
+}
+
+function api(snapshot = workspace()): ApiClient {
+  return {
+    baseUrl: "http://127.0.0.1:8765/api/v1",
+    getToken: () => "test-token",
+    getSecurityBrowserAssessments: vi.fn(async () => snapshot),
+    createSecurityBrowserAssessment: vi.fn(async (_projectId, request) => ({
+      id: "assessment-1",
+      revision: 1,
+      engagementId: "project-1",
+      name: request.name,
+      objective: request.objective,
+      profile: request.profile,
+      sessionId: request.sessionId,
+      identityIds: request.identityIds,
+      primaryIdentityId: request.primaryIdentityId,
+      targetUrls: request.targetUrls,
+      scopePolicyId: "scope-1",
+      scopePolicyRevision: 4,
+      riskClasses: ["passive"],
+      status: "draft",
+      phase: "preflight",
+      progress: 0,
+      budget,
+      coverage: { discoveredUrls: 0, visitedUrls: 0, analyzedExchanges: 0, discoveredForms: 0, discoveredApis: 0, websocketChannels: 0 },
+      engines: snapshot.engines,
+      evidenceIds: [],
+      candidateIds: [],
+      controlOwner: "nebula",
+      createdAt: "2026-08-28T00:00:00Z",
+      updatedAt: "2026-08-28T00:00:00Z",
+    })),
+  } as unknown as ApiClient;
+}
+
+function renderPanel(client: ApiClient, desktop = true) {
+  return render(
+    <MemoryRouter initialEntries={["/project?view=browser&tool=traffic"]}>
+      <SecurityBrowserWorkspacePanel
+        api={client}
+        desktop={desktop}
+        projectId="project-1"
+        identity={identity}
+        session={session}
+        targetOptions={["https://app.example.test/"]}
+        toolNavigation={<nav><button type="button">Traffic</button></nav>}
+        onClose={() => undefined}
+      >
+        <div>Traffic tool content</div>
+      </SecurityBrowserWorkspacePanel>
+    </MemoryRouter>,
+  );
+}
+
+function assessmentWorkspace(): SecurityBrowserAssessmentWorkspace {
+  const snapshot = workspace();
+  snapshot.assessments = [{
+    id: "assessment-1", revision: 2, engagementId: "project-1", name: "Portal review",
+    objective: "Review the member portal", profile: "standard", sessionId: session.id,
+    identityIds: [identity.id], primaryIdentityId: identity.id,
+    targetUrls: ["https://app.example.test/"], scopePolicyId: "scope-1",
+    scopePolicyRevision: 4, riskClasses: ["passive"], status: "running", phase: "passive_audit",
+    progress: 0.5, budget, coverage: { discoveredUrls: 2, visitedUrls: 1, analyzedExchanges: 4, discoveredForms: 1, discoveredApis: 0, websocketChannels: 0 },
+    engines: snapshot.engines, evidenceIds: [], candidateIds: ["candidate-1"], controlOwner: "nebula",
+    createdAt: "2026-08-28T00:00:00Z", updatedAt: "2026-08-28T00:01:00Z",
+  }];
+  snapshot.candidates = [{
+    id: "candidate-1", revision: 1, assessmentId: "assessment-1", ruleId: "reflected-input",
+    checkFamily: "xss", title: "Reflected input", cwe: "CWE-79",
+    targetUrl: "https://app.example.test/search", insertionPoint: "query:q", severity: "medium",
+    confidence: "firm", evidenceIds: ["evidence-1"], validationStatus: "unvalidated",
+  }];
+  return snapshot;
+}
+
+describe("SecurityBrowserWorkspacePanel", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("walks a new operator through all five preflight decisions before creating", async () => {
+    const client = api();
+    renderPanel(client);
+    await waitFor(() => expect(screen.getByRole("button", { name: /start guided test/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: /start guided test/i }));
+    expect(screen.getByText("Where may Nebula test?")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(screen.getByText("Use one continuous browser identity")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(screen.getByText("What outcome should the test pursue?")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(screen.getByText("Choose depth and traffic risk")).toBeVisible();
+    expect(screen.getByRole("button", { name: /Validation/ })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(screen.getByText("Review before anything executes")).toBeVisible();
+    expect(screen.getByText("Scanner runtime is not prepared.")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: /create assessment/i }));
+    await waitFor(() => expect(client.createSecurityBrowserAssessment).toHaveBeenCalledWith(
+      "project-1",
+      expect.objectContaining({
+        profile: "standard",
+        targetUrls: ["https://app.example.test/"],
+        primaryIdentityId: "identity-1",
+      }),
+    ));
+  });
+
+  it("keeps mobile as a monitor surface and prevents native execution start", async () => {
+    renderPanel(api(), false);
+    await waitFor(() => expect(screen.getByText(/Monitor, approve, pause, stop, and retry/)).toBeVisible());
+    expect(screen.getByRole("button", { name: /start guided test/i })).toBeDisabled();
+    expect(screen.getByText("Traffic tool content")).toBeVisible();
+  });
+
+  it("previews and requests an explicit target-specific validation grant", async () => {
+    const snapshot = assessmentWorkspace();
+    const client = api(snapshot);
+    client.grantSecurityBrowserCandidateValidation = vi.fn(async (_candidate, request) => ({
+      id: "grant-1", revision: 1, assessmentId: "assessment-1", candidateId: "candidate-1",
+      targetUrl: "https://app.example.test/search", technique: request.technique,
+      maxRequests: request.maxRequests, requestsUsed: 0, durationSeconds: request.durationSeconds,
+      expiresAt: "2026-08-28T00:11:00Z", status: "active" as const,
+    }));
+    render(
+      <MemoryRouter initialEntries={["/project?view=browser&tool=analyze&assessment=assessment-1"]}>
+        <SecurityBrowserWorkspacePanel api={client} desktop projectId="project-1" identity={identity} session={session} targetOptions={["https://app.example.test/"]} toolNavigation={<nav><button type="button">Analyze</button></nav>} onClose={() => undefined}><div>Analyze content</div></SecurityBrowserWorkspacePanel>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Candidate issues" })).toBeVisible());
+    fireEvent.click(screen.getByRole("button", { name: /Reflected input/ }));
+    expect(screen.getByText("This authorizes exploit-validation traffic")).toBeVisible();
+    expect(screen.getByRole("button", { name: /grant bounded validation/i })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("Exact validation technique"), {
+      target: { value: "Replay the reflected query with one inert marker and a negative encoding control." },
+    });
+    expect(screen.getByText(/Up to 10 requests over 600 seconds/)).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: /grant bounded validation/i }));
+    await waitFor(() => expect(client.grantSecurityBrowserCandidateValidation).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "candidate-1" }),
+      {
+        technique: "Replay the reflected query with one inert marker and a negative encoding control.",
+        maxRequests: 10,
+        durationSeconds: 600,
+      },
+    ));
+  });
+});

--- a/ui/src/components/SecurityBrowserWorkspacePanel.tsx
+++ b/ui/src/components/SecurityBrowserWorkspacePanel.tsx
@@ -1,0 +1,437 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  AlertTriangle,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  CirclePause,
+  CirclePlay,
+  Hand,
+  LoaderCircle,
+  Plus,
+  RefreshCw,
+  ShieldCheck,
+  Square,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useSearchParams } from "react-router-dom";
+import type { ApiClient } from "../api/client";
+import { AssessmentEventStream } from "../api/assessmentEvents";
+import type {
+  SecurityBrowserAssessmentProfile,
+  SecurityBrowserAssessmentWorkspace,
+  SecurityBrowserIdentity,
+  SecurityBrowserSession,
+} from "../api/types";
+import type { StreamState } from "../api/events";
+import { logCaughtDiagnostic } from "../diagnostics";
+
+interface SecurityBrowserWorkspacePanelProps {
+  api: ApiClient;
+  desktop: boolean;
+  projectId: string;
+  identity?: SecurityBrowserIdentity;
+  session?: SecurityBrowserSession;
+  targetOptions: string[];
+  toolNavigation: ReactNode;
+  children: ReactNode;
+  onClose: () => void;
+}
+
+const PROFILE_ORDER: SecurityBrowserAssessmentProfile[] = [
+  "explore",
+  "standard",
+  "deep",
+  "api",
+  "validation",
+];
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function stateLabel(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+function percent(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+export function SecurityBrowserWorkspacePanel({
+  api,
+  desktop,
+  projectId,
+  identity,
+  session,
+  targetOptions,
+  toolNavigation,
+  children,
+  onClose,
+}: SecurityBrowserWorkspacePanelProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [workspace, setWorkspace] = useState<SecurityBrowserAssessmentWorkspace>();
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string>();
+  const [streamState, setStreamState] = useState<StreamState>("closed");
+  const [wizardOpen, setWizardOpen] = useState(false);
+  const [wizardStep, setWizardStep] = useState(0);
+  const [target, setTarget] = useState("");
+  const [objective, setObjective] = useState("");
+  const [profileId, setProfileId] = useState<SecurityBrowserAssessmentProfile>("standard");
+  const [validationTechnique, setValidationTechnique] = useState("");
+  const [validationMaxRequests, setValidationMaxRequests] = useState(10);
+  const [validationDurationSeconds, setValidationDurationSeconds] = useState(600);
+
+  const selectedId = searchParams.get("assessment") ?? undefined;
+  const selected = workspace?.assessments.find((assessment) => assessment.id === selectedId);
+  const selectedCandidateId = searchParams.get("candidate") ?? undefined;
+
+  const selectAssessment = useCallback((assessmentId?: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (assessmentId) next.set("assessment", assessmentId);
+    else next.delete("assessment");
+    next.delete("candidate");
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  const selectCandidate = useCallback((candidateId?: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (candidateId) next.set("candidate", candidateId);
+    else next.delete("candidate");
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  const refresh = useCallback(async (signal?: AbortSignal) => {
+    try {
+      const next = await api.getSecurityBrowserAssessments(projectId, signal);
+      setWorkspace(next);
+      setError(undefined);
+      if (selectedId && !next.assessments.some((item) => item.id === selectedId)) {
+        selectAssessment(next.assessments.at(-1)?.id);
+      } else if (!selectedId && next.assessments.length) {
+        selectAssessment(next.assessments.at(-1)?.id);
+      }
+    } catch (caught) {
+      if (signal?.aborted) return;
+      void logCaughtDiagnostic(
+        "interface.security_browser.assessment_snapshot_failed",
+        "The Security Browser assessment snapshot could not be loaded.",
+        caught,
+        "security_browser",
+      );
+      setError(`${message(caught)} Manual browsing remains available; retry the assessment snapshot.`);
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, [api, projectId, selectAssessment, selectedId]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    void refresh(controller.signal);
+    return () => controller.abort();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setStreamState("closed");
+      return;
+    }
+    const stream = new AssessmentEventStream({
+      apiBaseUrl: api.baseUrl,
+      token: api.getToken(),
+      assessmentId: selectedId,
+      onStateChange: setStreamState,
+      onEvent: () => void refresh(),
+    });
+    stream.connect();
+    return () => stream.disconnect();
+  }, [api, refresh, selectedId]);
+
+  useEffect(() => {
+    if (!target && targetOptions[0]) setTarget(targetOptions[0]);
+  }, [target, targetOptions]);
+
+  const profile = workspace?.profiles.find((item) => item.id === profileId);
+  const selectedSteps = useMemo(
+    () => workspace?.steps.filter((step) => step.assessmentId === selected?.id)
+      .sort((left, right) => left.sequence - right.sequence) ?? [],
+    [selected?.id, workspace?.steps],
+  );
+  const selectedCandidates = workspace?.candidates.filter(
+    (candidate) => candidate.assessmentId === selected?.id,
+  ) ?? [];
+  const selectedCandidate = selectedCandidates.find(
+    (candidate) => candidate.id === selectedCandidateId,
+  );
+  const selectedValidationGrant = workspace?.validationGrants.find(
+    (grant) => grant.id === selectedCandidate?.validationGrantId,
+  );
+
+  useEffect(() => {
+    if (selectedCandidateId && !selectedCandidate) selectCandidate(undefined);
+  }, [selectCandidate, selectedCandidate, selectedCandidateId]);
+
+  useEffect(() => {
+    setValidationTechnique("");
+    setValidationMaxRequests(10);
+    setValidationDurationSeconds(600);
+  }, [selectedCandidate?.id]);
+
+  const openWizard = () => {
+    setWizardStep(0);
+    setTarget((current) => current || targetOptions[0] || "");
+    setObjective((current) => current || `Assess ${targetOptions[0] ?? "the selected target"} and preserve reviewable evidence.`);
+    setProfileId("standard");
+    setWizardOpen(true);
+  };
+
+  const createAssessment = async () => {
+    if (!identity || !session || !target || !objective.trim() || !profile) return;
+    setBusy(true);
+    setError(undefined);
+    try {
+      const created = await api.createSecurityBrowserAssessment(projectId, {
+        name: `${profile.name} · ${new URL(target).hostname}`,
+        objective: objective.trim(),
+        profile: profile.id,
+        sessionId: session.id,
+        identityIds: [identity.id],
+        primaryIdentityId: identity.id,
+        targetUrls: [target],
+        budget: profile.defaultBudget,
+      });
+      setWizardOpen(false);
+      selectAssessment(created.id);
+      await refresh();
+    } catch (caught) {
+      void logCaughtDiagnostic(
+        "interface.security_browser.assessment_create_failed",
+        "The guided Security Browser assessment could not be created.",
+        caught,
+        "security_browser",
+      );
+      setError(`${message(caught)} No assessment or browser execution was started.`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const transition = async (
+    action: Parameters<ApiClient["transitionSecurityBrowserAssessment"]>[1],
+    options?: { reason?: string; recoveryAction?: string },
+  ) => {
+    if (!selected) return;
+    setBusy(true);
+    setError(undefined);
+    try {
+      await api.transitionSecurityBrowserAssessment(selected, action, options);
+      await refresh();
+    } catch (caught) {
+      void logCaughtDiagnostic(
+        "interface.security_browser.assessment_transition_failed",
+        `The Security Browser assessment could not ${action}.`,
+        caught,
+        "security_browser",
+      );
+      setError(`${message(caught)} The live browser remains usable; refresh readiness or retry the valid action.`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const refreshReadiness = async () => {
+    if (!selected) return;
+    setBusy(true);
+    try {
+      await api.refreshSecurityBrowserAssessmentReadiness(selected);
+      await refresh();
+    } catch (caught) {
+      void logCaughtDiagnostic(
+        "interface.security_browser.assessment_readiness_failed",
+        "The Security Browser assessment readiness could not be refreshed.",
+        caught,
+        "security_browser",
+      );
+      setError(`${message(caught)} Manual legacy browsing remains available.`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const deleteSelected = async () => {
+    if (!selected) return;
+    setBusy(true);
+    try {
+      await api.deleteSecurityBrowserAssessment(selected);
+      selectAssessment(undefined);
+      await refresh();
+    } catch (caught) {
+      void logCaughtDiagnostic(
+        "interface.security_browser.assessment_delete_failed",
+        "The Security Browser assessment could not be deleted.",
+        caught,
+        "security_browser",
+      );
+      setError(`${message(caught)} Stop or revoke the assessment, then retry deletion.`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const grantValidation = async () => {
+    if (!selectedCandidate || !validationTechnique.trim()) return;
+    setBusy(true);
+    setError(undefined);
+    try {
+      await api.grantSecurityBrowserCandidateValidation(selectedCandidate, {
+        technique: validationTechnique.trim(),
+        maxRequests: validationMaxRequests,
+        durationSeconds: validationDurationSeconds,
+      });
+      await refresh();
+    } catch (caught) {
+      void logCaughtDiagnostic(
+        "interface.security_browser.validation_grant_failed",
+        "The Security Browser validation grant could not be created.",
+        caught,
+        "security_browser",
+      );
+      setError(`${message(caught)} The issue remains an unvalidated candidate; review its target-specific exploitation grant and retry from this detail.`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const revokeValidation = async () => {
+    if (!selectedCandidate || !selectedValidationGrant) return;
+    setBusy(true);
+    setError(undefined);
+    try {
+      await api.revokeSecurityBrowserCandidateValidation(
+        selectedCandidate,
+        selectedValidationGrant,
+        "Emergency revocation requested by the operator from issue detail.",
+      );
+      await refresh();
+    } catch (caught) {
+      void logCaughtDiagnostic(
+        "interface.security_browser.validation_revoke_failed",
+        "The Security Browser validation grant could not be revoked.",
+        caught,
+        "security_browser",
+      );
+      setError(`${message(caught)} Validation remains visibly bounded by its existing expiry; stop the assessment for the broader emergency kill switch.`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const wizardPages = [
+    <section key="target" className="security-browser-wizard-page">
+      <span className="security-browser-wizard-kicker">1 · Target</span>
+      <h3>Where may Nebula test?</h3>
+      <p>Choose an enumerated Project target. The saved assessment freezes the current scope revision.</p>
+      <label>Authorized target<select value={target} onChange={(event) => setTarget(event.target.value)}><option value="">Choose a target</option>{targetOptions.map((option) => <option key={option} value={option}>{option}</option>)}</select></label>
+      {!targetOptions.length && <div className="security-browser-callout warning" role="alert"><AlertTriangle size={16} /> No HTTP target is available. Add a URL or domain to Project scope, then return here.</div>}
+    </section>,
+    <section key="identity" className="security-browser-wizard-page">
+      <span className="security-browser-wizard-kicker">2 · Identity and login</span>
+      <h3>Use one continuous browser identity</h3>
+      <p>Manual takeover and autonomous work share this identity, cookies, traffic history, and evidence chain.</p>
+      <dl><div><dt>Identity</dt><dd>{identity?.name ?? "No identity selected"}</dd></div><div><dt>Session</dt><dd>{session?.name ?? "No session selected"}</dd></div><div><dt>Login handling</dt><dd>Take over for login, MFA, CAPTCHA, consent, or ambiguity.</dd></div></dl>
+    </section>,
+    <section key="objective" className="security-browser-wizard-page">
+      <span className="security-browser-wizard-kicker">3 · Objective</span>
+      <h3>What outcome should the test pursue?</h3>
+      <p>Keep the goal concrete. Nebula will show a reviewable staged plan before execution.</p>
+      <label>Assessment goal<textarea rows={5} maxLength={4000} value={objective} onChange={(event) => setObjective(event.target.value)} /></label>
+    </section>,
+    <section key="profile" className="security-browser-wizard-page">
+      <span className="security-browser-wizard-kicker">4 · Test profile</span>
+      <h3>Choose depth and traffic risk</h3>
+      <div className="security-browser-profile-grid">{PROFILE_ORDER.map((id) => {
+        const option = workspace?.profiles.find((item) => item.id === id);
+        if (!option) return null;
+        const locked = option.validationLocked;
+        return <button key={id} type="button" className={profileId === id ? "selected" : ""} disabled={locked} onClick={() => setProfileId(id)} aria-pressed={profileId === id}><strong>{option.name}</strong><span>{option.summary}</span>{locked && <small>Start from an issue and request a bounded validation grant.</small>}</button>;
+      })}</div>
+    </section>,
+    <section key="review" className="security-browser-wizard-page">
+      <span className="security-browser-wizard-kicker">5 · Scope, risk, and budget</span>
+      <h3>Review before anything executes</h3>
+      <dl><div><dt>Target</dt><dd>{target || "Not selected"}</dd></div><div><dt>Identity</dt><dd>{identity?.name ?? "Unavailable"}</dd></div><div><dt>Profile</dt><dd>{profile?.name ?? "Unavailable"}</dd></div><div><dt>Risk</dt><dd>{profile?.riskClasses.join(", ") || "None"}</dd></div><div><dt>Request budget</dt><dd>{profile?.defaultBudget.maxRequests ?? 0}</dd></div><div><dt>Duration</dt><dd>{Math.round((profile?.defaultBudget.maxDurationSeconds ?? 0) / 60)} minutes</dd></div></dl>
+      <div className="security-browser-engine-review">{profile?.requiredAdapters.map((adapter) => {
+        const engine = workspace?.engines.find((item) => item.adapter === adapter);
+        return <div key={adapter} className={`engine-${engine?.state ?? "unavailable"}`}><span>{engine?.state === "ready" ? <Check size={14} /> : <AlertTriangle size={14} />}</span><div><strong>{engine?.displayName ?? adapter}</strong><small>{engine?.state === "ready" ? `${engine.installedVersion ?? "Installed"} · contract v${engine.contractVersion}` : engine?.unavailabilityReason ?? "Runtime status unavailable"}</small></div></div>;
+      })}</div>
+      <p>Creating the assessment stores preflight and plan state. Execution starts separately and remains blocked until every required adapter reports ready.</p>
+    </section>,
+  ];
+
+  return <aside className="browser-research-panel security-browser-workspace" aria-label="Security Browser workspace">
+    <header>
+      <div><strong>Security Browser</strong><small>Guided assessments, live browser, evidence, and expert tools</small></div>
+      <div className="security-browser-header-actions"><span className={`security-browser-stream stream-${streamState}`}>{stateLabel(streamState)}</span><button type="button" aria-label="Close Security Browser" onClick={onClose}><X size={17} /></button></div>
+    </header>
+    {error && <div className="security-browser-error" role="alert"><AlertTriangle size={16} /><span>{error}</span><button type="button" onClick={() => void refresh()}><RefreshCw size={14} /> Retry</button></div>}
+    <div className="security-browser-layout">
+      <aside className="security-browser-assessment-rail" aria-label="Assessments">
+        <button className="button primary" type="button" disabled={!desktop || !identity || !session} onClick={openWizard}><Plus size={15} /> Start guided test</button>
+        {!desktop && <p>Monitor, approve, pause, stop, and retry here. Start and live traffic editing stay on the paired desktop.</p>}
+        <div className="security-browser-assessment-list">
+          {loading ? <span className="security-browser-loading"><LoaderCircle className="spin" size={15} /> Loading assessments…</span> : workspace?.assessments.length ? [...workspace.assessments].reverse().map((assessment) => <button key={assessment.id} type="button" className={assessment.id === selected?.id ? "selected" : ""} onClick={() => selectAssessment(assessment.id)}><span className={`security-browser-status status-${assessment.status}`}>{stateLabel(assessment.status)}</span><strong>{assessment.name}</strong><small>{assessment.targetUrls[0]}</small><span>{percent(assessment.progress)} · {stateLabel(assessment.phase)}</span></button>) : <div className="security-browser-empty"><ShieldCheck size={20} /><strong>No assessments yet</strong><span>Start guided test to freeze scope, identity, profile, and budget.</span></div>}
+        </div>
+      </aside>
+      <section className="security-browser-main">
+        {selected ? <div className="security-browser-run-summary">
+          <header><div><span className={`security-browser-status status-${selected.status}`}>{stateLabel(selected.status)}</span><h2>{selected.name}</h2><p>{selected.objective}</p></div><div className="security-browser-run-controls">
+            {selected.status === "ready" && <button className="button primary" type="button" disabled={!desktop || busy} onClick={() => void transition("start")}><CirclePlay size={15} /> Start</button>}
+            {selected.status === "running" && <><button className="button secondary" type="button" disabled={busy} onClick={() => void transition("takeover", { reason: "Operator requested control of the live browser." })}><Hand size={15} /> Take over</button><button className="button secondary" type="button" disabled={busy} onClick={() => void transition("pause", { reason: "Paused by operator." })}><CirclePause size={15} /> Pause</button><button className="button danger" type="button" disabled={busy} onClick={() => void transition("stop")}><Square size={14} /> Stop</button></>}
+            {selected.status === "waiting_operator" && <button className="button primary" type="button" disabled={!desktop || busy} onClick={() => void transition("return_control")}><CirclePlay size={15} /> Return control to Nebula</button>}
+            {selected.status === "paused" && <><button className="button primary" type="button" disabled={!desktop || busy} onClick={() => void transition("resume")}><CirclePlay size={15} /> Resume</button><button className="button danger" type="button" disabled={busy} onClick={() => void transition("stop")}><Square size={14} /> Stop</button></>}
+            {selected.status === "draft" && <button className="button secondary" type="button" disabled={busy} onClick={() => void refreshReadiness()}><RefreshCw size={14} /> Prepare / Retry</button>}
+            {["failed", "stopped"].includes(selected.status) && <button className="button secondary" type="button" disabled={busy} onClick={() => void transition("retry")}><RefreshCw size={14} /> Retry preflight</button>}
+          </div></header>
+          {(selected.pauseReason || selected.failure) && <div className="security-browser-callout warning"><AlertTriangle size={16} /><div><strong>{selected.failure ? "Assessment failed" : "Action required"}</strong><span>{selected.failure ?? selected.pauseReason}</span><small>{selected.recoveryAction ?? "The live browser and saved evidence remain usable."}</small></div></div>}
+          <div className="security-browser-metrics"><div><span>Phase</span><strong>{stateLabel(selected.phase)}</strong></div><div><span>Coverage</span><strong>{selected.coverage.visitedUrls} / {selected.coverage.discoveredUrls} URLs</strong></div><div><span>Requests</span><strong>{selected.budget.requestsUsed} / {selected.budget.maxRequests}</strong></div><div><span>Candidates</span><strong>{selectedCandidates.length}</strong></div><div><span>Control</span><strong>{selected.controlOwner}</strong></div></div>
+          <div className="security-browser-progress" aria-label={`${percent(selected.progress)} complete`}><span style={{ width: percent(selected.progress) }} /></div>
+          <details><summary>Proposed plan · {selectedSteps.length} steps</summary><ol>{selectedSteps.map((step) => <li key={step.id}><span className={`security-browser-step step-${step.status}`}>{stateLabel(step.status)}</span><div><strong>{step.title}</strong><small>{step.intent}</small>{step.error && <em>{step.error} {step.recoveryAction}</em>}</div></li>)}</ol></details>
+          {selectedCandidates.length > 0 && <section className="security-browser-candidates" aria-labelledby="security-browser-candidates-title">
+            <header><div><h3 id="security-browser-candidates-title">Candidate issues</h3><p>Candidate status is separate from Findings. Validation requires evidence and never promotes automatically.</p></div><span>{selectedCandidates.length}</span></header>
+            <div className="security-browser-candidate-layout">
+              <div className="security-browser-candidate-list">{selectedCandidates.map((candidate) => <button key={candidate.id} type="button" className={candidate.id === selectedCandidate?.id ? "selected" : ""} onClick={() => selectCandidate(candidate.id)} aria-pressed={candidate.id === selectedCandidate?.id}><span className={`security-browser-status status-${candidate.validationStatus}`}>{stateLabel(candidate.validationStatus)}</span><strong>{candidate.title}</strong><small>{candidate.severity} · {candidate.confidence}</small></button>)}</div>
+              {selectedCandidate && <article className="security-browser-candidate-detail">
+                <header><div><span className={`security-browser-status status-${selectedCandidate.validationStatus}`}>{stateLabel(selectedCandidate.validationStatus)}</span><h4>{selectedCandidate.title}</h4></div><button type="button" aria-label="Close candidate detail" onClick={() => selectCandidate(undefined)}><X size={15} /></button></header>
+                <dl><div><dt>Target</dt><dd><code>{selectedCandidate.targetUrl}</code></dd></div><div><dt>Insertion point</dt><dd>{selectedCandidate.insertionPoint ?? "Whole request"}</dd></div><div><dt>Check</dt><dd>{selectedCandidate.ruleId}{selectedCandidate.cwe ? ` · ${selectedCandidate.cwe}` : ""}</dd></div><div><dt>Evidence</dt><dd>{selectedCandidate.evidenceIds.length} retained item{selectedCandidate.evidenceIds.length === 1 ? "" : "s"}</dd></div></dl>
+                {selectedValidationGrant ? <div className="security-browser-grant-status"><div className="security-browser-callout warning" role="status"><ShieldCheck size={16} /><div><strong>{selectedValidationGrant.status === "active" && new Date(selectedValidationGrant.expiresAt).getTime() > Date.now() ? "Bounded validation authorized" : `Validation grant ${selectedValidationGrant.status === "active" ? "expired" : selectedValidationGrant.status}`}</strong><span>{selectedValidationGrant.technique}</span><small>Up to {selectedValidationGrant.maxRequests} requests over {selectedValidationGrant.durationSeconds} seconds to this target only; expires {new Date(selectedValidationGrant.expiresAt).toLocaleString()}.</small></div></div>{selectedValidationGrant.status === "active" && new Date(selectedValidationGrant.expiresAt).getTime() > Date.now() && <button className="button danger" type="button" disabled={busy} onClick={() => void revokeValidation()}><Square size={14} /> Revoke validation now</button>}</div> : <div className="security-browser-validation-form">
+                  <div className="security-browser-callout warning" role="alert"><AlertTriangle size={16} /><div><strong>This authorizes exploit-validation traffic</strong><span>Name one exact technique. Nebula will still enforce the frozen target, duration, request budget, and emergency revocation independently.</span></div></div>
+                  <label>Exact validation technique<textarea rows={3} maxLength={1000} value={validationTechnique} onChange={(event) => setValidationTechnique(event.target.value)} placeholder="Describe the probe and its negative control without placing secrets here." /></label>
+                  <div className="security-browser-validation-budget"><label>Maximum requests<input type="number" min={1} max={10000} value={validationMaxRequests} onChange={(event) => setValidationMaxRequests(Number(event.target.value))} /></label><label>Duration (seconds)<input type="number" min={30} max={3600} value={validationDurationSeconds} onChange={(event) => setValidationDurationSeconds(Number(event.target.value))} /></label></div>
+                  <div className="security-browser-traffic-preview"><strong>Expected traffic</strong><span>Up to {validationMaxRequests} requests over {validationDurationSeconds} seconds to <code>{selectedCandidate.targetUrl}</code> through the policy path.</span></div>
+                  <button className="button danger" type="button" disabled={busy || !validationTechnique.trim() || validationMaxRequests < 1 || validationMaxRequests > 10000 || validationDurationSeconds < 30 || validationDurationSeconds > 3600} onClick={() => void grantValidation()}><ShieldCheck size={15} /> Grant bounded validation</button>
+                </div>}
+              </article>}
+            </div>
+          </section>}
+          {selected.status !== "running" && <button className="security-browser-delete" type="button" disabled={busy} onClick={() => void deleteSelected()}><Trash2 size={13} /> Delete assessment metadata</button>}
+        </div> : <div className="security-browser-welcome"><ShieldCheck size={28} /><h2>One workspace for manual and autonomous testing</h2><p>Select an assessment or start a guided test. Browser identity, traffic, frozen scope, evidence, and candidate review remain connected.</p></div>}
+        <div className="security-browser-tool-dock">
+          {toolNavigation}
+          <div className="security-browser-tool-content">{children}</div>
+        </div>
+      </section>
+    </div>
+    {wizardOpen && <div className="security-browser-wizard-backdrop" role="presentation">
+      <div className="security-browser-wizard" role="dialog" aria-modal="true" aria-labelledby="security-browser-wizard-title">
+        <header><div><span>Guided test preflight</span><strong id="security-browser-wizard-title">{["Target", "Identity and login", "Objective", "Test profile", "Final review"][wizardStep]}</strong></div><button type="button" aria-label="Close guided test" onClick={() => setWizardOpen(false)}><X size={17} /></button></header>
+        <div className="security-browser-wizard-steps" aria-label={`Step ${wizardStep + 1} of 5`}>{[0, 1, 2, 3, 4].map((step) => <span key={step} className={step <= wizardStep ? "active" : ""}>{step + 1}</span>)}</div>
+        {wizardPages[wizardStep]}
+        <footer><button className="button secondary" type="button" disabled={wizardStep === 0 || busy} onClick={() => setWizardStep((step) => step - 1)}><ChevronLeft size={15} /> Back</button>{wizardStep < 4 ? <button className="button primary" type="button" disabled={(wizardStep === 0 && !target) || (wizardStep === 1 && (!identity || !session)) || (wizardStep === 2 && !objective.trim())} onClick={() => setWizardStep((step) => step + 1)}>Continue <ChevronRight size={15} /></button> : <button className="button primary" type="button" disabled={busy || !target || !identity || !session || !profile} onClick={() => void createAssessment()}>{busy ? <LoaderCircle className="spin" size={15} /> : <Check size={15} />} Create assessment</button>}</footer>
+      </div>
+    </div>}
+  </aside>;
+}

--- a/ui/src/components/WorkbenchBrowser.tsx
+++ b/ui/src/components/WorkbenchBrowser.tsx
@@ -29,9 +29,16 @@ import type { NebulaDraftRequest } from "../state/WorkbenchDraftContext";
 import { useConfirmation, useDialogOpen } from "./DialogSystem";
 import { aiRuntimeLabel, aiRuntimeOptions } from "./aiRuntimes";
 import { BrowserResearchSuite, type BrowserResearchToolView } from "./BrowserResearchSuite";
+import { SecurityBrowserWorkspacePanel } from "./SecurityBrowserWorkspacePanel";
 
-type ResearchView = "traffic" | "actions" | "identities" | "session" | BrowserResearchToolView;
-const RESEARCH_VIEWS = new Set<ResearchView>(["target", "traffic", "intercepts", "repeater", "intruder", "utilities", "actions", "identities", "session"]);
+type ResearchView = "target" | "traffic" | "intercepts" | "repeater" | "automate" | "analyze" | "actions" | "identities" | "session";
+const RESEARCH_VIEWS = new Set<ResearchView>(["target", "traffic", "intercepts", "repeater", "automate", "analyze", "actions", "identities", "session"]);
+
+function normalizedResearchView(value: string | null): ResearchView {
+  if (value === "intruder") return "automate";
+  if (value === "utilities") return "analyze";
+  return value && RESEARCH_VIEWS.has(value as ResearchView) ? value as ResearchView : "traffic";
+}
 
 interface BrowserTab {
   id: string;
@@ -157,10 +164,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   const [workspaceError, setWorkspaceError] = useState<string>();
   const [sessionId, setSessionId] = useState<string | undefined>(() => searchParams.get("browserSession") ?? undefined);
   const [researchOpen, setResearchOpen] = useState(false);
-  const [researchView, setResearchView] = useState<ResearchView>(() => {
-    const requested = searchParams.get("browserTool") as ResearchView | null;
-    return requested && RESEARCH_VIEWS.has(requested) ? requested : "traffic";
-  });
+  const [researchView, setResearchView] = useState<ResearchView>(() => normalizedResearchView(searchParams.get("tool") ?? searchParams.get("browserTool")));
   const [selectedExchangeIds, setSelectedExchangeIds] = useState<string[]>([]);
   const [identityName, setIdentityName] = useState("");
   const [identityBusy, setIdentityBusy] = useState(false);
@@ -186,7 +190,8 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
     // another view, while avoiding stale-hook races when Browser is entered.
     if (current.get("view") !== "browser") return;
     const next = new URLSearchParams(current);
-    next.set("browserTool", researchView);
+    next.set("tool", researchView);
+    next.delete("browserTool");
     if (sessionId) next.set("browserSession", sessionId); else next.delete("browserSession");
     if (activeId) next.set("browserTab", activeId); else next.delete("browserTab");
     if (next.toString() !== current.toString()) setSearchParams(next, { replace: true });
@@ -1598,23 +1603,27 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
     bytes: selectedExchanges[0].responseBytes === selectedExchanges[1].responseBytes ? "same" : `${selectedExchanges[0].responseBytes ?? "—"} → ${selectedExchanges[1].responseBytes ?? "—"}`,
   } : undefined;
 
-  const researchPanel = researchOpen ? <aside className="browser-research-panel" aria-label="Security research workbench">
-    <header>
-      <div><strong>Research workbench</strong><small>{activeSession?.name ?? "Loading durable session"} · {activeIdentity?.name ?? "No identity"}</small></div>
-      <button type="button" aria-label="Close research workbench" onClick={() => setResearchOpen(false)}><X size={15} /></button>
-    </header>
-    <nav aria-label="Research tools">
+  const researchPanel = researchOpen ? <SecurityBrowserWorkspacePanel
+    api={api}
+    desktop={desktop}
+    projectId={projectId}
+    identity={activeIdentity}
+    session={activeSession}
+    targetOptions={automationTargetOptions}
+    onClose={() => setResearchOpen(false)}
+    toolNavigation={<nav aria-label="Security Browser tools">
       <button type="button" className={researchView === "target" ? "active" : ""} onClick={() => setResearchView("target")}>Target</button>
-      <button type="button" className={researchView === "traffic" ? "active" : ""} onClick={() => setResearchView("traffic")}><Network size={14} /> Proxy <span>{sessionTraffic.length}</span></button>
+      <button type="button" className={researchView === "traffic" ? "active" : ""} onClick={() => setResearchView("traffic")}><Network size={14} /> Traffic <span>{sessionTraffic.length}</span></button>
       <button type="button" className={researchView === "intercepts" ? "active" : ""} onClick={() => setResearchView("intercepts")}>Intercept</button>
       <button type="button" className={researchView === "repeater" ? "active" : ""} onClick={() => setResearchView("repeater")}>Repeater</button>
-      <button type="button" className={researchView === "intruder" ? "active" : ""} onClick={() => setResearchView("intruder")}>Intruder</button>
-      <button type="button" className={researchView === "utilities" ? "active" : ""} onClick={() => setResearchView("utilities")}>Decoder · Comparer · Sequencer</button>
+      <button type="button" className={researchView === "automate" ? "active" : ""} onClick={() => setResearchView("automate")}>Automate <small>Intruder</small></button>
+      <button type="button" className={researchView === "analyze" ? "active" : ""} onClick={() => setResearchView("analyze")}>Analyze</button>
       <button type="button" className={researchView === "actions" ? "active" : ""} onClick={() => setResearchView("actions")}><Sparkles size={14} /> Actions <span>{workspace?.actions.filter((action) => action.sessionId === activeSession?.id).length ?? 0}</span></button>
       <button type="button" className={researchView === "identities" ? "active" : ""} onClick={() => setResearchView("identities")}><UserRound size={14} /> Identities <span>{workspace?.identities.length ?? 0}</span></button>
       <button type="button" className={researchView === "session" ? "active" : ""} onClick={() => setResearchView("session")}><History size={14} /> Session</button>
-    </nav>
-    {workspaceLoading ? <div className="browser-research-empty"><LoaderCircle className="spin" size={18} /> Loading durable browser state…</div> : workspaceError ? <div className="browser-research-empty error" role="alert"><strong>Research state is unavailable</strong><span>{workspaceError}</span><button className="button secondary" type="button" onClick={() => void refreshWorkspace()}>Try again</button></div> : (["target", "intercepts", "repeater", "intruder", "utilities"] as const).includes(researchView as BrowserResearchToolView) ? <BrowserResearchSuite api={api} desktop={desktop} identity={activeIdentity} operatorId={operatorId} projectId={projectId} session={activeSession} view={researchView as BrowserResearchToolView} /> : researchView === "traffic" ? <div className="browser-traffic-workbench">
+    </nav>}
+  >
+    {workspaceLoading ? <div className="browser-research-empty"><LoaderCircle className="spin" size={18} /> Loading durable browser state…</div> : workspaceError ? <div className="browser-research-empty error" role="alert"><strong>Research state is unavailable</strong><span>{workspaceError}</span><button className="button secondary" type="button" onClick={() => void refreshWorkspace()}>Try again</button></div> : (["target", "intercepts", "repeater"] as const).includes(researchView as "target" | "intercepts" | "repeater") || researchView === "automate" || researchView === "analyze" ? <BrowserResearchSuite api={api} desktop={desktop} identity={activeIdentity} operatorId={operatorId} projectId={projectId} session={activeSession} view={(researchView === "automate" ? "intruder" : researchView === "analyze" ? "utilities" : researchView) as BrowserResearchToolView} /> : researchView === "traffic" ? <div className="browser-traffic-workbench">
       <div className="browser-research-toolbar"><span>Metadata and redacted headers</span><button type="button" disabled={selectedExchangeIds.length !== 2} onClick={() => setSelectedExchangeIds([])}><GitCompareArrows size={13} /> {selectedExchangeIds.length === 2 ? "Clear comparison" : "Select two to compare"}</button></div>
       {comparison && <div className="browser-exchange-diff"><strong>Authorization response diff</strong><span>Status: {comparison.status}</span><span>Bytes: {comparison.bytes}</span><span>{comparison.changedHeaders.length ? `${comparison.changedHeaders.length} response headers changed: ${comparison.changedHeaders.join(", ")}` : "Response headers are identical."}</span></div>}
       {sessionTraffic.length ? <ol className="browser-traffic-list">{[...sessionTraffic].reverse().map((exchange) => <li key={exchange.id} className={selectedExchangeIds.includes(exchange.id) ? "selected" : ""}>
@@ -1677,7 +1686,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
       {desktop && capabilities?.devtools && <button className="button secondary" type="button" disabled={!activeTab?.created} onClick={() => activeTab && void workbenchBrowser.openDevtools(activeTab.id, projectId).catch((caught) => { void logCaughtDiagnostic("interface.security_browser.devtools_open_failed", "Browser DevTools could not be opened.", caught, "workbench_browser"); setError(errorMessage(caught)); })}><Bug size={14} /> Open DevTools</button>}
       {!desktop && activeSession && activeTab?.url && <button className="button primary" type="button" onClick={() => void api.createSecurityBrowserHandoff(activeSession.id, { requestedByDeviceId: "paired-browser", command: "navigate", tabId: activeTab.id, url: activeTab.url }).then(() => { setNotice({ kind: "info", message: "Navigation queued for the desktop browser for five minutes." }); return refreshWorkspace(); }).catch((caught) => { void logCaughtDiagnostic("interface.security_browser.handoff_create_failed", "A browser navigation handoff could not be queued for the desktop.", caught, "workbench_browser"); setWorkspaceError(errorMessage(caught)); })}>Send page to desktop</button>}
     </div>}
-  </aside> : null;
+  </SecurityBrowserWorkspacePanel> : null;
 
   if (!desktop) return <div className={`workbench-browser web-browser-fallback${researchOpen ? " research-open" : ""}`}>
     <div className="browser-web-research-bar"><button className="button secondary" type="button" aria-expanded={researchOpen} onClick={() => setResearchOpen((value) => !value)}><Network size={14} /> Research workbench</button><span>Durable history and desktop handoff are available on paired devices.</span></div>

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -280,6 +280,27 @@ async function installTruthfulCore(page: Page) {
         actions: [],
         handoffs: [],
       };
+    } else if (path.endsWith("/engagements/scratch-project/browser-assessments")) {
+      const budget = { max_requests: 2000, max_actions: 500, max_duration_seconds: 3600, max_concurrency: 2, requests_used: 0, actions_used: 0 };
+      body = {
+        assessments: [],
+        steps: [],
+        login_flows: [],
+        recipes: [],
+        candidates: [],
+        validation_grants: [],
+        profiles: [
+          { id: "explore", name: "Explore", summary: "Guided manual exploration.", risk_classes: ["passive"], required_adapters: ["managed-chromium"], default_budget: budget, validation_locked: false },
+          { id: "standard", name: "Standard", summary: "Crawl and passive analysis.", risk_classes: ["passive"], required_adapters: ["managed-chromium", "zap"], default_budget: budget, validation_locked: false },
+          { id: "deep", name: "Deep", summary: "Bounded active checks.", risk_classes: ["passive", "active_scan"], required_adapters: ["managed-chromium", "zap"], default_budget: budget, validation_locked: false },
+          { id: "api", name: "API", summary: "API import and testing.", risk_classes: ["passive", "active_scan"], required_adapters: ["managed-chromium", "zap"], default_budget: budget, validation_locked: false },
+          { id: "validation", name: "Validation", summary: "Issue-specific validation.", risk_classes: ["exploitation"], required_adapters: ["managed-chromium"], default_budget: budget, validation_locked: true },
+        ],
+        engines: [
+          { adapter: "managed-chromium", display_name: "Managed Chromium", contract_version: "1", state: "unavailable", installed_version: null, digest: null, actions: [], protocols: [], check_families: [], unavailability_reason: "Managed runtime is not prepared.", recovery_action: "Prepare the managed browser runtime.", desktop_only: true },
+          { adapter: "legacy-webview", display_name: "Legacy system WebView", contract_version: "1", state: "degraded", installed_version: null, digest: null, actions: ["manual.navigate"], protocols: ["http", "https"], check_families: [], unavailability_reason: "Manual-only fallback.", recovery_action: "Prepare Managed Chromium.", desktop_only: true },
+        ],
+      };
     } else if (path.endsWith("/engagements/scratch-project/browser-research")) {
       body = {
         site_nodes: [],
@@ -4725,7 +4746,7 @@ test("browser research tools expose durable workflows on paired clients", async 
   await page.getByText("Result history (1)").click();
   await expect(page.getByText("128 bytes", { exact: false })).toBeVisible();
 
-  await page.getByRole("button", { name: "Intruder", exact: true }).click();
+  await page.getByRole("button", { name: /Automate/ }).click();
   await expect(page.getByRole("heading", { name: "Intruder" })).toBeVisible();
   await expect(page.getByLabel("Position names")).toBeVisible();
   await expect(page.locator("label", { hasText: "Payload sets" }).locator("small")).toContainText("separate sets with a line containing only");

--- a/ui/tests/real-core.spec.ts
+++ b/ui/tests/real-core.spec.ts
@@ -647,6 +647,27 @@ test("real Core Browser shows durable scope and an honest device-browser handoff
       expected_revision: scope.revision,
     } });
     expect(update.ok(), await update.text()).toBe(true);
+    const browserWorkspaceResponse = await api.get(`engagements/${projectId}/browser-workspace`);
+    expect(browserWorkspaceResponse.ok(), await browserWorkspaceResponse.text()).toBe(true);
+    const browserWorkspace = await browserWorkspaceResponse.json() as {
+      identities: Array<{ id: string }>;
+      sessions: Array<{ id: string }>;
+    };
+    const assessmentResponse = await api.post(
+      `engagements/${projectId}/browser-assessments`,
+      { data: {
+        name: "LAN guided assessment",
+        objective: "Map the authorized account surface and preserve evidence.",
+        profile: "explore",
+        session_id: browserWorkspace.sessions[0].id,
+        identity_ids: [browserWorkspace.identities[0].id],
+        primary_identity_id: browserWorkspace.identities[0].id,
+        target_urls: ["https://example.com/"],
+      } },
+    );
+    expect(assessmentResponse.ok(), await assessmentResponse.text()).toBe(true);
+    const assessment = await assessmentResponse.json() as { id: string; status: string };
+    expect(assessment.status).toBe("draft");
 
     await page.addInitScript(() => {
       window.open = () => ({}) as Window;
@@ -663,6 +684,10 @@ test("real Core Browser shows durable scope and an honest device-browser handoff
     await expect(page.getByRole("button", { name: "Ask Nebula about the live page" })).toHaveCount(0);
 
     await page.getByRole("button", { name: "Research workbench" }).click();
+    await expect(page.getByRole("heading", { name: "LAN guided assessment" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Prepare / Retry" })).toBeVisible();
+    await expect(page.getByText(/Manual legacy browsing remains available/)).toBeVisible();
+    await expect.poll(() => new URL(page.url()).searchParams.get("assessment")).toBe(assessment.id);
     await page.getByRole("button", { name: "Repeater", exact: true }).click();
     await expect(page.getByRole("heading", { name: "Repeater" })).toBeVisible();
     await page.getByLabel("Name").fill("Durable account request");
@@ -674,6 +699,8 @@ test("real Core Browser shows durable scope and an honest device-browser handoff
     await page.goto(`${core.origin}/?view=browser&browserTool=repeater#token=${encodeURIComponent(core.token)}`);
     await expect(page.getByRole("button", { name: "Nebula Core ready" })).toBeVisible({ timeout: 20_000 });
     await page.getByRole("button", { name: "Research workbench" }).click();
+    await expect.poll(() => new URL(page.url()).searchParams.get("tool")).toBe("repeater");
+    expect(new URL(page.url()).searchParams.has("browserTool")).toBe(false);
     await page.getByRole("button", { name: "Repeater", exact: true }).click();
     await expect(page.getByText("Durable account request", { exact: true })).toBeVisible();
     expect(new URL(page.url()).hostname).toBe(lanAddress);


### PR DESCRIPTION
## Summary

- promote the browser research drawer into a guided Security Browser workspace with URL-authoritative assessment and tool selection
- add durable Core assessment, step, candidate, validation-grant, event replay, and WebSocket contracts
- add the versioned managed-browser adapter and loopback-authenticated nebula-browserd with full-Chromium provenance checks and durable action tokens
- stage full Chromium packaging metadata and add a real browserd smoke journey
- retain legacy manual browsing as an honest degraded fallback while managed/scanner capabilities are unavailable

This is the first mergeable foundation of the staged Security Browser program. It does not claim completion of the full five-stage plan.

## Verification

- poetry run pytest -q tests/v3: 695 passed, 5 skipped
- npm --prefix ui test -- --testTimeout=15000: 362 passed
- Ruff check and format plus mypy: passed
- npm --prefix ui run audit:diagnostics: zero unclassified catches
- npm --prefix ui run audit:css: passed
- npm --prefix ui run build: production bundle passed
- production Playwright browser workflow: 9 passed across desktop 1440/1024/390, mobile Chromium 320/390/430, and mobile WebKit 320/390/430
- real-Core Browser workflow: 1 passed through a non-loopback LAN origin using the production bundle
- browserd staged full-Chromium smoke: passed; digest sha256:2d18db9d8608b052b6a552ee00ec1e830f93692e928b65ecc67d693bd33fe801; duplicate action receipt recovered; paused action cancelled
- poetry check and poetry build: passed

## Remaining release gates

- packaged headed Linux Tauri workflow was not run
- no physical paired-phone journey was run
- ZAP adapter, recipe breadth, full expert traffic tooling, deterministic vulnerability canaries, 20-repetition reliability campaign, 100k-history performance gate, and 60-minute soak are future stages

These gaps prevent an unqualified production-ready or full-plan-complete claim.