### PR TITLE
Route harness commands through Nebula runtime

### DIFF
--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -251,10 +251,12 @@ from .domain import (
     Entity,
     Evidence,
     GeneratedDraft,
+    HarnessProfile,
     HarnessInteraction,
     HarnessInteractionStatus,
     HarnessSession,
     HarnessTurn,
+    HarnessWorkspaceAccess,
     KnowledgeSource,
     LibraryItem,
     MissionGrant,
@@ -9785,6 +9787,20 @@ def _register_crud_routes(
 ) -> None:
     """Register typed routes while preserving concrete OpenAPI schemas."""
 
+    def enforce_harness_command_boundary(entity: Any) -> Any:
+        if not isinstance(entity, HarnessProfile):
+            return entity
+        return entity.model_copy(
+            update={
+                "native_capabilities": entity.native_capabilities.model_copy(
+                    update={
+                        "workspace_access": HarnessWorkspaceAccess.NONE,
+                        "shell": False,
+                    }
+                )
+            }
+        )
+
     def make_create() -> Callable[..., Any]:
         async def create_entity(entity: Any) -> Entity:
             protected = {"id", "created_at", "updated_at", "revision"}.intersection(
@@ -9807,6 +9823,7 @@ def _register_crud_routes(
                         ),
                     }
                 )
+            entity = enforce_harness_command_boundary(entity)
             if isinstance(entity, Engagement) and entity.workspace_path:
                 try:
                     linked_workspace = (
@@ -9897,6 +9914,7 @@ def _register_crud_routes(
                 entity, ProviderProfile
             ):
                 entity = _invalidate_provider_verification(current, entity)
+            entity = enforce_harness_command_boundary(entity)
             expected_revision = current.revision if if_match is None else if_match
             if isinstance(current, LEGACY_RELATION_MODELS):
                 return relation_service.replace_legacy_entity(
@@ -9930,11 +9948,19 @@ def _register_crud_routes(
             payload = current.model_dump(mode="python")
             payload.update(patch.changes)
             candidate = model.model_validate(payload)
+            candidate = enforce_harness_command_boundary(candidate)
             changes = dict(patch.changes)
             if isinstance(current, ProviderProfile) and isinstance(
                 candidate, ProviderProfile
             ):
                 candidate = _invalidate_provider_verification(current, candidate)
+                changes = {
+                    key: value
+                    for key, value in candidate.model_dump(mode="python").items()
+                    if key not in {"id", "created_at", "updated_at", "revision"}
+                    and value != getattr(current, key)
+                }
+            elif isinstance(current, HarnessProfile):
                 changes = {
                     key: value
                     for key, value in candidate.model_dump(mode="python").items()

--- a/src/nebula/v3/harnesses.py
+++ b/src/nebula/v3/harnesses.py
@@ -292,13 +292,32 @@ _GATEWAY_KNOWLEDGE_SCHEMAS: dict[str, dict[str, Any]] = {
 }
 
 
+def _container_only_native_capabilities(
+    capabilities: HarnessNativeCapabilities,
+) -> HarnessNativeCapabilities:
+    # Nebula owns project command execution.  The vendor harness may still use
+    # explicitly enabled research/skill capabilities, but it must never receive
+    # a host-backed project filesystem or shell.  Keeping this enforcement at
+    # the permission/config boundary also protects sessions created from legacy
+    # profiles that persisted these flags before the container-only policy.
+    return capabilities.model_copy(
+        update={
+            "workspace_access": HarnessWorkspaceAccess.NONE,
+            "shell": False,
+        }
+    )
+
+
 def _session_native_capabilities(
     session: HarnessSession, profile: HarnessProfile
 ) -> HarnessNativeCapabilities:
     raw = session.metadata.get("native_capabilities")
-    if isinstance(raw, dict):
-        return HarnessNativeCapabilities.model_validate(raw)
-    return profile.native_capabilities
+    capabilities = (
+        HarnessNativeCapabilities.model_validate(raw)
+        if isinstance(raw, dict)
+        else profile.native_capabilities
+    )
+    return _container_only_native_capabilities(capabilities)
 
 
 def _native_capability_names(capabilities: HarnessNativeCapabilities) -> list[str]:
@@ -322,9 +341,6 @@ def _native_capability_names(capabilities: HarnessNativeCapabilities) -> list[st
 
 def _supported_native_capabilities(kind: HarnessKind) -> list[str]:
     common = [
-        "isolated_workspace_read",
-        "isolated_workspace_write",
-        "shell",
         "web_search",
         "skills",
         "subagents",
@@ -408,9 +424,8 @@ def _harness_developer_instructions(
         "an unrestricted vendor workspace agent. Vendor-native capabilities are "
         "available only when named in the trusted native inventory below. Never "
         "advertise or imply access to any other vendor-native capability. Native "
-        "shell and file capabilities operate only in an isolated scratch workspace; "
-        "they must not be used to act on engagement targets or replace Nebula's "
-        "scoped command runtime. Native web and browser capabilities are for research, not "
+        "shell and project-file capabilities are not provided. Native web and browser "
+        "capabilities are for research, not "
         "target scanning. Use the session-scoped Nebula command runtime for project "
         "work; it runs Bash in a pinned isolated container. "
         "Use only the Nebula MCP gateway tools actually supplied in this thread. "
@@ -4448,10 +4463,7 @@ class ClaudeAgentSdkAdapter(HarnessAdapter):
                     hooks=True,
                     subagent_activity=True,
                     subagent_control=profile.native_capabilities.subagents,
-                    checkpoint_rewind=(
-                        profile.native_capabilities.workspace_access
-                        == HarnessWorkspaceAccess.WRITE
-                    ),
+                    checkpoint_rewind=False,
                     models=list(
                         dict.fromkeys(
                             [
@@ -5432,7 +5444,9 @@ class HarnessRuntimeService:
         )
         metadata: dict[str, Any] = {
             "context_management": "runtime_managed",
-            "native_capabilities": profile.native_capabilities.model_dump(mode="json"),
+            "native_capabilities": _container_only_native_capabilities(
+                profile.native_capabilities
+            ).model_dump(mode="json"),
             "command_runtime_enabled": oci_snapshot is not None,
             "runtime_options": {
                 "reasoning_effort": resolved_reasoning_effort,
@@ -5482,9 +5496,7 @@ class HarnessRuntimeService:
             model=selected_model,
             mcp_server_ids=[],
         )
-        native = profile.native_capabilities.model_copy(
-            update={"workspace_access": HarnessWorkspaceAccess.WRITE}
-        )
+        native = _container_only_native_capabilities(profile.native_capabilities)
         session = self.store.update(
             HarnessSession,
             session.id,
@@ -8825,11 +8837,6 @@ class HarnessRuntimeService:
                         )
 
         try:
-            adapter_workspace = (
-                isolated_workspace
-                if analysis_only
-                else self.workspace_resolver(session.engagement_id)
-            )
             catalog = self._gateway_catalog(session)
             gateway_tools = tuple(
                 {
@@ -8843,7 +8850,7 @@ class HarnessRuntimeService:
                 AdapterOpenRequest(
                     profile=profile,
                     session=session,
-                    workspace=adapter_workspace,
+                    workspace=isolated_workspace,
                     mcp_profiles=(),
                     gateway_config=launch.runtime_config(),
                     gateway_tools=gateway_tools,

--- a/tests/v3/test_harness_adapters.py
+++ b/tests/v3/test_harness_adapters.py
@@ -1989,9 +1989,7 @@ def test_claude_native_capabilities_exclude_project_files_and_shell(
         assert skill_result["hookSpecificOutput"]["permissionDecision"] == "allow"
         assert write_result["hookSpecificOutput"]["permissionDecision"] == "deny"
 
-        allowed = await options["can_use_tool"](
-            "Skill", {"skill": "review"}, None
-        )
+        allowed = await options["can_use_tool"]("Skill", {"skill": "review"}, None)
         assert allowed.behavior == "allow"
         assert observed_permissions[-1].vendor_name == "Skill"
         await connection.close()

--- a/tests/v3/test_harness_adapters.py
+++ b/tests/v3/test_harness_adapters.py
@@ -1896,7 +1896,7 @@ def test_claude_sdk_strict_mcp_resume_permissions_and_partial_messages(
     asyncio.run(scenario())
 
 
-def test_claude_native_capabilities_use_an_explicit_toolset_and_pretool_gate(
+def test_claude_native_capabilities_exclude_project_files_and_shell(
     tmp_path, monkeypatch
 ):
     async def scenario() -> None:
@@ -1951,10 +1951,6 @@ def test_claude_native_capabilities_use_an_explicit_toolset_and_pretool_gate(
         )
         options = FakeClaudeClient.latest.options.kwargs
         assert set(options["tools"]) == {
-            "Read",
-            "Glob",
-            "Grep",
-            "Bash",
             "WebSearch",
             "WebFetch",
             "Skill",
@@ -1962,7 +1958,15 @@ def test_claude_native_capabilities_use_an_explicit_toolset_and_pretool_gate(
         }
         assert options["setting_sources"] == ["user"]
         assert options["skills"] == "all"
-        assert {"Write", "Edit", "NotebookEdit"}.issubset(options["disallowed_tools"])
+        assert {
+            "Read",
+            "Glob",
+            "Grep",
+            "Bash",
+            "Write",
+            "Edit",
+            "NotebookEdit",
+        }.issubset(options["disallowed_tools"])
         assert "BEGIN TRUSTED VENDOR-NATIVE CAPABILITIES" in options["system_prompt"]
 
         pre_tool_use = options["hooks"]["PreToolUse"][0].hooks[0]
@@ -1981,15 +1985,15 @@ def test_claude_native_capabilities_use_an_explicit_toolset_and_pretool_gate(
             None,
             None,
         )
-        assert read_result["hookSpecificOutput"]["permissionDecision"] == "ask"
+        assert read_result["hookSpecificOutput"]["permissionDecision"] == "deny"
         assert skill_result["hookSpecificOutput"]["permissionDecision"] == "allow"
         assert write_result["hookSpecificOutput"]["permissionDecision"] == "deny"
 
         allowed = await options["can_use_tool"](
-            "Read", {"file_path": "README.md"}, None
+            "Skill", {"skill": "review"}, None
         )
         assert allowed.behavior == "allow"
-        assert observed_permissions[-1].vendor_name == "Read"
+        assert observed_permissions[-1].vendor_name == "Skill"
         await connection.close()
 
     asyncio.run(scenario())

--- a/tests/v3/test_harnesses.py
+++ b/tests/v3/test_harnesses.py
@@ -66,7 +66,6 @@ from nebula.v3.domain import (
     McpServerProfile,
     McpToolSnapshot,
     McpTransport,
-    RiskClass,
     RunBudget,
     RunStatus,
     ScopePolicy,
@@ -660,7 +659,8 @@ def test_shared_session_handoff_streaming_and_frozen_mcp_snapshot(tmp_path):
             == "https://mcp.invalid/api"
         )
         assert len(adapter.opens) == 1
-        assert adapter.opens[0].workspace == tmp_path
+        assert adapter.opens[0].workspace.name == "vendor-workspace"
+        assert adapter.opens[0].workspace != tmp_path
         assert adapter.opens[0].mcp_profiles == ()
         assert set(adapter.opens[0].gateway_config) == {"nebula"}
 
@@ -1237,7 +1237,13 @@ def test_harness_session_freezes_native_capabilities(tmp_path):
         expected_revision=profile.revision,
     )
 
-    assert session.metadata["native_capabilities"] == configured.model_dump(mode="json")
+    frozen = HarnessNativeCapabilities.model_validate(
+        session.metadata["native_capabilities"]
+    )
+    assert frozen.workspace_access == HarnessWorkspaceAccess.NONE
+    assert frozen.shell is False
+    assert frozen.web_search is True
+    assert frozen.subagents is True
 
 
 def test_harness_session_does_not_require_unprepared_optional_command_runtime(tmp_path):
@@ -2135,7 +2141,7 @@ def test_mcp_policy_fails_closed_and_routes_exact_approval(tmp_path):
     asyncio.run(scenario())
 
 
-def test_native_command_policy_requires_profile_capability_and_exact_approval(tmp_path):
+def test_native_command_policy_denies_legacy_host_shell_capabilities(tmp_path):
     async def scenario() -> None:
         store, engagement, profile, _, _, runtime = _runtime(tmp_path)
         profile = store.update(
@@ -2168,58 +2174,19 @@ def test_native_command_policy_requires_profile_capability_and_exact_approval(tm
                 annotations={"vendor_item_id": "codex-item-1"},
             ),
         )
-        approval = store.get(Approval, ticket.approval_id or "")
-        assert approval.risk_class == RiskClass.LOCAL_READ
-        assert approval.exact_request["arguments"] == {
-            "command": "pwd",
-            "cwd": ".",
-        }
-        assert approval.exact_request["argument_editing"] is False
-        decided = store.update(
-            Approval,
-            approval.id,
-            {"status": ApprovalStatus.APPROVED, "decided_by": "operator"},
-            expected_revision=approval.revision,
-        )
-        await runtime.resolve_approval(decided)
-        assert (await ticket.decision).allowed is True
-
+        assert ticket.approval_id is None
+        assert ticket.tool_call_id is not None
+        decision = await ticket.decision
+        assert decision.allowed is False
+        assert "not enabled" in decision.reason
+        denied_call = store.get(ToolCall, ticket.tool_call_id)
+        assert denied_call.status == ToolCallStatus.DENIED
         session = store.get(HarnessSession, turn.harness_session_id)
-        started = runtime._record_tool_event(
-            turn,
-            session,
-            HarnessEvent(
-                type="tool_started",
-                server_id="codex",
-                tool_name="commandExecution",
-                payload={"id": "codex-item-1", "command": "pwd"},
-            ),
-        )
-        completed = runtime._record_tool_event(
-            turn,
-            session,
-            HarnessEvent(
-                type="tool_completed",
-                server_id="codex",
-                tool_name="commandExecution",
-                payload={
-                    "id": "codex-item-1",
-                    "status": "completed",
-                    "output": "scratch workspace",
-                },
-            ),
-        )
-        assert started.tool_call_id == ticket.tool_call_id
-        assert completed.tool_call_id == ticket.tool_call_id
-        native_call = store.get(ToolCall, ticket.tool_call_id or "")
-        assert native_call.status == ToolCallStatus.COMPLETE
-        assert native_call.result == "scratch workspace"
-
         frozen = HarnessNativeCapabilities.model_validate(
             session.metadata["native_capabilities"]
         )
-        assert frozen.shell is True
-        assert frozen.workspace_access == HarnessWorkspaceAccess.READ
+        assert frozen.shell is False
+        assert frozen.workspace_access == HarnessWorkspaceAccess.NONE
 
     asyncio.run(scenario())
 
@@ -2512,6 +2479,27 @@ def test_harness_api_chat_mission_handoff_and_catalog(tmp_path):
     headers = {"Authorization": "Bearer test-token"}
 
     with TestClient(app) as client:
+        created_profile = client.post(
+            "/api/v1/harnesses",
+            headers=headers,
+            json={
+                "name": "Container-only Codex",
+                "kind": "codex_app_server",
+                "executable": "/bin/true",
+                "auth_mode": "existing_session",
+                "native_capabilities": {
+                    "workspace_access": "write",
+                    "shell": True,
+                    "web_search": True,
+                },
+            },
+        )
+        assert created_profile.status_code == 201, created_profile.text
+        created_native = created_profile.json()["native_capabilities"]
+        assert created_native["workspace_access"] == "none"
+        assert created_native["shell"] is False
+        assert created_native["web_search"] is True
+
         catalog = client.get("/api/v1/harness-catalog", headers=headers)
         assert catalog.status_code == 200
         assert [item["kind"] for item in catalog.json()] == [

--- a/ui/src/components/HarnessSettings.tsx
+++ b/ui/src/components/HarnessSettings.tsx
@@ -28,8 +28,6 @@ export function HarnessSettings() {
   const [harnessSessionCredential, setHarnessSessionCredential] = useState(false);
   const [harnessLocalOnly, setHarnessLocalOnly] = useState(false);
   const [harnessSensitiveData, setHarnessSensitiveData] = useState(false);
-  const [nativeWorkspaceAccess, setNativeWorkspaceAccess] = useState<"none" | "read" | "write">("none");
-  const [nativeShell, setNativeShell] = useState(false);
   const [nativeWebSearch, setNativeWebSearch] = useState(false);
   const [nativeBrowser, setNativeBrowser] = useState(false);
   const [nativeComputerUse, setNativeComputerUse] = useState(false);
@@ -89,8 +87,6 @@ export function HarnessSettings() {
     setHarnessSessionCredential(false);
     setHarnessLocalOnly(profile?.localOnly ?? false);
     setHarnessSensitiveData(profile?.permitsSensitiveData ?? false);
-    setNativeWorkspaceAccess(profile?.nativeCapabilities.workspaceAccess ?? "write");
-    setNativeShell(profile?.nativeCapabilities.shell ?? nextKind === "grok_acp");
     setNativeWebSearch(profile?.nativeCapabilities.webSearch ?? false);
     setNativeBrowser(profile?.nativeCapabilities.browser ?? false);
     setNativeComputerUse(profile?.nativeCapabilities.computerUse ?? false);
@@ -130,8 +126,8 @@ export function HarnessSettings() {
           permits_sensitive_data: harnessSensitiveData,
         },
         native_capabilities: {
-          workspace_access: nativeWorkspaceAccess,
-          shell: nativeShell,
+          workspace_access: "none",
+          shell: false,
           web_search: nativeWebSearch,
           web_fetch: false,
           browser: kind === "codex_app_server" && nativeBrowser,
@@ -248,8 +244,8 @@ export function HarnessSettings() {
     const capabilities = { ...profile.nativeCapabilities, ...changes };
     return updateHarness(profile, {
       native_capabilities: {
-        workspace_access: capabilities.workspaceAccess,
-        shell: capabilities.shell,
+        workspace_access: "none",
+        shell: false,
         web_search: capabilities.webSearch,
         web_fetch: false,
         browser: profile.kind === "codex_app_server" && capabilities.browser,
@@ -276,9 +272,7 @@ export function HarnessSettings() {
         <dl className="integration-card-facts"><div><dt>Model</dt><dd>{profile.defaultModel ?? "Selected per session"}</dd></div><div><dt>Auth</dt><dd>{profile.authMode === "existing_session" ? "Existing local sign-in" : "Secret-backed · configured"}</dd></div><div><dt>Privacy</dt><dd>{profile.localOnly ? "Local runtime" : profile.permitsSensitiveData ? "Cloud project data allowed" : "Text only"}</dd></div><div><dt>Version</dt><dd title={profile.version}>{profile.version ?? "Not checked"}</dd></div></dl>
         <details className="provider-capability-policy">
           <summary>Vendor-native capabilities</summary>
-          <p className="provider-dialog-note">Opt-in capabilities are frozen when a new harness session starts. Project actions use the session-scoped command runtime.</p>
-          <label>Project workspace<select value={profile.nativeCapabilities.workspaceAccess} disabled={busy === profile.id} onChange={(event) => void updateNativeCapabilities(profile, { workspaceAccess: event.target.value as HarnessNativeCapabilities["workspaceAccess"] })}><option value="none">Disabled</option><option value="read">Read only</option><option value="write">Read and write</option></select></label>
-          <label className="provider-consent"><input type="checkbox" checked={profile.nativeCapabilities.shell} disabled={busy === profile.id} onChange={(event) => void updateNativeCapabilities(profile, { shell: event.target.checked })} /><span><strong>Native shell</strong><small>Commands run from the selected project folder with Nebula approval.</small></span></label>
+          <p className="provider-dialog-note"><ShieldAlert size={14} /> Project files and commands use Nebula's pinned automation container at <code>/workspace</code>. The vendor harness has no host workspace or native shell access.</p>
           <label className="provider-consent"><input type="checkbox" checked={profile.nativeCapabilities.webSearch} disabled={busy === profile.id} onChange={(event) => void updateNativeCapabilities(profile, { webSearch: event.target.checked })} /><span><strong>Web search</strong><small>Vendor-hosted research, never target scanning.</small></span></label>
           {profile.kind === "codex_app_server" && <><label className="provider-consent"><input type="checkbox" checked={profile.nativeCapabilities.browser} disabled={busy === profile.id} onChange={(event) => void updateNativeCapabilities(profile, { browser: event.target.checked })} /><span><strong>Browser</strong><small>Browser-driven research with action approvals.</small></span></label><label className="provider-consent"><input type="checkbox" checked={profile.nativeCapabilities.computerUse} disabled={busy === profile.id} onChange={(event) => void updateNativeCapabilities(profile, { computerUse: event.target.checked })} /><span><strong>Computer use</strong><small>Interactive vendor computer-use surface.</small></span></label><label className="provider-consent"><input type="checkbox" checked={profile.nativeCapabilities.imageGeneration} disabled={busy === profile.id} onChange={(event) => void updateNativeCapabilities(profile, { imageGeneration: event.target.checked })} /><span><strong>Image generation</strong><small>Vendor-hosted analyst image generation.</small></span></label></>}
           <label className="provider-consent"><input type="checkbox" checked={profile.nativeCapabilities.skills} disabled={busy === profile.id} onChange={(event) => void updateNativeCapabilities(profile, { skills: event.target.checked })} /><span><strong>Installed skills</strong><small>Expose already-installed vendor skills.</small></span></label>
@@ -316,7 +310,7 @@ export function HarnessSettings() {
         <p className="provider-dialog-note">{harnessModelOptions.length ? "Choose a model reported by the harness, or use its automatic default." : "Saving runs a harness check and discovers available models and modes."}</p>
         <label className="provider-consent"><input type="checkbox" checked={harnessLocalOnly} onChange={(event) => setHarnessLocalOnly(event.target.checked)} /><span><strong>Model runtime is local</strong><small>Only enable when prompts and outputs do not leave this machine.</small></span></label>
         <label className="provider-consent"><input type="checkbox" checked={harnessSensitiveData} onChange={(event) => setHarnessSensitiveData(event.target.checked)} /><span><strong>Permit project/document data</strong><small>Allow bounded excerpts in knowledge-enabled requests. Local-only items remain blocked.</small></span></label>
-        <p className="provider-dialog-note">Nebula launches absolute executables directly, never through a shell or ambient PATH search. Native workspace, shell, web, skills, and subagent capabilities remain disabled until explicitly enabled and are frozen per session.</p>
+        <p className="provider-dialog-note">Nebula launches the harness executable directly, but project files and commands are available only through the pinned automation container. Optional web, skills, and subagent capabilities are frozen per session.</p>
         {error && <DiagnosticErrorNotice error={error} fallback="The operation could not be completed." compact />}
         <footer><button className="button secondary" type="button" onClick={() => setHarnessDialog(false)}>Cancel</button><button className="button primary" type="submit" disabled={Boolean(busy) || !name.trim()}>{busy ? "Saving and checking…" : "Save harness"}</button></footer>
     </ModalSurface>}

--- a/ui/src/components/MissionControls.test.tsx
+++ b/ui/src/components/MissionControls.test.tsx
@@ -27,7 +27,7 @@ const api = {
   listHarnesses: vi.fn().mockResolvedValue([harness]),
   listMcpServers: vi.fn().mockResolvedValue([]),
   listHarnessSessions: vi.fn().mockResolvedValue([]),
-  getAutomationRuntime: vi.fn().mockResolvedValue({ configured: false, ready: false, detail: "Optional command runtime unavailable" }),
+  getAutomationRuntime: vi.fn().mockResolvedValue({ configured: true, ready: true, detail: "Pinned automation runtime ready" }),
 };
 
 vi.mock("../state/WorkspaceContext", () => ({
@@ -55,7 +55,8 @@ describe("NewMissionButton", () => {
     await user.type(screen.getByLabelText("Objective"), "Review the bounded project");
     await user.click(screen.getByText("Advanced"));
     expect(screen.getByText("Supervised security automation")).toBeInTheDocument();
-    expect(screen.getByText("Harness native")).toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("Bash and process I/O use Nebula's pinned automation runtime.")).toBeInTheDocument();
     await waitFor(() => expect(screen.getByLabelText("Model")).toHaveValue("gpt-5.6-sol"));
     expect(screen.getByLabelText("Mission harness effort")).toHaveValue("high");
     expect(screen.getByLabelText("Mission harness speed")).toHaveValue("priority");

--- a/ui/src/components/MissionControls.tsx
+++ b/ui/src/components/MissionControls.tsx
@@ -150,11 +150,10 @@ export function NewMissionButton({ className = "button primary", children, showS
 
   const verification = providerModelVerification(provider, model);
   const providerSupportsTools = verification?.status === "verified";
-  const automaticTools = useMemo(() => providerSupportsTools && runtimeReady
+  const automaticTools = useMemo(() => runtimeReady && (runtimeKind === "harness" || providerSupportsTools)
     ? ["run_command", "process_io"]
-    : [], [providerSupportsTools, runtimeReady]);
-  const harnessHasNativeShell = runtimeKind === "harness" && selectedHarness?.nativeCapabilities?.shell === true;
-  const runtimeCanExecute = harnessHasNativeShell || automaticTools.length > 0 || selectedMcpIds.length > 0;
+    : [], [providerSupportsTools, runtimeKind, runtimeReady]);
+  const runtimeCanExecute = automaticTools.length > 0 || selectedMcpIds.length > 0;
   const toolSelectionMessage = toolVerificationBusy
     ? `Checking tool support for ${model.trim()}…`
     : toolPreparation === "preparing"
@@ -163,7 +162,7 @@ export function NewMissionButton({ className = "button primary", children, showS
     ? coreState !== "online"
       ? "Nebula Core is offline; reconnect Core before using command execution."
       : "The pinned automation runtime is not configured."
-    : !providerSupportsTools
+    : runtimeKind !== "harness" && !providerSupportsTools
       ? verification?.status === "failed"
         ? `Tool verification failed for ${model}: ${verification.failureDetail ?? "the provider did not return a valid structured call"}. Reverify it in Settings.`
         : model
@@ -386,10 +385,8 @@ export function NewMissionButton({ className = "button primary", children, showS
               <label>Retries<input type="number" min={0} max={2} value={maxRetries} onChange={(event) => setMaxRetries(Number(event.target.value))} /></label>
             </div>
             <section className="mission-tool-selection">
-              <header><div><Wrench size={15} /><span><strong>Command runtime</strong><small>{harnessHasNativeShell ? "The selected harness owns its frozen shell capability." : "Bash and process I/O use Nebula's pinned automation runtime."}</small></span></div><span>{harnessHasNativeShell ? "Harness native" : automaticTools.length ? "Ready" : "Analysis only"}</span></header>
-              {harnessHasNativeShell
-                ? <div className="mission-tool-empty" role="status"><ShieldCheck size={17} /><p>Native shell access is available through the selected harness and remains governed by its saved capability profile.</p></div>
-                : runtimeReady && providerSupportsTools && automaticTools.length
+              <header><div><Wrench size={15} /><span><strong>Command runtime</strong><small>Bash and process I/O use Nebula's pinned automation runtime.</small></span></div><span>{automaticTools.length ? "Ready" : "Analysis only"}</span></header>
+              {runtimeReady && automaticTools.length
                 ? <fieldset className="resource-checklist automatic-tool-list"><legend>Automatically enabled capabilities</legend>{automaticTools.map((name) => <div key={name}><ShieldCheck size={15} /><span><strong>{name}</strong><small>{name === "run_command" ? "session-scoped Bash · project networking optional" : "poll, stdin, and termination"}</small></span></div>)}</fieldset>
                 : <div className="mission-tool-empty" role="status"><ShieldCheck size={17} /><p>{toolPreparation === "unavailable" ? toolPreparationDetail : toolSelectionMessage}</p></div>}
               {(automaticTools.length > 0 || selectedMcpIds.length > 0 || runtimeKind === "harness") && <div className="resource-form-grid"><label>Maximum execution calls<small id="mission-tool-unlimited-help">Leave blank for unlimited (default)</small><input aria-label="Maximum execution calls" aria-describedby="mission-tool-unlimited-help" type="number" min={1} max={100} placeholder="Unlimited" value={maxToolCalls ?? ""} onChange={(event) => setMaxToolCalls(event.target.value === "" ? null : Number(event.target.value))} /></label><label>Maximum concurrency<input type="number" min={1} max={2} value={maxConcurrency} onChange={(event) => setMaxConcurrency(Number(event.target.value))} /></label></div>}


### PR DESCRIPTION
## Outcome

Force project files and command execution for vendor harnesses through Nebula Core’s pinned automation runtime. Vendor-native shell and project workspace access are clamped off at the API, persisted-profile, frozen-session, adapter, and permission boundaries.

## Operator workflow

- Settings now explains that harness project actions use the pinned container at `/workspace`.
- Native shell/workspace toggles are removed.
- Harness missions automatically expose `run_command` and `process_io` whenever the automation runtime is ready.
- Legacy profiles requesting native shell/workspace access are denied and normalized.

## Verification

- `.venv/bin/pytest -q tests/v3/test_harnesses.py` — 41 passed
- `.venv/bin/ruff check src/nebula/v3/api.py src/nebula/v3/harnesses.py tests/v3/test_harnesses.py` — passed
- `npm test` — 72 files, 364 tests passed
- `npm run build` — production bundle passed
- Playwright mission workflow — 7 projects passed: desktop 1440, compact 1024, Chromium 390/320, WebKit 390/430

## Verification boundary

A live Codex/Grok harness journey, non-loopback LAN run, WebKit 320 profile, and physical-device run were not available locally. CI supplies the broader repository gates; this PR does not claim those unrun environments as verified.