### PR TITLE
Add mission result copy and assistant continuation

### DIFF
--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -6729,8 +6729,11 @@ def create_app(
         tags=["runs", "chat"],
         dependencies=[Depends(require_auth)],
     )
-    async def discuss_harness_run(run_id: str) -> ChatSession:
-        return harness_runtime.attach_run_to_chat(run_id)
+    async def discuss_run(run_id: str) -> ChatSession:
+        run = store.get(AgentRun, run_id)
+        if run.backend == RunBackend.HARNESS:
+            return harness_runtime.attach_run_to_chat(run_id)
+        return chat_service().attach_native_run_to_chat(run_id)
 
     @app.post(
         f"{API_PREFIX}/chat/sessions/{{session_id}}/continue-as-mission",

--- a/src/nebula/v3/chat.py
+++ b/src/nebula/v3/chat.py
@@ -2169,9 +2169,7 @@ class ChatService:
             return existing
         summary = run.metadata.get("final_summary")
         if not isinstance(summary, str) or not summary.strip():
-            raise ChatHistoryConflict(
-                "mission has no final result to continue in chat"
-            )
+            raise ChatHistoryConflict("mission has no final result to continue in chat")
         saved_name = run.metadata.get("name")
         title = (
             saved_name.strip()

--- a/src/nebula/v3/chat.py
+++ b/src/nebula/v3/chat.py
@@ -30,6 +30,7 @@ from .artifacts import ArtifactStore
 from .browser_tools import BrowserToolPlatform, combine_tool_components
 
 from .domain import (
+    AgentRun,
     Approval,
     ApprovalStatus,
     Artifact,
@@ -52,6 +53,7 @@ from .domain import (
     McpServerProfile,
     NebulaModel,
     ProviderProfile,
+    RunBackend,
     ToolCallOrigin,
     ToolCall,
     ToolCallStatus,
@@ -2140,6 +2142,83 @@ class ChatService:
     def session_messages(self, session_id: str) -> list[ChatMessage]:
         session = self.store.get(ChatSession, session_id)
         return self._session_messages(session)
+
+    def attach_native_run_to_chat(self, run_id: str) -> ChatSession:
+        """Create or return the durable provider chat that continues a mission result."""
+
+        run = self.store.get(AgentRun, run_id)
+        if run.backend != RunBackend.NATIVE:
+            raise ChatConfigurationError(
+                "only native runs can be attached to provider chat"
+            )
+        if not run.supervisor_provider_id or not run.supervisor_model:
+            raise ChatConfigurationError(
+                "mission has no provider runtime to continue in chat"
+            )
+        existing = next(
+            (
+                item
+                for item in self.store.list_entities(
+                    ChatSession, engagement_id=run.engagement_id, limit=1_000
+                )
+                if run.id in item.metadata.get("attached_run_ids", [])
+            ),
+            None,
+        )
+        if existing is not None:
+            return existing
+        summary = run.metadata.get("final_summary")
+        if not isinstance(summary, str) or not summary.strip():
+            raise ChatHistoryConflict(
+                "mission has no final result to continue in chat"
+            )
+        saved_name = run.metadata.get("name")
+        title = (
+            saved_name.strip()
+            if isinstance(saved_name, str) and saved_name.strip()
+            else run.objective.strip()
+        )
+        chat = ChatSession(
+            id=str(uuid4()),
+            engagement_id=run.engagement_id,
+            title=(title or "Mission discussion")[:300],
+            backend=ChatBackend.PROVIDER,
+            provider_profile_id=run.supervisor_provider_id,
+            model=run.supervisor_model,
+            metadata={
+                "attached_run_ids": [run.id],
+                "context_management": "nebula",
+            },
+        )
+        with self.store.transaction() as transaction:
+            transaction.add(chat)
+            transaction.add(
+                ChatMessage(
+                    id=str(uuid4()),
+                    engagement_id=run.engagement_id,
+                    session_id=chat.id,
+                    sequence=1,
+                    role=ChatRole.USER,
+                    content=run.objective,
+                    provider_profile_id=run.supervisor_provider_id,
+                    model=run.supervisor_model,
+                    metadata={"run_id": run.id, "handoff": "mission_to_chat"},
+                )
+            )
+            transaction.add(
+                ChatMessage(
+                    id=str(uuid4()),
+                    engagement_id=run.engagement_id,
+                    session_id=chat.id,
+                    sequence=2,
+                    role=ChatRole.ASSISTANT,
+                    content=summary,
+                    provider_profile_id=run.supervisor_provider_id,
+                    model=run.supervisor_model,
+                    metadata={"run_id": run.id, "handoff": "mission_to_chat"},
+                )
+            )
+        return chat
 
     def fork_session(
         self,

--- a/tests/v3/test_missions.py
+++ b/tests/v3/test_missions.py
@@ -517,9 +517,7 @@ def test_api_starts_explicit_analysis_mission_and_persists_events(tmp_path):
         assert provider.requests[0].model == "security-model"
         assert provider.requests[0].tools == []
 
-        discussed = client.post(
-            f"/api/v1/runs/{queued['id']}/discuss", headers=_auth()
-        )
+        discussed = client.post(f"/api/v1/runs/{queued['id']}/discuss", headers=_auth())
         assert discussed.status_code == 200, discussed.text
         chat = discussed.json()
         assert chat["backend"] == "provider"

--- a/tests/v3/test_missions.py
+++ b/tests/v3/test_missions.py
@@ -517,6 +517,28 @@ def test_api_starts_explicit_analysis_mission_and_persists_events(tmp_path):
         assert provider.requests[0].model == "security-model"
         assert provider.requests[0].tools == []
 
+        discussed = client.post(
+            f"/api/v1/runs/{queued['id']}/discuss", headers=_auth()
+        )
+        assert discussed.status_code == 200, discussed.text
+        chat = discussed.json()
+        assert chat["backend"] == "provider"
+        assert chat["provider_profile_id"] == profile.id
+        assert chat["model"] == "security-model"
+        transcript = client.get(
+            f"/api/v1/chat/sessions/{chat['id']}/messages", headers=_auth()
+        )
+        assert transcript.status_code == 200, transcript.text
+        assert [message["content"] for message in transcript.json()] == [
+            "Review the explicitly bounded scope",
+            completed["metadata"]["final_summary"],
+        ]
+        discussed_again = client.post(
+            f"/api/v1/runs/{queued['id']}/discuss", headers=_auth()
+        )
+        assert discussed_again.status_code == 200
+        assert discussed_again.json()["id"] == chat["id"]
+
         terminal_stop = client.post(
             f"/api/v1/runs/{queued['id']}/stop",
             headers=_auth(),

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
     {
       name: "mobile-chromium",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"] },
     },
     {
@@ -58,31 +58,31 @@ export default defineConfig({
     {
       name: "mobile-chromium-small",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"], viewport: { width: 320, height: 700 } },
     },
     {
       name: "mobile-chromium-wide",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output/,
+      grep: /universal search opens|theme picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output/,
       use: { ...devices["Pixel 5"], viewport: { width: 430, height: 932 } },
     },
     {
       name: "mobile-webkit-small",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output/,
+      grep: /universal search opens|theme picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output/,
       use: { ...devices["iPhone 13"], viewport: { width: 320, height: 700 } },
     },
     {
       name: "mobile-webkit",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["iPhone 13"] },
     },
     {
       name: "mobile-webkit-wide",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|completed harness output|activity ledger groups repeated work|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["iPhone 13"], viewport: { width: 430, height: 932 } },
     },
     {

--- a/ui/src/components-domain.css
+++ b/ui/src/components-domain.css
@@ -560,6 +560,9 @@
   .mission-hero { align-items: flex-start; flex-direction: column; }
   .mission-hero-progress { width: 100%; }
   .mission-hero-progress > span { flex: 1; }
+  .mission-result > footer { align-items: stretch; flex-direction: column; }
+  .mission-result-actions { justify-content: stretch; }
+  .mission-result-actions .button { min-height: 44px; flex: 1 1 180px; justify-content: center; }
   .agent-card-grid, .provider-grid, .settings-bottom-grid { grid-template-columns: 1fr; }
   .secrets-panel { grid-column: auto; }
   .release-panel { grid-column: auto; }

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -1044,6 +1044,8 @@ kbd { font-size: 11px; }
 .mission-result-body .assistant-markdown h3 { margin: 18px 0 7px; padding-top: 14px; border-top: 1px solid var(--border-soft); font-size: 13px; }
 .mission-result-body .assistant-code-block { box-shadow: none; }
 .mission-result > footer { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 9px 18px; border-top: 1px solid var(--border-soft); color: var(--muted); font-size: 11px; }.mission-result > footer a { color: var(--red); font-weight: var(--weight-bold); }
+.mission-result-actions { display: flex; align-items: center; justify-content: flex-end; gap: 7px; flex-wrap: wrap; }
+.mission-result-action-error { padding: 9px 18px; border-top: 1px solid color-mix(in srgb, var(--red) 28%, var(--border-soft)); color: var(--red); background: var(--red-muted); font-size: 11px; }
 .mission-failure-callout { border-color: color-mix(in srgb, var(--red) 34%, var(--border)); background: var(--red-muted); }.mission-failure-callout > svg { flex: 0 0 auto; color: var(--red); }.mission-failure-callout .button { margin-left: auto; white-space: nowrap; }
 .mission-runtime-setup { display: inline-flex; max-width: 390px; align-items: center; gap: 8px; padding: 7px 9px; border: 1px solid color-mix(in srgb, var(--orange) 32%, var(--border-soft)); border-radius: 8px; color: var(--muted-strong); background: color-mix(in srgb, var(--orange) 7%, var(--surface)); font-size: 11px; line-height: 1.35; }
 .mission-runtime-setup a { flex: 0 0 auto; color: var(--blue); font-weight: var(--weight-semibold); }

--- a/ui/src/pages/AgentsPage.test.tsx
+++ b/ui/src/pages/AgentsPage.test.tsx
@@ -5,9 +5,10 @@ import { DialogProvider } from "../components/DialogSystem";
 import { AgentsPage } from "./AgentsPage";
 
 const steerRun = vi.fn().mockResolvedValue(undefined);
+const discussRun = vi.fn().mockResolvedValue({ id: "chat-from-mission" });
 const selectMission = vi.fn();
 const workspace = {
-  api: { steerRun, discussRun: vi.fn() },
+  api: { steerRun, discussRun },
   approvals: [],
   coreState: "offline" as const,
   deleteMission: vi.fn(),
@@ -141,6 +142,70 @@ describe("mission activity", () => {
     const links = screen.getAllByRole("link", { name: "View diagnostics" });
     expect(links).toHaveLength(2);
     links.forEach((link) => expect(link).toHaveAttribute("href", "/settings#diagnostics-settings"));
+    (workspace.run as { status: string }).status = previousStatus;
+    workspace.events = previousEvents;
+  });
+
+  it("copies a mission result and continues it in durable assistant chat", async () => {
+    const user = userEvent.setup();
+    const previousStatus = workspace.run.status;
+    const previousBackend = workspace.run.backend;
+    const previousEvents = workspace.events;
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+    discussRun.mockClear();
+    (workspace.run as { status: string }).status = "complete";
+    (workspace.run as { backend: string }).backend = "native";
+    workspace.events = [{
+      id: "event-completed",
+      sequence: 20,
+      kind: "run.completed",
+      actor: "Nebula Core",
+      occurredAt: "2026-07-14T12:10:00Z",
+      summary: "**Result**\n\nThe bounded review is complete.",
+      payload: {},
+    }];
+    render(<DialogProvider><AgentsPage embedded /></DialogProvider>);
+
+    await user.click(screen.getByRole("button", { name: "Copy result" }));
+    expect(writeText).toHaveBeenCalledWith("**Result**\n\nThe bounded review is complete.");
+    expect(screen.getByRole("button", { name: "Copied" })).toBeVisible();
+    expect(screen.getByRole("status")).toHaveTextContent("Mission result copied to clipboard.");
+
+    await user.click(screen.getByRole("button", { name: "Continue in assistant chat" }));
+    expect(discussRun).toHaveBeenCalledWith("run-1");
+    expect(new URLSearchParams(window.location.search).get("view")).toBe("chat");
+    expect(new URLSearchParams(window.location.search).get("session")).toBe("chat-from-mission");
+
+    (workspace.run as { status: string }).status = previousStatus;
+    (workspace.run as { backend: string }).backend = previousBackend;
+    workspace.events = previousEvents;
+  });
+
+  it("keeps the result usable when clipboard access fails", async () => {
+    const user = userEvent.setup();
+    const previousStatus = workspace.run.status;
+    const previousEvents = workspace.events;
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    (workspace.run as { status: string }).status = "complete";
+    workspace.events = [{
+      id: "event-copy-failed",
+      sequence: 21,
+      kind: "run.completed",
+      actor: "Nebula Core",
+      occurredAt: "2026-07-14T12:11:00Z",
+      summary: "The result remains selectable.",
+      payload: {},
+    }];
+    render(<DialogProvider><AgentsPage embedded /></DialogProvider>);
+
+    await user.click(screen.getByRole("button", { name: "Copy result" }));
+    expect(screen.getByRole("alert")).toHaveTextContent("Select the result text and copy it manually.");
+    expect(within(screen.getByRole("region", { name: "Mission result" })).getByText("The result remains selectable.")).toBeVisible();
+
     (workspace.run as { status: string }).status = previousStatus;
     workspace.events = previousEvents;
   });

--- a/ui/src/pages/AgentsPage.tsx
+++ b/ui/src/pages/AgentsPage.tsx
@@ -4,6 +4,7 @@ import {
   CircleDashed,
   CircleAlert,
   Clock3,
+  Copy,
   DollarSign,
   FileCheck2,
   GitBranch,
@@ -24,6 +25,7 @@ import { DiagnosticErrorNotice, logCaughtDiagnostic } from "../diagnostics";
 import { MissionPromotionDialog } from "../components/MissionPromotionDialog";
 import { ActivityLedger } from "../components/ActivityLedger";
 import { activityLedgerFromMission, type ActivityLedgerEntry } from "../components/activityLedgerModel";
+import { copySelectionText } from "../components/selection/selectionActions";
 
 const agents = [
   { name: "Scope planner", detail: "Policy and mission decomposition", state: "complete", icon: ShieldCheck, tools: "No executable tools" },
@@ -69,14 +71,29 @@ export function AgentsPage({ embedded = false }: { embedded?: boolean }) {
   const [missionQuery, setMissionQuery] = useState("");
   const [missionStatus, setMissionStatus] = useState("all");
   const [visibleMissionCount, setVisibleMissionCount] = useState(12);
+  const [copiedResultId, setCopiedResultId] = useState<string>();
+  const [resultActionError, setResultActionError] = useState<{ runId: string; message: string }>();
+  const [discussingRunId, setDiscussingRunId] = useState<string>();
   const discuss = async () => {
-    if (!api || !run || run.backend !== "harness") return;
-    const chat = await api.discussRun(run.id);
-    const params = new URLSearchParams(window.location.search);
-    params.set("view", "chat");
-    params.set("session", chat.id);
-    window.history.pushState({}, "", `${window.location.pathname}?${params}`);
-    window.dispatchEvent(new PopStateEvent("popstate"));
+    if (!api || !run || discussingRunId) return;
+    setDiscussingRunId(run.id);
+    setResultActionError(undefined);
+    try {
+      const chat = await api.discussRun(run.id);
+      const params = new URLSearchParams(window.location.search);
+      params.set("view", "chat");
+      params.set("session", chat.id);
+      window.history.pushState({}, "", `${window.location.pathname}?${params}`);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    } catch (error) {
+      void logCaughtDiagnostic("interface.agents_page.mission_discuss", "A mission result could not be continued in assistant chat.", error, "agents_page");
+      setResultActionError({
+        runId: run.id,
+        message: "Assistant chat could not be opened. The mission result is still available; try again.",
+      });
+    } finally {
+      setDiscussingRunId(undefined);
+    }
   };
   const steer = async (event: FormEvent) => {
     event.preventDefault();
@@ -95,11 +112,28 @@ export function AgentsPage({ embedded = false }: { embedded?: boolean }) {
     }
   };
   const resultEvent = events.find((event) => event.kind === "run.completed" || event.kind === "run.failed");
+  const copyResult = async () => {
+    if (!run || !resultEvent) return;
+    setResultActionError(undefined);
+    try {
+      await copySelectionText(resultEvent.summary);
+      setCopiedResultId(resultEvent.id);
+    } catch (error) {
+      void logCaughtDiagnostic("interface.agents_page.mission_result_copy", "A mission result could not be copied.", error, "agents_page");
+      setResultActionError({
+        runId: run.id,
+        message: "Copy is unavailable in this browser. Select the result text and copy it manually.",
+      });
+    }
+  };
   const latestEvent = events[0];
   const progress = run?.totalTasks ? Math.min(100, Math.round((run.completedTasks / run.totalTasks) * 100)) : 0;
   const terminal = Boolean(run && ["complete", "failed", "cancelled", "interrupted"].includes(run.status));
   const selectedApprovals = run ? approvals.filter((approval) => approval.runId === run.id) : [];
   const missionLedger = run ? activityLedgerFromMission(run, events) : undefined;
+  const activeResultActionError = resultActionError && resultActionError.runId === run?.id
+    ? resultActionError.message
+    : undefined;
   const filteredRuns = useMemo(() => {
     const query = missionQuery.trim().toLocaleLowerCase();
     return [...runs]
@@ -121,7 +155,7 @@ export function AgentsPage({ embedded = false }: { embedded?: boolean }) {
         />}
         <section className="mission-commandbar" aria-label="Mission controls">
           <div><Radio size={15} /><span><strong>{run ? "Mission control" : "No mission selected"}</strong><small>{run ? `Core status: ${run.status.replaceAll("_", " ")} · live feed ${streamState}` : "Start a mission to see its plan and live execution here."}</small></span></div>
-          <div>{run?.backend === "harness" && <button className="button secondary" type="button" onClick={() => void discuss()}><MessageSquare size={15} /> Discuss in chat</button>}{terminal && <RetryMissionButton />}<StopMissionButton /><DeleteMissionButton /><NewMissionButton /></div>
+          <div>{run?.backend === "harness" && <button className="button secondary" type="button" disabled={Boolean(discussingRunId)} onClick={() => void discuss()}><MessageSquare size={15} /> {discussingRunId === run.id ? "Opening chat…" : "Discuss in chat"}</button>}{terminal && <RetryMissionButton />}<StopMissionButton /><DeleteMissionButton /><NewMissionButton /></div>
         </section>
         <section className="panel mission-picker" aria-label="Missions">
           <header><div><strong>Mission history</strong><small>Select a named mission to inspect its result</small></div><span>{runs.length}</span></header>
@@ -141,7 +175,9 @@ export function AgentsPage({ embedded = false }: { embedded?: boolean }) {
         {resultEvent && <section className={`panel mission-result ${resultEvent.kind === "run.failed" ? "failed" : "complete"}`} aria-labelledby="mission-result-title">
           <header><span className="mission-result-icon"><FileCheck2 size={19} /></span><div><small>{resultEvent.kind === "run.failed" ? "Mission ended with errors" : "Completed mission"}</small><h2 id="mission-result-title">Mission result</h2></div><span className="mission-result-sequence">#{resultEvent.sequence}</span></header>
           <div className="mission-result-body"><AssistantMarkdown content={resultEvent.summary} durable={false} runnableLanguages={new Set()} onRun={() => undefined} /></div>
-          <footer><span>{resultEvent.actor ?? "Nebula Core"} · {new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(resultEvent.occurredAt))}</span>{resultEvent.kind === "run.completed" && run && <MissionPromotionDialog run={run} summary={resultEvent.summary} />}{resultEvent.kind === "run.failed" && <a href="/settings#diagnostics-settings">View diagnostics</a>}</footer>
+          <footer><span>{resultEvent.actor ?? "Nebula Core"} · {new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(resultEvent.occurredAt))}</span><div className="mission-result-actions">{resultEvent.kind === "run.completed" && run && <MissionPromotionDialog run={run} summary={resultEvent.summary} />}{resultEvent.kind === "run.failed" && <a href="/settings#diagnostics-settings">View diagnostics</a>}<button className="button quiet" type="button" onClick={() => void copyResult()}><Copy size={14} aria-hidden="true" /> {copiedResultId === resultEvent.id ? "Copied" : "Copy result"}</button><button className="button primary" type="button" disabled={Boolean(discussingRunId)} onClick={() => void discuss()}><MessageSquare size={14} aria-hidden="true" /> {discussingRunId === run?.id ? "Opening chat…" : "Continue in assistant chat"}</button></div></footer>
+          {activeResultActionError && <div className="mission-result-action-error" role="alert">{activeResultActionError}</div>}
+          <span className="sr-only" role="status" aria-live="polite">{copiedResultId === resultEvent.id ? "Mission result copied to clipboard." : ""}</span>
         </section>}
         {missionLedger && <ActivityLedger model={missionLedger} renderEntryDetails={(entry) => <MissionLedgerEntryDetails entry={entry} />} />}
       </div>

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -1286,6 +1286,127 @@ test("mission workflow freezes harness options, stages, and URL identity", async
   expect(accessibility.violations).toEqual([]);
 });
 
+test("mission result actions copy exactly and continue in assistant chat", async ({ page }) => {
+  const runId = "mission-result-actions";
+  const result = "**Verified result**\n\nThe bounded review is complete.";
+  let discussed = false;
+  await page.addInitScript(({ missionId, missionResult }) => {
+    localStorage.setItem("nebula.mission", missionId);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (value: string) => {
+          (globalThis as typeof globalThis & { __copiedMissionResult?: string }).__copiedMissionResult = value;
+        },
+      },
+    });
+    class MissionEventWebSocket extends EventTarget {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly CLOSING = 2;
+      static readonly CLOSED = 3;
+      readonly url: string;
+      readonly protocol = "nebula.events.v1";
+      readonly extensions = "";
+      readonly bufferedAmount = 0;
+      readonly binaryType = "blob";
+      readyState = MissionEventWebSocket.CONNECTING;
+      constructor(url: string | URL) {
+        super();
+        this.url = String(url);
+        setTimeout(() => {
+          this.readyState = MissionEventWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+          this.dispatchEvent(new MessageEvent("message", { data: JSON.stringify({
+            kind: "event",
+            event: {
+              id: "mission-result-event",
+              run_id: missionId,
+              sequence: 7,
+              event_type: "run.completed",
+              actor_id: "Nebula Core",
+              occurred_at: "2026-07-14T12:10:00Z",
+              payload: { summary: missionResult },
+            },
+          }) }));
+        }, 10);
+      }
+      send(): void {}
+      close(code = 1000, reason = "closed"): void {
+        this.readyState = MissionEventWebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close", { code, reason, wasClean: true }));
+      }
+    }
+    Object.defineProperty(globalThis, "WebSocket", { configurable: true, writable: true, value: MissionEventWebSocket });
+  }, { missionId: runId, missionResult: result });
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    if (path.endsWith("/runs") && request.method() === "GET") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([{
+        ...entity,
+        id: runId,
+        engagement_id: "scratch-project",
+        objective: "Review the bounded project",
+        status: "complete",
+        backend: "native",
+        supervisor_provider_id: "local-provider",
+        supervisor_model: "security-model",
+        harness_profile_id: null,
+        harness_session_id: null,
+        runtime_snapshot: {},
+        budget: { max_duration_seconds: null, max_tokens: null, max_cost_usd: null, max_tool_calls: null, max_artifact_queries: null, max_concurrency: 1, max_delegation_depth: 0, max_retries_per_task: 0 },
+        started_at: entity.created_at,
+        completed_at: entity.updated_at,
+        metadata: { name: "Bounded project review", total_tasks: 1, completed_tasks: 1, final_summary: result },
+      }]) });
+      return;
+    }
+    if (path.endsWith(`/runs/${runId}/discuss`) && request.method() === "POST") {
+      discussed = true;
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({
+        ...entity,
+        id: "chat-from-mission-result",
+        engagement_id: "scratch-project",
+        title: "Bounded project review",
+        backend: "provider",
+        provider_profile_id: "local-provider",
+        harness_profile_id: null,
+        harness_session_id: null,
+        model: "security-model",
+        metadata: { attached_run_ids: [runId] },
+      }) });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await openWorkspace(page, `/?view=missions&mission=${runId}`, "Workbench");
+  const resultRegion = page.getByRole("region", { name: "Mission result" });
+  await expect(resultRegion).toBeVisible();
+  await resultRegion.getByRole("button", { name: "Copy result" }).click();
+  await expect(resultRegion.getByRole("button", { name: "Copied" })).toBeVisible();
+  await expect.poll(() => page.evaluate(() => (globalThis as typeof globalThis & { __copiedMissionResult?: string }).__copiedMissionResult)).toBe(result);
+
+  const geometry = await resultRegion.evaluate((element) => ({
+    left: element.getBoundingClientRect().left,
+    right: element.getBoundingClientRect().right,
+    viewportWidth: innerWidth,
+    scrollWidth: element.scrollWidth,
+    clientWidth: element.clientWidth,
+  }));
+  expect(geometry.left).toBeGreaterThanOrEqual(0);
+  expect(geometry.right).toBeLessThanOrEqual(geometry.viewportWidth + 1);
+  expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth + 1);
+  const accessibility = await new AxeBuilder({ page }).include(".mission-result").analyze();
+  expect(accessibility.violations).toEqual([]);
+
+  await resultRegion.getByRole("button", { name: "Continue in assistant chat" }).click();
+  await expect.poll(() => discussed).toBe(true);
+  await expect.poll(() => new URL(page.url()).searchParams.get("view")).toBe("chat");
+  await expect.poll(() => new URL(page.url()).searchParams.get("session")).toBe("chat-from-mission-result");
+});
+
 test("Diagnostics explains and focuses a requested failure at every breakpoint", async ({ page }) => {
   await openWorkspace(page, "/settings?diagnostic=err_preview_123#diagnostics-settings", "Settings");
   await expect(page.getByRole("heading", { name: "Diagnostics", exact: true })).toBeVisible();


### PR DESCRIPTION
## Summary
- add exact-copy and accessible feedback controls to mission results
- continue native and harness mission results in durable assistant chats
- add Core, component, responsive browser, accessibility, and LAN-origin regression coverage

## Verification
- `poetry run pytest tests/v3/test_missions.py::test_api_starts_explicit_analysis_mission_and_persists_events -q`
- `poetry run ruff check src/nebula/v3/api.py src/nebula/v3/chat.py tests/v3/test_missions.py`
- `npm test -- --run src/pages/AgentsPage.test.tsx`
- `npm run build`
- `npm run audit:css`
- Playwright mission result journey: desktop, compact, mobile Chromium 320/390/430, mobile WebKit 320/390/430
- production-bundle Playwright over non-loopback LAN origin