### PR TITLE
Render Markdown while assistant responses stream

### DIFF
--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -1003,14 +1003,13 @@ kbd { font-size: 11px; }
   .chat-message-actions .icon-button { width: 44px; height: 44px; }
 }
 @media (prefers-reduced-motion: reduce) { .chat-message-actions { transition: none; } }
-.assistant-streaming-text { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
-.assistant-streaming-text::after { content: ""; display: inline-block; width: 2px; height: 1em; margin-left: 3px; border-radius: var(--radius-control); vertical-align: -2px; background: var(--blue); animation: assistant-stream-caret 1s steps(2, jump-none) infinite; }
+.assistant-markdown.streaming::after { content: ""; display: inline-block; width: 2px; height: 1em; margin-left: 3px; border-radius: var(--radius-control); vertical-align: -2px; background: var(--blue); animation: assistant-stream-caret 1s steps(2, jump-none) infinite; }
 .assistant-commentary { display: grid; gap: 12px; margin: 0 0 12px; padding-left: 12px; border-left: 2px solid var(--border); }
 .assistant-commentary p { margin: 0; color: var(--muted-strong); line-height: 1.55; white-space: pre-wrap; overflow-wrap: anywhere; }
 .assistant-commentary.live { border-left-color: var(--blue); }
 .assistant-commentary.live p:last-child { color: var(--text); }
 @keyframes assistant-stream-caret { 50% { opacity: .2; } }
-@media (prefers-reduced-motion: reduce) { .assistant-streaming-text::after { animation: none; } }
+@media (prefers-reduced-motion: reduce) { .assistant-markdown.streaming::after { animation: none; } }
 .citation-chip { font-size: 11px; }
 .assistant-markdown { min-width: 0; color: var(--text); font-size: 13px; line-height: 1.68; }
 .assistant-markdown > :first-child, .assistant-markdown > :first-child > :first-child { margin-top: 0; }

--- a/ui/src/components/AssistantMarkdown.tsx
+++ b/ui/src/components/AssistantMarkdown.tsx
@@ -23,6 +23,7 @@ interface AssistantMarkdownProps {
   content: string;
   messageId?: string;
   durable: boolean;
+  streaming?: boolean;
   runnableLanguages: ReadonlySet<ExecutionLanguage>;
   onRun: (candidate: FencedRunCandidate) => void;
 }
@@ -166,6 +167,7 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
   content,
   messageId,
   durable,
+  streaming = false,
   runnableLanguages,
   onRun,
 }: AssistantMarkdownProps) {
@@ -205,7 +207,7 @@ export const AssistantMarkdown = memo(function AssistantMarkdown({
   };
 
   return (
-    <div className="assistant-markdown">
+    <div className={`assistant-markdown${streaming ? " streaming" : ""}`}>
       {renderable && (
         <ReactMarkdown remarkPlugins={[remarkGfm]} components={components} urlTransform={safeUrl}>
           {renderable}

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -3314,7 +3314,9 @@ export function SessionsPage() {
                       {commentaryItems.length > 0 && <div className={`assistant-commentary${message.state === "streaming" ? " live" : ""}`} aria-label="Assistant commentary" aria-live="polite">
                         {commentaryItems.map((item) => <p key={item.key}>{item.text}</p>)}
                       </div>}
-                      {message.content && (message.role === "assistant" && message.state === "complete" ? <AssistantMarkdown content={message.content} messageId={message.id} durable={message.durable} runnableLanguages={runnableLanguages} onRun={setRunCandidate} /> : <p className={message.role === "assistant" && message.state === "streaming" ? "assistant-streaming-text" : undefined}>{message.content}</p>)}
+                      {message.content && (message.role === "assistant"
+                        ? <AssistantMarkdown content={message.content} messageId={message.id} durable={message.durable && message.state === "complete"} streaming={message.state === "streaming"} runnableLanguages={runnableLanguages} onRun={setRunCandidate} />
+                        : <p>{message.content}</p>)}
                       {api && message.contentBlocks?.filter((block) => block.type === "image").map((block, index) => <AuthenticatedChatImage api={api} block={block} key={`${block.artifactId ?? "image"}-${index}`} />)}
                       {activityLedger && <ActivityLedger
                         model={activityLedger}

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -3365,10 +3365,12 @@ test("completed harness output keeps one continuous transcript scroll", async ({
       (globalThis as typeof globalThis & { __harnessTurnRequest?: unknown }).__harnessTurnRequest = JSON.parse(String(init?.body ?? "{}"));
       const encoder = new TextEncoder();
       const output = "Completed command output stays available behind its disclosure without creating a second transcript scroll.\n".repeat(80);
-      const answer = "Verification completed successfully. The operator remains in control of the next action.\n\n".repeat(30);
+      const streamingAnswer = "**Streaming Markdown is visible.** Inline `memcpy` is formatted before completion.\n\n```python\nprint('waiting for completion')\n";
+      const answer = "**Verification completed successfully.** The operator remains in control of the next action.\n\n".repeat(30);
       const frames: unknown[] = [
         { type: "started", harness_profile_id: "harness-completion", harness_session_id: session, harness_turn_id: turn, model: "gpt-5-codex", session_id: "chat-harness-completion", turn_id: "chat-turn-completion" },
         { type: "status", harness_session_id: session, harness_turn_id: turn, payload: { phase: "command_runtime_session_created", detail: "The command runtime changed, so Nebula preserved the prior session and continued in a new session with the current runtime.", previous_session_id: "prior-runtime-session" } },
+        { type: "message_delta", harness_session_id: session, harness_turn_id: turn, delta: streamingAnswer },
         { type: "output_delta", schema_version: "nebula.harness-activity/v1", sequence: 1, vendor: "codex_app_server", harness_session_id: session, harness_turn_id: turn, item_id: "commentary-1", item_kind: "reasoning", item_status: "streaming", title: "Commentary", stream: "commentary", delta: "I found the verification path. I’m checking the production behavior before changing anything.", artifact_ids: [], payload: {} },
         { type: "item_upsert", schema_version: "nebula.harness-activity/v1", sequence: 2, vendor: "codex_app_server", harness_session_id: session, harness_turn_id: turn, item_id: "command-1", item_kind: "command", item_status: "running", title: "Run verification", artifact_ids: [], payload: { command: "npm test" } },
         { type: "output_delta", schema_version: "nebula.harness-activity/v1", sequence: 3, vendor: "codex_app_server", harness_session_id: session, harness_turn_id: turn, item_id: "command-1", item_kind: "command", item_status: "streaming", title: "Run verification", stream: "stdout", delta: output, artifact_ids: [], payload: {} },
@@ -3417,6 +3419,11 @@ test("completed harness output keeps one continuous transcript scroll", async ({
   const commentary = page.getByLabel("Assistant commentary");
   await expect(commentary).toContainText("I found the verification path. I’m checking the production behavior before changing anything.");
   await expect(commentary).toBeVisible();
+  const streamingMessage = page.locator(".chat-message.assistant").last();
+  await expect(streamingMessage.locator(".assistant-markdown strong")).toHaveText("Streaming Markdown is visible.");
+  await expect(streamingMessage.locator(".assistant-markdown code")).toHaveText("memcpy");
+  await expect(streamingMessage.locator(".assistant-inert-fence")).toContainText("print('waiting for completion')");
+  await expect(streamingMessage.getByRole("button", { name: /Review and run/ })).toHaveCount(0);
   await expect(page.getByText("Tool started", { exact: true })).toHaveCount(0);
   await expect.poll(() => page.evaluate(() => (globalThis as typeof globalThis & { __harnessTurnRequest?: { harness_mode?: string } }).__harnessTurnRequest?.harness_mode)).toBe("plan");
   expect(await page.evaluate(() => (globalThis as typeof globalThis & { __harnessTurnRequest?: { harness_skill?: unknown } }).__harnessTurnRequest?.harness_skill)).toEqual({
@@ -3488,6 +3495,7 @@ test("completed harness output keeps one continuous transcript scroll", async ({
     await expect.poll(() => chatScroll.evaluate((element) => element.scrollTop)).toBeGreaterThan(outerBefore + 2);
   }
   const completedMessage = page.locator(".chat-message.assistant").filter({ hasText: "Verification completed successfully" });
+  await expect(completedMessage.locator(".assistant-markdown strong").first()).toHaveText("Verification completed successfully.");
   const forkAction = completedMessage.getByRole("button", { name: "Fork conversation here" });
   await expect(completedMessage.locator("header").getByRole("button", { name: "Fork conversation here" })).toHaveCount(0);
   await expect(forkAction.locator("xpath=..")).toHaveClass(/chat-message-actions/);

--- a/ui/tests/real-core.spec.ts
+++ b/ui/tests/real-core.spec.ts
@@ -165,7 +165,7 @@ async function startLocalModelStub(options: { fail?: boolean; streamDelayMs?: nu
           object: "chat.completion.chunk",
           created: 1,
           model: "security-model",
-          choices: [{ index: 0, delta: { role: "assistant", content: "Core is continuing in Project A" }, finish_reason: null }],
+          choices: [{ index: 0, delta: { role: "assistant", content: "**Core is continuing in Project A**" }, finish_reason: null }],
         })}\n\n`);
         setTimeout(() => {
           response.write(`data: ${JSON.stringify({
@@ -503,7 +503,7 @@ test("production assistant work survives a project switch through real Core", as
     await expect(composer).toBeEnabled({ timeout: 20_000 });
     await composer.fill("Keep this response running while I switch projects");
     await page.getByRole("button", { name: "Send message" }).click();
-    await expect(page.getByText("Core is continuing in Project A")).toBeVisible({ timeout: 20_000 });
+    await expect(page.locator(".chat-message.assistant .assistant-markdown strong")).toHaveText("Core is continuing in Project A", { timeout: 20_000 });
 
     await page.getByRole("button", { name: "Switch project" }).click();
     await page.getByRole("dialog", { name: "Project switcher" }).getByRole("button", { name: /Background Project B/ }).click();
@@ -520,13 +520,14 @@ test("production assistant work survives a project switch through real Core", as
       if (!messagesResponse.ok()) return "";
       const messages = await messagesResponse.json() as Array<{ role: string; content: string }>;
       return messages.find((message) => message.role === "assistant")?.content ?? "";
-    }, { timeout: 20_000 }).toBe("Core is continuing in Project A and finished after the viewer detached.");
+    }, { timeout: 20_000 }).toBe("**Core is continuing in Project A** and finished after the viewer detached.");
 
     await page.getByRole("button", { name: "Switch project" }).click();
     await page.getByRole("dialog", { name: "Project switcher" }).getByRole("button", { name: new RegExp(projectA.name) }).click();
     await page.getByRole("button", { name: "Show conversations" }).click();
     await page.locator(".session-select").filter({ hasText: "Keep this response running while I switch projects" }).click();
-    await expect(page.getByText("Core is continuing in Project A and finished after the viewer detached.")).toBeVisible({ timeout: 20_000 });
+    await expect(page.locator(".chat-message.assistant .assistant-markdown strong")).toHaveText("Core is continuing in Project A", { timeout: 20_000 });
+    await expect(page.locator(".chat-message.assistant .assistant-markdown")).toContainText("and finished after the viewer detached.");
     expect(new URL(page.url()).hostname).toBe(lanAddress);
   } finally {
     await api.dispose();


### PR DESCRIPTION
## Outcome

Assistant responses now render Markdown throughout streaming instead of exposing literal `**` and backtick syntax until completion. The same safe renderer remains in place after persistence and reload.

Incomplete fenced code stays inert, reviewed Run controls remain unavailable until the message is both complete and durable, and the streaming caret retains reduced-motion behavior.

## State and lifecycle contract

- The transient runtime message remains authoritative while streaming.
- Core remains authoritative after completion and across reload/reconnect.
- Streaming and completed assistant content share one Markdown interpretation.
- User messages remain plain text.
- Runnable code remains gated by completion, durability, and advertised runtime support.

## Verification

- `npm test` — 72 files, 362 tests passed
- `npm run audit:diagnostics` — zero unclassified catch handlers
- `npm run build` — production bundle passed
- Focused mocked Playwright journey — desktop Chromium 1440; compact Chromium 1024; Mobile Chromium 320/390/430; Mobile WebKit 320/390/430 all passed
- Real-Core Playwright — production bundle over non-loopback LAN origin passed streaming, project switch/detach, durable persistence, and restored Markdown rendering

## Acceptance limitations

- Mobile profiles were emulated, not physical devices.
- No physical-device browser run was performed; this change does not touch origin-sensitive browser APIs.
