### PR TITLE
Add fail-closed OpenVPN egress for container terminals

### DIFF
--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -6436,7 +6436,7 @@ def create_app(
             session.vpn_profile_id == profile_id
             and session.status
             not in {AutomationSessionStatus.CLOSED, AutomationSessionStatus.FAILED}
-            for session in store.list_entities(AutomationSession, limit=10_000)
+            for session in store.list_entities(AutomationSession, limit=1_000)
         ):
             raise HTTPException(
                 status_code=409,

--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -40,7 +40,7 @@ from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.routing import APIRoute
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.staticfiles import StaticFiles
-from pydantic import Field, ValidationError, model_validator
+from pydantic import Field, SecretStr, ValidationError, model_validator
 from starlette.background import BackgroundTask
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.cors import CORSMiddleware
@@ -1412,6 +1412,7 @@ def create_app(
             tool_platform=tool_platform,
             execution_service=executions,
             command_history=terminal_commands,
+            credential_store=credentials,
             operator_id=active_operator_id,
         )
     if container_terminals is not None and container_terminals.store is not store:
@@ -1424,6 +1425,8 @@ def create_app(
         container_terminals.bind_execution_service(executions)
     if container_terminals is not None and container_terminals.command_history is None:
         container_terminals.bind_command_history(terminal_commands)
+    if container_terminals is not None and container_terminals.credential_store is None:
+        container_terminals.bind_credential_store(credentials)
     workspaces = workspace_service
     if workspaces is None and artifact_store is not None and tool_platform is not None:
         workspaces = WorkspaceService(
@@ -6391,7 +6394,7 @@ def create_app(
                 )
             secret = credentials.create(
                 CredentialCreateRequest(
-                    secret=parsed.config, persistence=request.persistence
+                    secret=SecretStr(parsed.config), persistence=request.persistence
                 )
             )
             try:
@@ -6441,6 +6444,13 @@ def create_app(
             raise HTTPException(
                 status_code=409,
                 detail="close active command sessions using this VPN profile first",
+            )
+        if container_terminals is not None and container_terminals.uses_vpn_profile(
+            profile_id
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail="close active terminal sessions using this VPN profile first",
             )
         store.delete(
             VpnProfile, profile_id, expected_revision=request.expected_revision

--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -212,6 +212,7 @@ from .credentials import (
     CredentialStore,
     CredentialUnavailableError,
 )
+from .vpn import VpnProfileError, parse_openvpn_profile
 from .domain import (
     ENTITY_MODEL_BY_KIND,
     AgentAttempt,
@@ -236,6 +237,8 @@ from .domain import (
     AutomationApprovalPolicy,
     AutomationProjectPolicy,
     AutomationSession,
+    AutomationSessionStatus,
+    VpnProfile,
     CommandExecution,
     ChatBackend,
     ChatMessage,
@@ -483,6 +486,7 @@ CUSTOM_RESOURCES = {
     "library_items",
     "operator_profiles",
     "runner_profiles",
+    "vpn_profiles",
     "browser_actions",
     "browser_handoffs",
     "browser_identities",
@@ -750,8 +754,22 @@ class AutomationPolicyUpdateRequest(NebulaModel):
     approval_policy: AutomationApprovalPolicy = AutomationApprovalPolicy.ON_BOUNDARY
     network_enabled: bool = True
     runner_profile_id: str | None = Field(default=None, max_length=200)
+    vpn_profile_id: str | None = Field(default=None, max_length=200)
     max_timeout_ms: int = Field(default=300_000, ge=1_000, le=86_400_000)
     expected_revision: int | None = Field(default=None, ge=1)
+
+
+class VpnProfileCreateRequest(NebulaModel):
+    name: str = Field(min_length=1, max_length=120)
+    filename: str = Field(min_length=1, max_length=255, pattern=r"^[^/\\]+\.ovpn$")
+    config: str = Field(min_length=1, max_length=15_000)
+    username: str | None = Field(default=None, max_length=512)
+    password: str | None = Field(default=None, max_length=4_096)
+    persistence: Literal["vault", "session"] = "vault"
+
+
+class VpnProfileDeleteRequest(NebulaModel):
+    expected_revision: int = Field(ge=1)
 
 
 class AutomationCommandRequest(RunCommandRequest):
@@ -1240,7 +1258,10 @@ def create_app(
                 workspace_resolver=tool_platform.workspace_for,
                 runtime_resolver=tool_platform.resolve_human_terminal_runtime,
                 cached_runtime_provider=tool_platform.last_automation_runtime_metadata,
+                credential_store=credentials,
             )
+    elif automation_runtime.credential_store is None:
+        automation_runtime.credential_store = credentials
     automation_tool_platform = (
         AutomationToolPlatform(
             manager=automation_runtime,
@@ -6334,6 +6355,99 @@ def create_app(
             )
         return await automation_runtime.prepare()
 
+    def public_vpn_profile(profile: VpnProfile) -> dict[str, Any]:
+        value = profile.model_dump(exclude={"secret_ref"})
+        value["available"] = credentials.status(profile.secret_ref).available
+        return value
+
+    @app.get(
+        f"{API_PREFIX}/vpn-profiles",
+        tags=["automation"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def list_vpn_profiles() -> list[dict[str, Any]]:
+        return [
+            public_vpn_profile(profile)
+            for profile in store.list_entities(VpnProfile, limit=1_000)
+        ]
+
+    @app.post(
+        f"{API_PREFIX}/vpn-profiles",
+        status_code=201,
+        tags=["automation"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def create_vpn_profile(request: VpnProfileCreateRequest) -> dict[str, Any]:
+        try:
+            parsed = parse_openvpn_profile(
+                request.config, username=request.username, password=request.password
+            )
+            if any(
+                item.fingerprint == parsed.fingerprint
+                for item in store.list_entities(VpnProfile, limit=1_000)
+            ):
+                raise HTTPException(
+                    status_code=409, detail="this VPN profile is already saved"
+                )
+            secret = credentials.create(
+                CredentialCreateRequest(
+                    secret=parsed.config, persistence=request.persistence
+                )
+            )
+            try:
+                profile = store.create(
+                    VpnProfile(
+                        name=request.name.strip(),
+                        filename=request.filename,
+                        remote_host=parsed.remote_host,
+                        remote_port=parsed.remote_port,
+                        protocol=parsed.protocol,
+                        fingerprint=parsed.fingerprint,
+                        requires_credentials=parsed.requires_credentials,
+                        secret_ref=secret.reference,
+                    )
+                )
+            except Exception:
+                credentials.delete(secret.reference)
+                raise
+            return public_vpn_profile(profile)
+        except VpnProfileError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    @app.delete(
+        f"{API_PREFIX}/vpn-profiles/{{profile_id}}",
+        status_code=204,
+        tags=["automation"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def delete_vpn_profile(
+        profile_id: str, request: VpnProfileDeleteRequest
+    ) -> Response:
+        profile = store.get(VpnProfile, profile_id)
+        if any(
+            policy.vpn_profile_id == profile_id
+            for policy in store.list_entities(AutomationProjectPolicy, limit=1_000)
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail="remove this VPN profile from project command policies first",
+            )
+        if any(
+            session.vpn_profile_id == profile_id
+            and session.status
+            not in {AutomationSessionStatus.CLOSED, AutomationSessionStatus.FAILED}
+            for session in store.list_entities(AutomationSession, limit=10_000)
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail="close active command sessions using this VPN profile first",
+            )
+        store.delete(
+            VpnProfile, profile_id, expected_revision=request.expected_revision
+        )
+        credentials.delete(profile.secret_ref)
+        return Response(status_code=204)
+
     @app.get(
         f"{API_PREFIX}/engagements/{{engagement_id}}/automation-policy",
         response_model=AutomationProjectPolicy,
@@ -6367,6 +6481,7 @@ def create_app(
             approval_policy=request.approval_policy,
             network_enabled=request.network_enabled,
             runner_profile_id=request.runner_profile_id,
+            vpn_profile_id=request.vpn_profile_id,
             max_timeout_ms=request.max_timeout_ms,
             expected_revision=request.expected_revision,
         )

--- a/src/nebula/v3/automation_runtime.py
+++ b/src/nebula/v3/automation_runtime.py
@@ -41,6 +41,7 @@ from .domain import (
     RunnerIsolation,
     RunnerProfile as StoredRunnerProfile,
     ScopePolicy,
+    VpnProfile,
     ToolCallOrigin,
     WorkspaceChange,
     utc_now,
@@ -66,6 +67,7 @@ from .sandbox import (
     _runtime_environment,
 )
 from .storage import ConflictError, NebulaStore, NotFoundError
+from .credentials import CredentialStore
 
 
 MAX_COMMAND_CHARACTERS = 200_000
@@ -221,6 +223,7 @@ class SessionLaunch:
     workspace_access: SandboxWorkspaceAccess = SandboxWorkspaceAccess.WRITE
     container_user: SandboxContainerUser = SandboxContainerUser.NON_ROOT
     loopback_only: bool = False
+    vpn_config: str | None = None
 
 
 class _ContainerProcess(RuntimeBackendProcess):
@@ -358,6 +361,7 @@ class ContainerRuntimeSession(RuntimeBackendSession):
                     if launch.runner.profile is not None
                     else None
                 ),
+                vpn_config=launch.vpn_config,
             )
         elif launch.loopback_only:
             # The prepared runtime image is digest-pinned and its loopback helper
@@ -576,6 +580,7 @@ class AutomationRuntimeManager:
         runtime_resolver: RuntimeResolver | None = None,
         cached_runtime_provider: CachedRuntimeProvider | None = None,
         session_factory: SessionFactory | None = None,
+        credential_store: CredentialStore | None = None,
     ) -> None:
         if runtime_image is None and runtime_resolver is None:
             raise ValueError("automation runtime requires an image or Kali resolver")
@@ -595,6 +600,7 @@ class AutomationRuntimeManager:
         self.runtime_resolver = runtime_resolver
         self.cached_runtime_provider = cached_runtime_provider
         self.session_factory = session_factory or ContainerRuntimeSession.start
+        self.credential_store = credential_store
         self.capture_root = self.data_root / "automation-runtime" / "captures"
         self.capture_root.mkdir(parents=True, exist_ok=True, mode=0o700)
         self.capture_root.chmod(0o700)
@@ -760,6 +766,7 @@ class AutomationRuntimeManager:
         approval_policy: AutomationApprovalPolicy,
         network_enabled: bool,
         runner_profile_id: str | None,
+        vpn_profile_id: str | None = None,
         max_timeout_ms: int,
         expected_revision: int | None = None,
     ) -> AutomationProjectPolicy:
@@ -770,6 +777,19 @@ class AutomationRuntimeManager:
                 raise AutomationRuntimeUnavailable(
                     "selected runner is not verified healthy"
                 )
+        if vpn_profile_id is not None:
+            if not network_enabled:
+                raise AutomationRuntimeUnavailable(
+                    "enable project networking before selecting a VPN profile"
+                )
+            vpn = self.store.get(VpnProfile, vpn_profile_id)
+            if (
+                self.credential_store is None
+                or not self.credential_store.status(vpn.secret_ref).available
+            ):
+                raise AutomationRuntimeUnavailable(
+                    "selected VPN profile is unavailable"
+                )
         return self.store.update(
             AutomationProjectPolicy,
             current.id,
@@ -777,6 +797,7 @@ class AutomationRuntimeManager:
                 "approval_policy": approval_policy,
                 "network_enabled": network_enabled,
                 "runner_profile_id": runner_profile_id,
+                "vpn_profile_id": vpn_profile_id,
                 "max_timeout_ms": max_timeout_ms,
             },
             expected_revision=expected_revision or current.revision,
@@ -1261,6 +1282,17 @@ class AutomationRuntimeManager:
                 else None
             )
             rules, domains = self._network_boundary(policy, scope)
+            vpn: VpnProfile | None = None
+            vpn_config = None
+            if policy.vpn_profile_id is not None:
+                if self.credential_store is None:
+                    raise AutomationRuntimeUnavailable(
+                        "VPN secret storage is unavailable"
+                    )
+                vpn = self.store.get(VpnProfile, policy.vpn_profile_id)
+                vpn_config = self.credential_store.resolve(
+                    vpn.secret_ref
+                ).get_secret_value()
             has_network_boundary = bool(rules or domains)
             session = AutomationSession(
                 engagement_id=engagement_id,
@@ -1274,6 +1306,8 @@ class AutomationRuntimeManager:
                 policy_revision=policy.revision,
                 scope_policy_id=scope.id if scope is not None else None,
                 scope_policy_revision=scope.revision if scope is not None else None,
+                vpn_profile_id=vpn.id if vpn is not None else None,
+                vpn_profile_revision=vpn.revision if vpn is not None else None,
                 # Even an automatic project never receives egress until a
                 # command explicitly asks for project_scope.
                 network_granted=False,
@@ -1308,6 +1342,7 @@ class AutomationRuntimeManager:
                         else (),
                         resolv_conf=resolver_file,
                         network_granted=session.network_granted,
+                        vpn_config=vpn_config,
                     )
                 )
             except Exception as exc:

--- a/src/nebula/v3/automation_runtime.py
+++ b/src/nebula/v3/automation_runtime.py
@@ -1329,7 +1329,7 @@ class AutomationRuntimeManager:
                 backend = await self.session_factory(
                     SessionLaunch(
                         session_id=session.id,
-                        runner=self._runner(profile),
+                        runner=self._runner(profile, workspace=workspace),
                         image=self.runtime_image,
                         workspace=workspace,
                         limits=SandboxLimits(
@@ -1405,7 +1405,11 @@ class AutomationRuntimeManager:
         return sorted(profiles, key=lambda item: (item.created_at, item.id))[0]
 
     def _runner(
-        self, stored: StoredRunnerProfile, *, helper_image: str | None = None
+        self,
+        stored: StoredRunnerProfile,
+        *,
+        helper_image: str | None = None,
+        workspace: Path | None = None,
     ) -> ContainerSandboxRunner:
         platform = (
             RunnerPlatform.LINUX
@@ -1435,12 +1439,21 @@ class AutomationRuntimeManager:
             if stored.seccomp_profile
             else None,
         )
+        workspace_roots = [self.data_root]
+        if workspace is not None:
+            resolved_workspace = workspace.expanduser().resolve(strict=True)
+            if not resolved_workspace.is_dir():
+                raise AutomationRuntimeUnavailable(
+                    "configured project workspace is not a directory"
+                )
+            if resolved_workspace not in workspace_roots:
+                workspace_roots.append(resolved_workspace)
         return ContainerSandboxRunner(
             profile=profile,
             egress_controller=ContainerEgressController(
                 helper_image=helper_image or self.runtime_image
             ),
-            workspace_roots=[self.data_root],
+            workspace_roots=workspace_roots,
         )
 
     @staticmethod

--- a/src/nebula/v3/container_terminal.py
+++ b/src/nebula/v3/container_terminal.py
@@ -22,19 +22,22 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from time import monotonic
 from typing import AsyncIterator, Callable, Literal
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 from pydantic import Field, field_validator
 
 from .domain import (
+    AutomationProjectPolicy,
     Engagement,
     ExecutionLimitsSnapshot,
     NebulaModel,
     OperationEvent,
     RunnerIsolation,
     RunnerRuntime,
+    VpnProfile,
     utc_now,
 )
+from .credentials import CredentialStore
 from .executions import (
     ExecutionService,
     _WorkspaceLimitError,
@@ -54,7 +57,7 @@ from .sandbox import (
     SandboxTerminalProcess,
     SandboxWorkspaceAccess,
 )
-from .storage import NebulaStore
+from .storage import NebulaStore, NotFoundError
 from .terminal_history import (
     CapturedTerminalCommand,
     Osc633CommandParser,
@@ -204,8 +207,11 @@ class ContainerTerminalRuntimeSnapshot(NebulaModel):
 
 
 class ContainerTerminalNetworkSnapshot(NebulaModel):
-    mode: Literal["unrestricted"] = "unrestricted"
-    runtime_network: Literal["bridge"] = "bridge"
+    mode: Literal["unrestricted", "vpn"] = "unrestricted"
+    runtime_network: Literal["bridge", "private_namespace"] = "bridge"
+    vpn_profile_id: str | None = Field(default=None, max_length=200)
+    vpn_profile_revision: int | None = Field(default=None, ge=1)
+    vpn_profile_name: str | None = Field(default=None, max_length=120)
     published_ports: list[ContainerTerminalPublishedPort] = Field(
         default_factory=list, max_length=16
     )
@@ -290,11 +296,13 @@ class ContainerTerminalRecoveryResponse(NebulaModel):
     active: bool
     session: ContainerTerminalStartResponse | None = None
     runtime: ContainerTerminalRuntimeSnapshot | None = None
+    network: ContainerTerminalNetworkSnapshot | None = None
 
 
 class ContainerTerminalRecoveredSession(NebulaModel):
     session: ContainerTerminalStartResponse
     runtime: ContainerTerminalRuntimeSnapshot
+    network: ContainerTerminalNetworkSnapshot
 
 
 class ContainerTerminalRecoveryListResponse(NebulaModel):
@@ -316,6 +324,7 @@ class _PreparedTerminal:
     sandbox_request: SandboxRequest
     policy_rule: str
     policy_detail: str
+    vpn_config: str | None = None
 
 
 @dataclass
@@ -325,6 +334,7 @@ class _TerminalReservation:
     request_fingerprint: str
     preview_fingerprint: str
     runtime: ContainerTerminalRuntimeSnapshot
+    network: ContainerTerminalNetworkSnapshot
     operator_id: str
     websocket_ticket: str
     ticket_expires_at: datetime | None
@@ -397,6 +407,7 @@ class ContainerTerminalService:
         tool_platform: RuntimePlatform | None,
         execution_service: ExecutionService | None = None,
         command_history: TerminalCommandHistory | None = None,
+        credential_store: CredentialStore | None = None,
         operator_id: Callable[[], str] | None = None,
         audit_nonce_factory: Callable[[], str] | None = None,
         max_active: int = 32,
@@ -421,6 +432,7 @@ class ContainerTerminalService:
         self.tool_platform = tool_platform
         self.execution_service = execution_service
         self.command_history = command_history
+        self.credential_store = credential_store
         self.operator_id = operator_id or (lambda: "system")
         self.audit_nonce_factory = audit_nonce_factory or (
             lambda: secrets.token_urlsafe(24)
@@ -463,6 +475,56 @@ class ContainerTerminalService:
         if self._sessions:
             raise ValueError("cannot bind command history after terminal startup")
         self.command_history = history
+
+    def bind_credential_store(self, credentials: CredentialStore) -> None:
+        if self._sessions:
+            raise ValueError("cannot bind credential storage after terminal startup")
+        self.credential_store = credentials
+
+    def uses_vpn_profile(self, profile_id: str) -> bool:
+        return any(
+            session.network.vpn_profile_id == profile_id
+            for session in (
+                *self._sessions.values(),
+                *self._finishing_sessions.values(),
+            )
+        )
+
+    def _selected_vpn(self, engagement_id: str) -> tuple[VpnProfile, str] | None:
+        policy_id = str(
+            uuid5(NAMESPACE_URL, f"nebula:automation-policy:{engagement_id}")
+        )
+        try:
+            policy = self.store.get(AutomationProjectPolicy, policy_id)
+        except NotFoundError:
+            return None
+        if policy.vpn_profile_id is None:
+            return None
+        if not policy.network_enabled:
+            raise ContainerTerminalError(
+                "vpn_unavailable",
+                "enable project networking before starting a VPN terminal",
+            )
+        try:
+            profile = self.store.get(VpnProfile, policy.vpn_profile_id)
+        except NotFoundError as exc:
+            raise ContainerTerminalError(
+                "vpn_unavailable",
+                "the selected VPN profile no longer exists; choose another profile",
+            ) from exc
+        if self.credential_store is None:
+            raise ContainerTerminalError(
+                "vpn_unavailable", "VPN secret storage is unavailable"
+            )
+        status = self.credential_store.status(profile.secret_ref)
+        if not status.available:
+            raise ContainerTerminalError(
+                "vpn_unavailable",
+                "the selected VPN profile is unavailable; upload it again or choose another profile",
+            )
+        return profile, self.credential_store.resolve(
+            profile.secret_ref
+        ).get_secret_value()
 
     def workspace_lock(self, engagement_id: str) -> asyncio.Lock:
         if self.execution_service is not None:
@@ -548,6 +610,7 @@ class ContainerTerminalService:
         error_code: str | None = None
         workspace_entries: int | None = None
         workspace_max_entries: int | None = None
+        network = ContainerTerminalNetworkSnapshot()
         if self.tool_platform is None:
             detail = "human terminal container execution is not configured"
         else:
@@ -562,10 +625,20 @@ class ContainerTerminalService:
                 workspace_max_entries = 50_000
                 if report.allowed:
                     ready = True
+                    selected_vpn = self._selected_vpn(engagement_id)
+                    if selected_vpn is not None:
+                        profile, _config = selected_vpn
+                        network = ContainerTerminalNetworkSnapshot(
+                            mode="vpn",
+                            runtime_network="private_namespace",
+                            vpn_profile_id=profile.id,
+                            vpn_profile_revision=profile.revision,
+                            vpn_profile_name=profile.name,
+                        )
                 else:
                     detail = report.detail
                     error_code = report.error_code or "workspace_limit"
-            except RuntimePlatformError as exc:
+            except (RuntimePlatformError, ContainerTerminalError) as exc:
                 record_caught_exception(
                     "terminal",
                     "terminal.container_terminal.caught_failure_001",
@@ -573,7 +646,14 @@ class ContainerTerminalService:
                     exc,
                     stage="container_terminal",
                 )
-                detail = str(exc)
+                detail = (
+                    exc.detail if isinstance(exc, ContainerTerminalError) else str(exc)
+                )
+                error_code = (
+                    exc.code
+                    if isinstance(exc, ContainerTerminalError)
+                    else "runner_unavailable"
+                )
         return ContainerTerminalCapabilities(
             engagement_id=engagement_id,
             ready=ready,
@@ -581,6 +661,7 @@ class ContainerTerminalService:
             error_code=error_code,
             workspace_entries=workspace_entries,
             workspace_max_entries=workspace_max_entries,
+            network=network,
             idle_timeout_seconds=int(self.idle_timeout_seconds),
         )
 
@@ -710,6 +791,7 @@ class ContainerTerminalService:
                 request_fingerprint=request_fingerprint,
                 preview_fingerprint=request.preview_fingerprint,
                 runtime=prepared.runtime,
+                network=prepared.network,
                 operator_id=operator_id,
                 websocket_ticket=ticket,
                 ticket_expires_at=expires,
@@ -814,10 +896,12 @@ class ContainerTerminalService:
                 response = self._recover_session_locked(session, now)
                 assert response.session is not None
                 assert response.runtime is not None
+                assert response.network is not None
                 recovered.append(
                     ContainerTerminalRecoveredSession(
                         session=response.session,
                         runtime=response.runtime,
+                        network=response.network,
                     )
                 )
             return ContainerTerminalRecoveryListResponse(sessions=recovered)
@@ -894,6 +978,7 @@ class ContainerTerminalService:
             active=True,
             session=recovered,
             runtime=session.runtime,
+            network=session.network,
         )
 
     async def claim(self, session_id: str, ticket: str) -> str:
@@ -1299,6 +1384,7 @@ class ContainerTerminalService:
                 container_name="nebula-terminal-" + session.id.replace("-", "")[:40],
                 columns=session.request.columns,
                 rows=session.request.rows,
+                vpn_config=prepared.vpn_config,
             )
         except (SandboxError, RuntimePlatformError) as exc:
             record_caught_exception(
@@ -1877,9 +1963,22 @@ class ContainerTerminalService:
                 default_tools=resolution.image.security_tools,
             )
         runtime = _runtime_snapshot(resolution)
-        network = ContainerTerminalNetworkSnapshot(
-            published_ports=request.published_ports
-        )
+        selected_vpn = self._selected_vpn(request.engagement_id)
+        vpn_config: str | None = None
+        if selected_vpn is None:
+            network = ContainerTerminalNetworkSnapshot(
+                published_ports=request.published_ports
+            )
+        else:
+            vpn_profile, vpn_config = selected_vpn
+            network = ContainerTerminalNetworkSnapshot(
+                mode="vpn",
+                runtime_network="private_namespace",
+                vpn_profile_id=vpn_profile.id,
+                vpn_profile_revision=vpn_profile.revision,
+                vpn_profile_name=vpn_profile.name,
+                published_ports=request.published_ports,
+            )
         security = ContainerTerminalSecuritySnapshot()
         sandbox_request = SandboxRequest(
             image=resolution.image.resolved_reference,
@@ -1893,7 +1992,11 @@ class ContainerTerminalService:
                 "PROMPT_COMMAND": TERMINAL_PROMPT_COMMAND,
                 "TERM": "xterm-256color",
             },
-            network=SandboxNetwork.UNRESTRICTED,
+            network=(
+                SandboxNetwork.VPN
+                if selected_vpn is not None
+                else SandboxNetwork.UNRESTRICTED
+            ),
             published_ports=[
                 SandboxPublishedPort.model_validate(item.model_dump(mode="json"))
                 for item in request.published_ports
@@ -1915,9 +2018,18 @@ class ContainerTerminalService:
             network=network,
             security=security,
             sandbox_request=sandbox_request,
-            policy_rule="human_terminal_unrestricted",
+            policy_rule=(
+                "human_terminal_vpn"
+                if selected_vpn is not None
+                else "human_terminal_unrestricted"
+            ),
             policy_detail=(
-                f"{resolution.image.detail}; human terminal has unrestricted outbound bridge networking"
+                f"{resolution.image.detail}; "
+                + (
+                    f"all terminal egress is fail-closed through VPN profile {vpn_profile.name!r}"
+                    if selected_vpn is not None
+                    else "human terminal has unrestricted outbound bridge networking"
+                )
                 + (
                     "; inbound ports "
                     + ", ".join(
@@ -1929,6 +2041,7 @@ class ContainerTerminalService:
                     else "; no inbound ports are published"
                 )
             ),
+            vpn_config=vpn_config,
         )
 
     def _recover_interrupted_events(self) -> None:

--- a/src/nebula/v3/container_terminal.py
+++ b/src/nebula/v3/container_terminal.py
@@ -497,6 +497,7 @@ class ContainerTerminalService:
         try:
             policy = self.store.get(AutomationProjectPolicy, policy_id)
         except NotFoundError:
+            # diagnostic-expected: projects without a saved policy use direct networking.
             return None
         if policy.vpn_profile_id is None:
             return None

--- a/src/nebula/v3/container_terminal.py
+++ b/src/nebula/v3/container_terminal.py
@@ -1788,6 +1788,11 @@ class ContainerTerminalService:
             "security": prepared.security.model_dump(mode="json"),
             "limits": _terminal_limits().model_dump(mode="json"),
             "workspace": "/workspace",
+            # Bind the reviewed session to the resolved host workspace without
+            # disclosing that host path to the remote browser.
+            "workspace_identity": hashlib.sha256(
+                os.fsencode(prepared.resolution.workspace)
+            ).hexdigest(),
             "policy_rule": prepared.policy_rule,
             "fresh_container": True,
             "idle_timeout_seconds": int(self.idle_timeout_seconds),

--- a/src/nebula/v3/domain.py
+++ b/src/nebula/v3/domain.py
@@ -870,7 +870,23 @@ class AutomationProjectPolicy(Entity):
     approval_policy: AutomationApprovalPolicy = AutomationApprovalPolicy.ON_BOUNDARY
     network_enabled: bool = True
     runner_profile_id: str | None = Field(default=None, max_length=200)
+    vpn_profile_id: str | None = Field(default=None, max_length=200)
     max_timeout_ms: int = Field(default=300_000, ge=1_000, le=86_400_000)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class VpnProfile(Entity):
+    """Public metadata for an OpenVPN profile; secret material stays in the vault."""
+
+    entity_kind: ClassVar[str] = "vpn_profiles"
+    name: str = Field(min_length=1, max_length=120)
+    filename: str = Field(min_length=1, max_length=255)
+    remote_host: str = Field(min_length=1, max_length=253)
+    remote_port: int = Field(ge=1, le=65_535)
+    protocol: str = Field(pattern=r"^(udp|tcp)$")
+    fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
+    requires_credentials: bool = False
+    secret_ref: str = Field(min_length=1, max_length=200)
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -889,6 +905,8 @@ class AutomationSession(Entity):
     policy_revision: int = Field(ge=1)
     scope_policy_id: str | None = Field(default=None, max_length=200)
     scope_policy_revision: int | None = Field(default=None, ge=1)
+    vpn_profile_id: str | None = Field(default=None, max_length=200)
+    vpn_profile_revision: int | None = Field(default=None, ge=1)
     status: AutomationSessionStatus = AutomationSessionStatus.STARTING
     network_granted: bool = False
     started_at: datetime = Field(default_factory=utc_now)
@@ -900,6 +918,8 @@ class AutomationSession(Entity):
     def scope_snapshot_is_complete(self) -> "AutomationSession":
         if (self.scope_policy_id is None) != (self.scope_policy_revision is None):
             raise ValueError("automation scope id and revision must be stored together")
+        if (self.vpn_profile_id is None) != (self.vpn_profile_revision is None):
+            raise ValueError("automation VPN id and revision must be stored together")
         return self
 
 
@@ -3911,6 +3931,7 @@ ENTITY_MODELS: tuple[type[Entity], ...] = (
     Engagement,
     ScopePolicy,
     AutomationProjectPolicy,
+    VpnProfile,
     AutomationSession,
     CommandExecution,
     RunnerProfile,

--- a/src/nebula/v3/egress_helper.py
+++ b/src/nebula/v3/egress_helper.py
@@ -231,6 +231,21 @@ def _vpn_log_detail(config: str, path: Path = VPN_LOG_PATH) -> str:
     return detail.replace(str(Path("/run/nebula-client.ovpn")), "[VPN profile]")
 
 
+def _openvpn_arguments(path: Path) -> list[str]:
+    return [
+        "openvpn",
+        "--config",
+        str(path),
+        "--dev",
+        "tun0",
+        "--auth-nocache",
+        "--script-security",
+        "1",
+        "--tmp-dir",
+        "/run",
+    ]
+
+
 def _start_vpn(config: str) -> subprocess.Popen[bytes]:
     rewritten, address, port, protocol = _vpn_material(config)
     binary = "iptables" if address.version == 4 else "ip6tables"
@@ -258,16 +273,7 @@ def _start_vpn(config: str) -> subprocess.Popen[bytes]:
     path.chmod(0o600)
     with VPN_LOG_PATH.open("wb") as vpn_log:
         process = subprocess.Popen(
-            [
-                "openvpn",
-                "--config",
-                str(path),
-                "--dev",
-                "tun0",
-                "--auth-nocache",
-                "--script-security",
-                "1",
-            ],
+            _openvpn_arguments(path),
             stdin=subprocess.DEVNULL,
             stdout=vpn_log,
             stderr=subprocess.STDOUT,

--- a/src/nebula/v3/egress_helper.py
+++ b/src/nebula/v3/egress_helper.py
@@ -24,6 +24,8 @@ DNS_PORT = 53
 SIOCGIFFLAGS = 0x8913
 SIOCSIFFLAGS = 0x8914
 IFF_UP = 0x1
+VPN_LOG_PATH = Path("/run/nebula-openvpn.log")
+VPN_LOG_BYTES = 4_096
 
 
 def _rule(value: str) -> tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, str]:
@@ -207,6 +209,28 @@ def _vpn_material(
     return rewritten, address, port, protocol
 
 
+def _vpn_log_detail(config: str, path: Path = VPN_LOG_PATH) -> str:
+    """Return a bounded diagnostic tail without disclosing inline credentials."""
+
+    try:
+        raw = path.read_bytes()[-VPN_LOG_BYTES:]
+    except OSError:
+        return ""
+    detail = raw.decode("utf-8", errors="replace").strip()
+    in_credentials = False
+    for line in config.splitlines():
+        normalized = line.strip().lower()
+        if normalized == "<auth-user-pass>":
+            in_credentials = True
+            continue
+        if normalized == "</auth-user-pass>":
+            in_credentials = False
+            continue
+        if in_credentials and line:
+            detail = detail.replace(line, "[REDACTED]")
+    return detail.replace(str(Path("/run/nebula-client.ovpn")), "[VPN profile]")
+
+
 def _start_vpn(config: str) -> subprocess.Popen[bytes]:
     rewritten, address, port, protocol = _vpn_material(config)
     binary = "iptables" if address.version == 4 else "ip6tables"
@@ -232,25 +256,30 @@ def _start_vpn(config: str) -> subprocess.Popen[bytes]:
     path = Path("/run/nebula-client.ovpn")
     path.write_text(rewritten, encoding="utf-8")
     path.chmod(0o600)
-    process = subprocess.Popen(
-        [
-            "openvpn",
-            "--config",
-            str(path),
-            "--dev",
-            "tun0",
-            "--auth-nocache",
-            "--script-security",
-            "1",
-        ],
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.STDOUT,
-    )
+    with VPN_LOG_PATH.open("wb") as vpn_log:
+        process = subprocess.Popen(
+            [
+                "openvpn",
+                "--config",
+                str(path),
+                "--dev",
+                "tun0",
+                "--auth-nocache",
+                "--script-security",
+                "1",
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=vpn_log,
+            stderr=subprocess.STDOUT,
+        )
     deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
         if process.poll() is not None:
-            raise RuntimeError("OpenVPN exited before the tunnel became ready")
+            detail = _vpn_log_detail(config)
+            raise RuntimeError(
+                "OpenVPN exited before the tunnel became ready"
+                + (f": {detail}" if detail else "")
+            )
         try:
             link = subprocess.run(
                 ["ip", "-o", "link", "show", "tun0"],
@@ -276,7 +305,15 @@ def _start_vpn(config: str) -> subprocess.Popen[bytes]:
             pass
         time.sleep(0.1)
     process.terminate()
-    raise RuntimeError("OpenVPN tunnel readiness timed out")
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+    detail = _vpn_log_detail(config)
+    raise RuntimeError(
+        "OpenVPN tunnel readiness timed out" + (f": {detail}" if detail else "")
+    )
 
 
 def _read_name(packet: bytes, offset: int) -> tuple[str, int]:

--- a/src/nebula/v3/egress_helper.py
+++ b/src/nebula/v3/egress_helper.py
@@ -143,13 +143,16 @@ def _base(binary: str) -> None:
 
 
 def _install_rule(
-    network: ipaddress.IPv4Network | ipaddress.IPv6Network, port: str
+    network: ipaddress.IPv4Network | ipaddress.IPv6Network,
+    port: str,
+    interface: str | None = None,
 ) -> None:
     binary = "iptables" if network.version == 4 else "ip6tables"
+    arguments = [binary, "-A", "OUTPUT"]
+    if interface is not None:
+        arguments.extend(["-o", interface])
     _run(
-        binary,
-        "-A",
-        "OUTPUT",
+        *arguments,
         "-p",
         "tcp",
         "-d",
@@ -163,9 +166,117 @@ def _install_rule(
 
 def _install_rules(
     rules: list[tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, str]],
+    interface: str | None = None,
 ) -> None:
     for network, port in rules:
-        _install_rule(network, port)
+        _install_rule(network, port, interface)
+
+
+def _vpn_material(
+    config: str,
+) -> tuple[str, ipaddress.IPv4Address | ipaddress.IPv6Address, int, str]:
+    remote_line = next(
+        (
+            line
+            for line in config.splitlines()
+            if line.strip().lower().startswith("remote ")
+        ),
+        None,
+    )
+    protocol_line = next(
+        (
+            line
+            for line in config.splitlines()
+            if line.strip().lower().startswith("proto ")
+        ),
+        "proto udp",
+    )
+    if remote_line is None:
+        raise ValueError("VPN profile has no remote")
+    fields = remote_line.split()
+    host = fields[1]
+    port = int(fields[2]) if len(fields) > 2 else 1194
+    protocol = "tcp" if protocol_line.split()[1].lower().startswith("tcp") else "udp"
+    addresses = socket.getaddrinfo(
+        host, port, type=socket.SOCK_STREAM if protocol == "tcp" else socket.SOCK_DGRAM
+    )
+    if not addresses:
+        raise ValueError("VPN remote could not be resolved")
+    address = ipaddress.ip_address(addresses[0][4][0])
+    rewritten = config.replace(remote_line, f"remote {address} {port}", 1)
+    return rewritten, address, port, protocol
+
+
+def _start_vpn(config: str) -> subprocess.Popen[bytes]:
+    rewritten, address, port, protocol = _vpn_material(config)
+    binary = "iptables" if address.version == 4 else "ip6tables"
+    _run(
+        binary,
+        "-A",
+        "OUTPUT",
+        "-o",
+        "eth0",
+        "-p",
+        protocol,
+        "-d",
+        str(address),
+        "--dport",
+        str(port),
+        "-m",
+        "owner",
+        "--uid-owner",
+        "0",
+        "-j",
+        "ACCEPT",
+    )
+    path = Path("/run/nebula-client.ovpn")
+    path.write_text(rewritten, encoding="utf-8")
+    path.chmod(0o600)
+    process = subprocess.Popen(
+        [
+            "openvpn",
+            "--config",
+            str(path),
+            "--dev",
+            "tun0",
+            "--auth-nocache",
+            "--script-security",
+            "1",
+        ],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError("OpenVPN exited before the tunnel became ready")
+        try:
+            link = subprocess.run(
+                ["ip", "-o", "link", "show", "tun0"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            routes = subprocess.run(
+                ["ip", "route", "show", "dev", "tun0"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            if (
+                "UP" in link.stdout
+                and "0.0.0.0/1" in routes.stdout
+                and "128.0.0.0/1" in routes.stdout
+            ):
+                return process
+        except subprocess.CalledProcessError:
+            pass
+        time.sleep(0.1)
+    process.terminate()
+    raise RuntimeError("OpenVPN tunnel readiness timed out")
 
 
 def _read_name(packet: bytes, offset: int) -> tuple[str, int]:
@@ -320,6 +431,7 @@ class PolicyResolver:
         ports: list[int],
         explicit_networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network],
         enabled: bool,
+        interface: str | None = None,
     ) -> None:
         self.domains = domains
         self.ports = [str(port) for port in ports] or ["1:65535"]
@@ -329,6 +441,7 @@ class PolicyResolver:
         self.lock = threading.Lock()
         self.stopped = threading.Event()
         self.enabled = threading.Event()
+        self.interface = interface
         if enabled:
             self.enabled.set()
         self.sockets: list[socket.socket] = []
@@ -397,7 +510,7 @@ class PolicyResolver:
                     for port in self.ports:
                         key = (str(network), port)
                         if key not in self.installed:
-                            _install_rule(network, port)
+                            _install_rule(network, port, self.interface)
                             self.installed.add(key)
             return response
         except (OSError, subprocess.SubprocessError, ValueError):
@@ -473,6 +586,7 @@ def serve(
     domain_ports: list[int],
     *,
     disabled: bool,
+    vpn_config: str | None = None,
 ) -> int:
     legacy = list(map(_rule, values))
     rules = [*legacy, *[_cidr_rule(value) for value in cidr_values]]
@@ -480,12 +594,16 @@ def serve(
         raise ValueError("at least one allow rule or domain is required")
     _base("iptables")
     _base("ip6tables")
+    vpn_process = (
+        _start_vpn(vpn_config) if vpn_config is not None and not disabled else None
+    )
     resolver = (
         PolicyResolver(
             domains=domains,
             ports=domain_ports,
             explicit_networks=[network for network, _port in rules],
             enabled=not disabled,
+            interface="tun0" if vpn_config is not None else None,
         )
         if domains
         else None
@@ -493,7 +611,7 @@ def serve(
     if resolver is not None:
         resolver.start()
     if not disabled:
-        _install_rules(rules)
+        _install_rules(rules, "tun0" if vpn_config is not None else None)
     stopped = threading.Event()
     signal.signal(signal.SIGTERM, lambda *_: stopped.set())
     signal.signal(signal.SIGINT, lambda *_: stopped.set())
@@ -501,14 +619,20 @@ def serve(
     try:
         while not stopped.wait(0.1):
             if disabled and ENABLE_REQUEST.exists():
-                _install_rules(rules)
+                if vpn_config is not None:
+                    vpn_process = _start_vpn(vpn_config)
+                _install_rules(rules, "tun0" if vpn_config is not None else None)
                 if resolver is not None:
                     resolver.enable()
                 disabled = False
                 ENABLE_ACK.touch(mode=0o600, exist_ok=True)
+            if vpn_process is not None and vpn_process.poll() is not None:
+                raise RuntimeError("OpenVPN tunnel stopped; egress remains blocked")
     finally:
         if resolver is not None:
             resolver.close()
+        if vpn_process is not None and vpn_process.poll() is None:
+            vpn_process.terminate()
     return 0
 
 
@@ -532,6 +656,7 @@ def main(argv: list[str] | None = None) -> int:
     serve_parser.add_argument("--domain", action="append", default=[])
     serve_parser.add_argument("--domain-port", action="append", type=int, default=[])
     serve_parser.add_argument("--disabled", action="store_true")
+    serve_parser.add_argument("--vpn-stdin", action="store_true")
     subparsers.add_parser("enable")
     subparsers.add_parser("loopback")
     options = parser.parse_args(argv)
@@ -548,6 +673,7 @@ def main(argv: list[str] | None = None) -> int:
             options.domain,
             options.domain_port,
             disabled=options.disabled,
+            vpn_config=sys.stdin.read() if options.vpn_stdin else None,
         )
     except Exception as exc:
         # diagnostic-expected: this isolated helper reports startup failure to its supervisor.

--- a/src/nebula/v3/egress_helper.py
+++ b/src/nebula/v3/egress_helper.py
@@ -215,6 +215,7 @@ def _vpn_log_detail(config: str, path: Path = VPN_LOG_PATH) -> str:
     try:
         raw = path.read_bytes()[-VPN_LOG_BYTES:]
     except OSError:
+        # diagnostic-expected: the optional VPN log may not exist after early startup failure.
         return ""
     detail = raw.decode("utf-8", errors="replace").strip()
     in_credentials = False
@@ -308,12 +309,14 @@ def _start_vpn(config: str) -> subprocess.Popen[bytes]:
             ):
                 return process
         except subprocess.CalledProcessError:
+            # diagnostic-expected: readiness polling continues until the bounded deadline.
             pass
         time.sleep(0.1)
     process.terminate()
     try:
         process.wait(timeout=5)
     except subprocess.TimeoutExpired:
+        # diagnostic-expected: escalation to kill is the bounded shutdown fallback.
         process.kill()
         process.wait(timeout=5)
     detail = _vpn_log_detail(config)

--- a/src/nebula/v3/egress_helper.py
+++ b/src/nebula/v3/egress_helper.py
@@ -587,10 +587,13 @@ def serve(
     *,
     disabled: bool,
     vpn_config: str | None = None,
+    vpn_unrestricted: bool = False,
 ) -> int:
     legacy = list(map(_rule, values))
     rules = [*legacy, *[_cidr_rule(value) for value in cidr_values]]
-    if not rules and not domains:
+    if vpn_unrestricted and vpn_config is None:
+        raise ValueError("unrestricted VPN egress requires a VPN profile")
+    if not vpn_unrestricted and not rules and not domains:
         raise ValueError("at least one allow rule or domain is required")
     _base("iptables")
     _base("ip6tables")
@@ -611,7 +614,11 @@ def serve(
     if resolver is not None:
         resolver.start()
     if not disabled:
-        _install_rules(rules, "tun0" if vpn_config is not None else None)
+        if vpn_unrestricted:
+            _run("iptables", "-A", "OUTPUT", "-o", "tun0", "-j", "ACCEPT")
+            _run("ip6tables", "-A", "OUTPUT", "-o", "tun0", "-j", "ACCEPT")
+        else:
+            _install_rules(rules, "tun0" if vpn_config is not None else None)
     stopped = threading.Event()
     signal.signal(signal.SIGTERM, lambda *_: stopped.set())
     signal.signal(signal.SIGINT, lambda *_: stopped.set())
@@ -621,7 +628,11 @@ def serve(
             if disabled and ENABLE_REQUEST.exists():
                 if vpn_config is not None:
                     vpn_process = _start_vpn(vpn_config)
-                _install_rules(rules, "tun0" if vpn_config is not None else None)
+                if vpn_unrestricted:
+                    _run("iptables", "-A", "OUTPUT", "-o", "tun0", "-j", "ACCEPT")
+                    _run("ip6tables", "-A", "OUTPUT", "-o", "tun0", "-j", "ACCEPT")
+                else:
+                    _install_rules(rules, "tun0" if vpn_config is not None else None)
                 if resolver is not None:
                     resolver.enable()
                 disabled = False
@@ -657,6 +668,7 @@ def main(argv: list[str] | None = None) -> int:
     serve_parser.add_argument("--domain-port", action="append", type=int, default=[])
     serve_parser.add_argument("--disabled", action="store_true")
     serve_parser.add_argument("--vpn-stdin", action="store_true")
+    serve_parser.add_argument("--vpn-unrestricted", action="store_true")
     subparsers.add_parser("enable")
     subparsers.add_parser("loopback")
     options = parser.parse_args(argv)
@@ -674,6 +686,7 @@ def main(argv: list[str] | None = None) -> int:
             options.domain_port,
             disabled=options.disabled,
             vpn_config=sys.stdin.read() if options.vpn_stdin else None,
+            vpn_unrestricted=options.vpn_unrestricted,
         )
     except Exception as exc:
         # diagnostic-expected: this isolated helper reports startup failure to its supervisor.

--- a/src/nebula/v3/runtime_platform.py
+++ b/src/nebula/v3/runtime_platform.py
@@ -272,6 +272,7 @@ class RuntimePlatform:
         """Prepare and return the one Kali image shared with agent automation."""
 
         profile = self.resolve_human_terminal_profile(engagement_id)
+        workspace = self.workspace_for(engagement_id)
         key = (profile.id, profile.revision)
         image = self._prepared_images.get(key)
         if image is None:
@@ -303,8 +304,8 @@ class RuntimePlatform:
                     self._prepared_images[key] = image
         return HumanTerminalRuntimeResolution(
             profile=profile,
-            runner=self._runner(profile),
-            workspace=self.workspace_for(engagement_id),
+            runner=self._runner(profile, workspace=workspace),
+            workspace=workspace,
             image=image,
         )
 
@@ -544,6 +545,7 @@ class RuntimePlatform:
         if runtime is None:
             raise RuntimePlatformError(f"Kali does not expose runtime {language!r}")
         image = metadata["image"]
+        workspace = self.workspace_for(engagement_id)
         return OperatorRuntimeResolution(
             canonical_language=canonical,
             runtime=runtime,
@@ -553,8 +555,9 @@ class RuntimePlatform:
             runner=self._runner(
                 profile,
                 egress_helper_image=image if network else None,
+                workspace=workspace,
             ),
-            workspace=self.workspace_for(engagement_id),
+            workspace=workspace,
         )
 
     def _runner(
@@ -562,6 +565,7 @@ class RuntimePlatform:
         stored: StoredRunnerProfile,
         *,
         egress_helper_image: str | None = None,
+        workspace: Path | None = None,
     ) -> ContainerSandboxRunner:
         if stored.isolation == RunnerIsolation.ROOTLESS:
             host = RunnerPlatform.LINUX
@@ -594,10 +598,22 @@ class RuntimePlatform:
             if egress_helper_image is not None
             else NoEgressController()
         )
+        workspace_roots = [self.workspace_root, self.parser_root]
+        if workspace is not None:
+            resolved_workspace = workspace.expanduser().resolve(strict=True)
+            if not resolved_workspace.is_dir():
+                raise RuntimePlatformError(
+                    "configured project workspace is not a directory"
+                )
+            if resolved_workspace not in workspace_roots:
+                # Admit the selected project's exact durable workspace, never its
+                # parent. ContainerSandboxRunner resolves the path again at launch,
+                # so a later symlink retarget fails closed.
+                workspace_roots.append(resolved_workspace)
         return ContainerSandboxRunner(
             profile=profile,
             egress_controller=egress,
-            workspace_roots=[self.workspace_root, self.parser_root],
+            workspace_roots=workspace_roots,
         )
 
 

--- a/src/nebula/v3/runtime_platform.py
+++ b/src/nebula/v3/runtime_platform.py
@@ -304,7 +304,11 @@ class RuntimePlatform:
                     self._prepared_images[key] = image
         return HumanTerminalRuntimeResolution(
             profile=profile,
-            runner=self._runner(profile, workspace=workspace),
+            runner=self._runner(
+                profile,
+                egress_helper_image=image.resolved_reference,
+                workspace=workspace,
+            ),
             workspace=workspace,
             image=image,
         )

--- a/src/nebula/v3/sandbox.py
+++ b/src/nebula/v3/sandbox.py
@@ -654,6 +654,83 @@ class ContainerEgressController(EgressController):
         self.helper_executable = helper_executable
         self.readiness_timeout_seconds = readiness_timeout_seconds
 
+    async def _remove_failed_helper(
+        self,
+        *,
+        runtime_argv: list[str],
+        runtime_environment: dict[str, str],
+        helper_name: str,
+    ) -> None:
+        try:
+            cleanup = await asyncio.create_subprocess_exec(
+                *runtime_argv,
+                "rm",
+                "--force",
+                helper_name,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+                env=runtime_environment,
+            )
+            await asyncio.wait_for(cleanup.wait(), timeout=10)
+        except (OSError, asyncio.TimeoutError) as caught_error:
+            record_caught_exception(
+                "sandbox",
+                "sandbox.egress_failed_cleanup",
+                "A failed egress helper container could not be removed.",
+                caught_error,
+                stage="sandbox",
+            )
+
+    async def _await_ready(
+        self,
+        process: asyncio.subprocess.Process,
+        *,
+        runtime_argv: list[str],
+        runtime_environment: dict[str, str],
+        helper_name: str,
+        label: str,
+    ) -> None:
+        assert process.stdout is not None
+        deadline = asyncio.get_running_loop().time() + self.readiness_timeout_seconds
+        detail = bytearray()
+        timed_out = False
+        while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                timed_out = True
+                break
+            try:
+                line = await asyncio.wait_for(
+                    process.stdout.readline(), timeout=remaining
+                )
+            except asyncio.TimeoutError:
+                timed_out = True
+                break
+            if not line:
+                break
+            if line.rstrip(b"\r\n") == b"READY" and process.returncode is None:
+                return
+            detail.extend(line)
+            if len(detail) > 4_096:
+                del detail[:-4_096]
+        if process.returncode is None:
+            process.kill()
+        await process.wait()
+        await self._remove_failed_helper(
+            runtime_argv=runtime_argv,
+            runtime_environment=runtime_environment,
+            helper_name=helper_name,
+        )
+        message = detail.decode("utf-8", errors="replace").strip()
+        if timed_out:
+            raise SandboxUnavailable(
+                f"{label} did not become ready" + (f": {message}" if message else "")
+            )
+        raise SandboxUnavailable(
+            f"{label} failed closed before readiness: {message or 'no status'}"
+        )
+
     async def acquire_loopback(
         self,
         *,
@@ -697,25 +774,14 @@ class ContainerEgressController(EgressController):
             raise SandboxUnavailable(
                 f"could not start loopback namespace helper: {exc}"
             ) from exc
+        await self._await_ready(
+            process,
+            runtime_argv=runtime_argv,
+            runtime_environment=runtime_environment,
+            helper_name=helper_name,
+            label="loopback namespace helper",
+        )
         assert process.stdout is not None
-        try:
-            line = await asyncio.wait_for(
-                process.stdout.readline(), timeout=self.readiness_timeout_seconds
-            )
-        except asyncio.TimeoutError as exc:
-            process.kill()
-            await process.wait()
-            raise SandboxUnavailable(
-                "loopback namespace helper did not become ready"
-            ) from exc
-        if line.rstrip(b"\r\n") != b"READY" or process.returncode is not None:
-            process.kill()
-            await process.wait()
-            detail = line.decode("utf-8", errors="replace").strip()
-            raise SandboxUnavailable(
-                "loopback namespace failed closed before readiness: "
-                + (detail or "no status")
-            )
         drain_task = create_diagnostic_task(
             _discard_stream(process.stdout),
             feature="sandbox",
@@ -850,28 +916,14 @@ class ContainerEgressController(EgressController):
             process.stdin.write(vpn_config.encode("utf-8"))
             await process.stdin.drain()
             process.stdin.close()
-        try:
-            line = await asyncio.wait_for(
-                process.stdout.readline(), timeout=self.readiness_timeout_seconds
-            )
-        except asyncio.TimeoutError as exc:
-            record_caught_exception(
-                "sandbox",
-                "sandbox.sandbox.caught_failure_005",
-                "A handled sandbox operation raised an exception.",
-                exc,
-                stage="sandbox",
-            )
-            process.kill()
-            await process.wait()
-            raise SandboxUnavailable("egress helper did not become ready") from exc
-        if line.rstrip(b"\r\n") != b"READY" or process.returncode is not None:
-            process.kill()
-            await process.wait()
-            detail = line.decode("utf-8", errors="replace").strip()
-            raise SandboxUnavailable(
-                f"egress helper failed closed before readiness: {detail or 'no status'}"
-            )
+        await self._await_ready(
+            process,
+            runtime_argv=runtime_argv,
+            runtime_environment=runtime_environment,
+            helper_name=helper_name,
+            label="egress helper",
+        )
+        assert process.stdout is not None
         drain_task = create_diagnostic_task(
             _discard_stream(process.stdout),
             feature="sandbox",

--- a/src/nebula/v3/sandbox.py
+++ b/src/nebula/v3/sandbox.py
@@ -2211,7 +2211,7 @@ class ContainerImagePreparer:
     """Verify official Kali and prepare a pinned local headless-tool image."""
 
     _derived_repository = "localhost/nebula-kali-headless"
-    _recipe_version = "v8"
+    _recipe_version = "v9"
     _installed_packages = (
         "kali-linux-headless",
         "iputils-ping",

--- a/src/nebula/v3/sandbox.py
+++ b/src/nebula/v3/sandbox.py
@@ -50,6 +50,7 @@ class SandboxNetwork(str, Enum):
     NONE = "none"
     SCOPED = "scoped"
     UNRESTRICTED = "unrestricted"
+    VPN = "vpn"
 
 
 class SandboxExecutionKind(str, Enum):
@@ -372,9 +373,12 @@ class SandboxRequest(BaseModel):
                     "or certified egress rules"
                 )
         elif self.execution_kind == SandboxExecutionKind.HUMAN_TERMINAL:
-            if self.network != SandboxNetwork.UNRESTRICTED:
+            if self.network not in {
+                SandboxNetwork.UNRESTRICTED,
+                SandboxNetwork.VPN,
+            }:
                 raise ValueError(
-                    "human terminals require unrestricted bridge networking"
+                    "human terminals require direct bridge or VPN networking"
                 )
             if self.container_user != SandboxContainerUser.ROOT:
                 raise ValueError("human terminals require the container root user")
@@ -515,8 +519,16 @@ class NoEgressController(EgressController):
         request: SandboxRequest,
         container_name: str,
         seccomp_profile: Path | None,
+        vpn_config: str | None = None,
     ) -> EgressLease:
-        del runtime_argv, runtime_environment, request, container_name, seccomp_profile
+        del (
+            runtime_argv,
+            runtime_environment,
+            request,
+            container_name,
+            seccomp_profile,
+            vpn_config,
+        )
         raise SandboxUnavailable(
             "network tool execution requires a certified per-invocation egress helper"
         )
@@ -731,9 +743,20 @@ class ContainerEgressController(EgressController):
         seccomp_profile: Path | None,
         vpn_config: str | None = None,
     ) -> EgressLease:
-        if request.execution_kind != SandboxExecutionKind.NETWORK_TOOL:
-            raise SandboxError("egress leases are only valid for network tools")
-        if not request.egress_rules and not request.egress_domains:
+        vpn_terminal = (
+            request.execution_kind == SandboxExecutionKind.HUMAN_TERMINAL
+            and request.network == SandboxNetwork.VPN
+        )
+        if (
+            request.execution_kind != SandboxExecutionKind.NETWORK_TOOL
+            and not vpn_terminal
+        ):
+            raise SandboxError(
+                "egress leases are valid only for network tools or VPN terminals"
+            )
+        if vpn_terminal and vpn_config is None:
+            raise SandboxError("VPN terminal egress requires an admitted VPN profile")
+        if not vpn_terminal and not request.egress_rules and not request.egress_domains:
             raise SandboxUnavailable(
                 "network execution requires broker-approved egress rules or domains"
             )
@@ -760,6 +783,11 @@ class ContainerEgressController(EgressController):
             argv.append(f"--security-opt=seccomp={seccomp_profile}")
         if vpn_config is not None:
             argv.extend(["--device=/dev/net/tun", "--interactive"])
+        if vpn_terminal:
+            for publication in request.published_ports:
+                argv.append(
+                    f"--publish=127.0.0.1:{publication.port}:{publication.port}/{publication.protocol}"
+                )
         # Containers joining this helper's network namespace cannot accept
         # their own --add-host flags. Put the approved host mappings on the
         # namespace owner so Docker/Podman can share the complete pinned
@@ -769,6 +797,8 @@ class ContainerEgressController(EgressController):
         argv.extend([self.helper_image, "serve"])
         if vpn_config is not None:
             argv.append("--vpn-stdin")
+        if vpn_terminal:
+            argv.append("--vpn-unrestricted")
         if request.start_egress_disabled:
             argv.append("--disabled")
         for rule in request.egress_rules:
@@ -1705,7 +1735,7 @@ class ContainerSandboxRunner(SandboxRunner):
             if network_mode is None:
                 for host, address in sorted(request.pinned_hosts.items()):
                     argv.append(f"--add-host={host}:{_bracket_ip(address)}")
-        if request.published_ports:
+        if request.published_ports and network_mode is None:
             if request.execution_kind != SandboxExecutionKind.HUMAN_TERMINAL:
                 raise SandboxError("published ports are reserved for human terminals")
             for publication in request.published_ports:
@@ -1727,6 +1757,7 @@ class ContainerSandboxRunner(SandboxRunner):
         container_name: str,
         columns: int,
         rows: int,
+        vpn_config: str | None = None,
     ) -> SandboxTerminalProcess:
         """Launch one fixed-command container with an interactive PTY."""
 
@@ -1751,8 +1782,12 @@ class ContainerSandboxRunner(SandboxRunner):
             raise SandboxError("terminal dimensions must be between 1 and 1000")
 
         lease: EgressLease | None = None
-        if request.network == SandboxNetwork.SCOPED:
-            if not request.egress_rules and not request.egress_domains:
+        if request.network in {SandboxNetwork.SCOPED, SandboxNetwork.VPN}:
+            if (
+                request.network == SandboxNetwork.SCOPED
+                and not request.egress_rules
+                and not request.egress_domains
+            ):
                 raise SandboxUnavailable(
                     "network terminal execution requires an explicit broker-approved boundary"
                 )
@@ -1766,6 +1801,7 @@ class ContainerSandboxRunner(SandboxRunner):
                 request=request,
                 container_name=container_name,
                 seccomp_profile=self.profile.seccomp_profile if self.profile else None,
+                vpn_config=vpn_config,
             )
         master_fd: int | None = None
         slave_fd: int | None = None
@@ -2123,7 +2159,7 @@ class ContainerImagePreparer:
     """Verify official Kali and prepare a pinned local headless-tool image."""
 
     _derived_repository = "localhost/nebula-kali-headless"
-    _recipe_version = "v6"
+    _recipe_version = "v7"
     _installed_packages = (
         "kali-linux-headless",
         "iputils-ping",

--- a/src/nebula/v3/sandbox.py
+++ b/src/nebula/v3/sandbox.py
@@ -705,6 +705,7 @@ class ContainerEgressController(EgressController):
                     process.stdout.readline(), timeout=remaining
                 )
             except asyncio.TimeoutError:
+                # diagnostic-expected: handled below as a bounded readiness failure.
                 timed_out = True
                 break
             if not line:

--- a/src/nebula/v3/sandbox.py
+++ b/src/nebula/v3/sandbox.py
@@ -501,6 +501,7 @@ class EgressController(ABC):
         request: SandboxRequest,
         container_name: str,
         seccomp_profile: Path | None,
+        vpn_config: str | None = None,
     ) -> EgressLease:
         raise NotImplementedError
 
@@ -728,6 +729,7 @@ class ContainerEgressController(EgressController):
         request: SandboxRequest,
         container_name: str,
         seccomp_profile: Path | None,
+        vpn_config: str | None = None,
     ) -> EgressLease:
         if request.execution_kind != SandboxExecutionKind.NETWORK_TOOL:
             raise SandboxError("egress leases are only valid for network tools")
@@ -756,6 +758,8 @@ class ContainerEgressController(EgressController):
         ]
         if seccomp_profile is not None:
             argv.append(f"--security-opt=seccomp={seccomp_profile}")
+        if vpn_config is not None:
+            argv.extend(["--device=/dev/net/tun", "--interactive"])
         # Containers joining this helper's network namespace cannot accept
         # their own --add-host flags. Put the approved host mappings on the
         # namespace owner so Docker/Podman can share the complete pinned
@@ -763,6 +767,8 @@ class ContainerEgressController(EgressController):
         for host, address in sorted(request.pinned_hosts.items()):
             argv.append(f"--add-host={host}:{_bracket_ip(address)}")
         argv.extend([self.helper_image, "serve"])
+        if vpn_config is not None:
+            argv.append("--vpn-stdin")
         if request.start_egress_disabled:
             argv.append("--disabled")
         for rule in request.egress_rules:
@@ -790,7 +796,11 @@ class ContainerEgressController(EgressController):
         try:
             process = await asyncio.create_subprocess_exec(
                 *argv,
-                stdin=asyncio.subprocess.DEVNULL,
+                stdin=(
+                    asyncio.subprocess.PIPE
+                    if vpn_config is not None
+                    else asyncio.subprocess.DEVNULL
+                ),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 env=runtime_environment,
@@ -805,6 +815,11 @@ class ContainerEgressController(EgressController):
             )
             raise SandboxUnavailable(f"could not start egress helper: {exc}") from exc
         assert process.stdout is not None
+        if vpn_config is not None:
+            assert process.stdin is not None
+            process.stdin.write(vpn_config.encode("utf-8"))
+            await process.stdin.drain()
+            process.stdin.close()
         try:
             line = await asyncio.wait_for(
                 process.stdout.readline(), timeout=self.readiness_timeout_seconds
@@ -2108,7 +2123,7 @@ class ContainerImagePreparer:
     """Verify official Kali and prepare a pinned local headless-tool image."""
 
     _derived_repository = "localhost/nebula-kali-headless"
-    _recipe_version = "v5"
+    _recipe_version = "v6"
     _installed_packages = (
         "kali-linux-headless",
         "iputils-ping",
@@ -2117,6 +2132,7 @@ class ContainerImagePreparer:
         "ripgrep",
         "git",
         "curl",
+        "openvpn",
     )
     _security_tool_manifest_path = "/usr/local/share/nebula/security-tools.json"
     _base_label = "org.nebula.human-terminal.base"

--- a/src/nebula/v3/sandbox.py
+++ b/src/nebula/v3/sandbox.py
@@ -2211,7 +2211,7 @@ class ContainerImagePreparer:
     """Verify official Kali and prepare a pinned local headless-tool image."""
 
     _derived_repository = "localhost/nebula-kali-headless"
-    _recipe_version = "v7"
+    _recipe_version = "v8"
     _installed_packages = (
         "kali-linux-headless",
         "iputils-ping",

--- a/src/nebula/v3/vpn.py
+++ b/src/nebula/v3/vpn.py
@@ -1,0 +1,192 @@
+"""Strict admission and runtime materialization for OpenVPN client profiles."""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+from dataclasses import dataclass
+
+
+MAX_PROFILE_CHARACTERS = 15_000
+_INLINE_BLOCKS = {
+    "ca",
+    "cert",
+    "key",
+    "tls-auth",
+    "tls-crypt",
+    "tls-crypt-v2",
+    "extra-certs",
+    "pkcs12",
+}
+_SAFE_OPTIONS = {
+    "auth",
+    "auth-nocache",
+    "cipher",
+    "client",
+    "connect-retry",
+    "connect-retry-max",
+    "connect-timeout",
+    "data-ciphers",
+    "data-ciphers-fallback",
+    "explicit-exit-notify",
+    "float",
+    "key-direction",
+    "mssfix",
+    "mute",
+    "nobind",
+    "persist-key",
+    "persist-tun",
+    "ping",
+    "ping-restart",
+    "proto",
+    "pull",
+    "remote",
+    "remote-cert-tls",
+    "resolv-retry",
+    "sndbuf",
+    "rcvbuf",
+    "tls-client",
+    "tls-version-min",
+    "tun-mtu",
+    "verb",
+    "verify-x509-name",
+}
+
+
+class VpnProfileError(ValueError):
+    """A profile cannot be admitted without weakening the runtime boundary."""
+
+
+@dataclass(frozen=True)
+class ParsedVpnProfile:
+    config: str
+    remote_host: str
+    remote_port: int
+    protocol: str
+    fingerprint: str
+    requires_credentials: bool
+
+
+def parse_openvpn_profile(
+    config: str, *, username: str | None = None, password: str | None = None
+) -> ParsedVpnProfile:
+    if not config or len(config) > MAX_PROFILE_CHARACTERS or "\x00" in config:
+        raise VpnProfileError("profile must contain 1 to 15000 text characters")
+    if (username is None) != (password is None):
+        raise VpnProfileError("username and password must be supplied together")
+    normalized = config.replace("\r\n", "\n").replace("\r", "\n")
+    output: list[str] = []
+    active_block: str | None = None
+    block_names: set[str] = set()
+    remotes: list[tuple[str, int]] = []
+    protocol = "udp"
+    has_client = False
+    has_tun = False
+    has_server_verification = False
+    auth_user_pass = False
+    for number, raw in enumerate(normalized.splitlines(), start=1):
+        stripped = raw.strip()
+        if active_block is not None:
+            output.append(raw)
+            if stripped.lower() == f"</{active_block}>":
+                active_block = None
+            continue
+        if not stripped or stripped.startswith(("#", ";")):
+            output.append(raw)
+            continue
+        if stripped.startswith("<") and stripped.endswith(">"):
+            name = stripped[1:-1].lower()
+            if name not in _INLINE_BLOCKS or name in block_names:
+                raise VpnProfileError(
+                    f"unsupported inline block on line {number}: {name}"
+                )
+            active_block = name
+            block_names.add(name)
+            output.append(f"<{name}>")
+            continue
+        try:
+            fields = shlex.split(stripped, comments=False, posix=True)
+        except ValueError as exc:
+            raise VpnProfileError(f"invalid quoting on line {number}") from exc
+        option = fields[0].lstrip("-").lower()
+        if option == "auth-user-pass":
+            if len(fields) != 1:
+                raise VpnProfileError("auth-user-pass file paths are not allowed")
+            auth_user_pass = True
+            continue
+        if option == "dev":
+            if len(fields) != 2 or fields[1].lower() not in {"tun", "tun0"}:
+                raise VpnProfileError("only a TUN client profile is supported")
+            has_tun = True
+            output.append("dev tun0")
+            continue
+        if option == "proto":
+            if len(fields) != 2 or fields[1].lower() not in {
+                "udp",
+                "udp4",
+                "tcp",
+                "tcp4",
+                "tcp-client",
+            }:
+                raise VpnProfileError("only UDP or TCP client transports are supported")
+            protocol = "tcp" if fields[1].lower().startswith("tcp") else "udp"
+        elif option == "remote":
+            if len(fields) not in {2, 3}:
+                raise VpnProfileError("remote must contain one host and optional port")
+            try:
+                port = int(fields[2]) if len(fields) == 3 else 1194
+            except ValueError as exc:
+                raise VpnProfileError("remote port must be a number") from exc
+            if not 1 <= port <= 65535:
+                raise VpnProfileError("remote port is outside 1..65535")
+            remotes.append((fields[1], port))
+        elif option == "client":
+            has_client = True
+        elif option in {"remote-cert-tls", "verify-x509-name"}:
+            has_server_verification = True
+        elif option == "setenv" and fields[1:] == ["opt", "block-outside-dns"]:
+            continue
+        elif option not in _SAFE_OPTIONS:
+            raise VpnProfileError(
+                f"unsupported or unsafe option on line {number}: {option}"
+            )
+        output.append(" ".join(shlex.quote(field) for field in fields))
+    if active_block is not None:
+        raise VpnProfileError(f"inline {active_block} block is not closed")
+    if not has_client or not has_tun or len(remotes) != 1:
+        raise VpnProfileError("profile must be a TUN client with exactly one remote")
+    if not has_server_verification:
+        raise VpnProfileError("profile must verify the VPN server certificate")
+    if auth_user_pass:
+        if username is None or password is None:
+            raise VpnProfileError("this profile requires a username and password")
+        if any(
+            "\n" in value or "\r" in value or "\x00" in value or "<" in value
+            for value in (username, password)
+        ):
+            raise VpnProfileError("VPN credentials cannot contain line breaks")
+        output.extend(["<auth-user-pass>", username, password, "</auth-user-pass>"])
+    elif username is not None:
+        raise VpnProfileError(
+            "credentials were supplied but the profile does not request them"
+        )
+    output.extend(
+        [
+            "auth-nocache",
+            "script-security 1",
+            "redirect-gateway def1",
+            "redirect-gateway ipv6",
+        ]
+    )
+    admitted = "\n".join(output).rstrip() + "\n"
+    if len(admitted) > 16_384:
+        raise VpnProfileError("admitted profile exceeds secure storage capacity")
+    remote_host, remote_port = remotes[0]
+    return ParsedVpnProfile(
+        config=admitted,
+        remote_host=remote_host,
+        remote_port=remote_port,
+        protocol=protocol,
+        fingerprint=hashlib.sha256(admitted.encode()).hexdigest(),
+        requires_credentials=auth_user_pass,
+    )

--- a/src/nebula/v3/vpn.py
+++ b/src/nebula/v3/vpn.py
@@ -30,9 +30,11 @@ _SAFE_OPTIONS = {
     "data-ciphers-fallback",
     "explicit-exit-notify",
     "float",
+    "fast-io",
     "key-direction",
     "mssfix",
     "mute",
+    "mute-replay-warnings",
     "nobind",
     "persist-key",
     "persist-tun",
@@ -42,16 +44,45 @@ _SAFE_OPTIONS = {
     "proto",
     "pull",
     "remote",
+    "remote-random",
+    "remote-random-hostname",
     "remote-cert-tls",
     "resolv-retry",
+    "reneg-bytes",
+    "reneg-pkts",
+    "reneg-sec",
+    "route-delay",
     "sndbuf",
+    "suppress-timestamps",
     "rcvbuf",
     "tls-client",
+    "tls-cipher",
+    "tls-ciphersuites",
     "tls-version-min",
     "tun-mtu",
     "verb",
     "verify-x509-name",
+    "x509-username-field",
 }
+
+_NO_ARGUMENT_OPTIONS = {
+    "auth-nocache",
+    "client",
+    "fast-io",
+    "float",
+    "mute-replay-warnings",
+    "nobind",
+    "persist-key",
+    "persist-tun",
+    "ping-timer-rem",
+    "pull",
+    "remote-random",
+    "remote-random-hostname",
+    "suppress-timestamps",
+    "tls-client",
+}
+
+_NONNEGATIVE_INTEGER_OPTIONS = {"reneg-bytes", "reneg-pkts", "reneg-sec"}
 
 
 class VpnProfileError(ValueError):
@@ -143,8 +174,19 @@ def parse_openvpn_profile(
             remotes.append((fields[1], port))
         elif option == "client":
             has_client = True
-        elif option == "ping-timer-rem" and len(fields) != 1:
-            raise VpnProfileError("ping-timer-rem does not accept arguments")
+        elif option in _NO_ARGUMENT_OPTIONS and len(fields) != 1:
+            raise VpnProfileError(f"{option} does not accept arguments")
+        elif option in _NONNEGATIVE_INTEGER_OPTIONS:
+            if len(fields) != 2:
+                raise VpnProfileError(f"{option} requires one non-negative integer")
+            try:
+                value = int(fields[1])
+            except ValueError as exc:
+                raise VpnProfileError(
+                    f"{option} requires one non-negative integer"
+                ) from exc
+            if not 0 <= value <= 2_147_483_647:
+                raise VpnProfileError(f"{option} requires one non-negative integer")
         elif option in {"remote-cert-tls", "verify-x509-name"}:
             has_server_verification = True
         elif option == "setenv" and fields[1:] == ["opt", "block-outside-dns"]:

--- a/src/nebula/v3/vpn.py
+++ b/src/nebula/v3/vpn.py
@@ -219,8 +219,7 @@ def parse_openvpn_profile(
         [
             "auth-nocache",
             "script-security 1",
-            "redirect-gateway def1",
-            "redirect-gateway ipv6",
+            "redirect-gateway def1 ipv6",
         ]
     )
     admitted = "\n".join(output).rstrip() + "\n"

--- a/src/nebula/v3/vpn.py
+++ b/src/nebula/v3/vpn.py
@@ -38,6 +38,7 @@ _SAFE_OPTIONS = {
     "persist-tun",
     "ping",
     "ping-restart",
+    "ping-timer-rem",
     "proto",
     "pull",
     "remote",
@@ -142,6 +143,8 @@ def parse_openvpn_profile(
             remotes.append((fields[1], port))
         elif option == "client":
             has_client = True
+        elif option == "ping-timer-rem" and len(fields) != 1:
+            raise VpnProfileError("ping-timer-rem does not accept arguments")
         elif option in {"remote-cert-tls", "verify-x509-name"}:
             has_server_verification = True
         elif option == "setenv" and fields[1:] == ["opt", "block-outside-dns"]:

--- a/tests/v3/test_automation_runtime.py
+++ b/tests/v3/test_automation_runtime.py
@@ -39,9 +39,11 @@ from nebula.v3.domain import (
     ToolCall,
     ToolCallOrigin,
     ToolCallStatus,
+    VpnProfile,
     RiskClass,
     utc_now,
 )
+from nebula.v3.credentials import CredentialCreateRequest, CredentialStore
 from nebula.v3.diagnostics import DiagnosticManager
 from nebula.v3.storage import NebulaStore
 from nebula.v3.tool_results import (
@@ -690,6 +692,65 @@ def test_domain_scope_resolver_is_readable_by_the_non_root_runtime(tmp_path):
     asyncio.run(scenario())
 
 
+def test_selected_vpn_is_frozen_and_streamed_only_to_the_namespace_launch(tmp_path):
+    async def scenario():
+        manager, store, _artifacts, engagement, _sessions = runtime(tmp_path)
+        credentials = CredentialStore()
+        secret = credentials.create(
+            CredentialCreateRequest(secret="client\ndev tun0\n", persistence="session")
+        )
+        vpn = store.create(
+            VpnProfile(
+                name="Assessment VPN",
+                filename="assessment.ovpn",
+                remote_host="vpn.example.test",
+                remote_port=1194,
+                protocol="udp",
+                fingerprint="f" * 64,
+                secret_ref=secret.reference,
+            )
+        )
+        manager.credential_store = credentials
+        policy = manager.project_policy(engagement.id)
+        manager.update_project_policy(
+            engagement.id,
+            approval_policy=AutomationApprovalPolicy.NEVER,
+            network_enabled=True,
+            runner_profile_id="runner",
+            vpn_profile_id=vpn.id,
+            max_timeout_ms=30_000,
+            expected_revision=policy.revision,
+        )
+        launches = []
+
+        async def launch(configuration):
+            launches.append(configuration)
+            return FakeSession(
+                network_granted=configuration.network_granted,
+                workspace=configuration.workspace,
+            )
+
+        manager.session_factory = launch
+        result = await manager.run_command(
+            engagement_id=engagement.id,
+            owner_kind="api",
+            owner_id="vpn-session",
+            request=RunCommandRequest(
+                command="curl https://example.test", network="project_scope"
+            ),
+        )
+
+        assert launches[0].vpn_config == "client\ndev tun0"
+        session = store.get(AutomationSession, result.session_id)
+        assert (session.vpn_profile_id, session.vpn_profile_revision) == (
+            vpn.id,
+            vpn.revision,
+        )
+        assert "client" not in session.model_dump_json()
+
+    asyncio.run(scenario())
+
+
 def test_api_exposes_only_the_fixed_runtime_command_surface(tmp_path):
     manager, store, artifacts, engagement, _sessions = runtime(tmp_path)
     app = create_app(
@@ -734,6 +795,70 @@ def test_api_exposes_only_the_fixed_runtime_command_surface(tmp_path):
             for path in paths
             for marker in ("tool-packs", "tool-catalog", "tool-assignment")
         )
+
+
+def test_api_saves_vpn_secret_outside_public_profile_and_selects_it(tmp_path):
+    manager, store, artifacts, engagement, _sessions = runtime(tmp_path)
+    app = create_app(
+        store,
+        artifact_store=artifacts,
+        auth_token="runtime-test-token",
+        automation_runtime=manager,
+    )
+    headers = {"Authorization": "Bearer runtime-test-token"}
+    config = """client
+dev tun
+proto udp
+remote vpn.example.test 1194
+remote-cert-tls server
+<ca>
+certificate
+</ca>
+"""
+
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/vpn-profiles",
+            headers=headers,
+            json={
+                "name": "Assessment VPN",
+                "filename": "assessment.ovpn",
+                "config": config,
+                "persistence": "session",
+            },
+        )
+        assert created.status_code == 201, created.text
+        profile = created.json()
+        assert "secret_ref" not in profile
+        assert "config" not in profile
+        assert profile["available"] is True
+
+        current = client.get(
+            f"/api/v1/engagements/{engagement.id}/automation-policy",
+            headers=headers,
+        ).json()
+        updated = client.put(
+            f"/api/v1/engagements/{engagement.id}/automation-policy",
+            headers=headers,
+            json={
+                "approval_policy": "on_boundary",
+                "network_enabled": True,
+                "runner_profile_id": "runner",
+                "vpn_profile_id": profile["id"],
+                "max_timeout_ms": 30000,
+                "expected_revision": current["revision"],
+            },
+        )
+        assert updated.status_code == 200, updated.text
+        assert updated.json()["vpn_profile_id"] == profile["id"]
+
+        blocked = client.request(
+            "DELETE",
+            f"/api/v1/vpn-profiles/{profile['id']}",
+            headers=headers,
+            json={"expected_revision": profile["revision"]},
+        )
+        assert blocked.status_code == 409
 
 
 def test_default_mission_degrades_to_analysis_when_command_runtime_is_unprepared(

--- a/tests/v3/test_automation_runtime.py
+++ b/tests/v3/test_automation_runtime.py
@@ -860,6 +860,25 @@ certificate
         )
         assert blocked.status_code == 409
 
+        policy = manager.project_policy(engagement.id)
+        manager.update_project_policy(
+            engagement.id,
+            approval_policy=policy.approval_policy,
+            network_enabled=policy.network_enabled,
+            runner_profile_id=policy.runner_profile_id,
+            vpn_profile_id=None,
+            max_timeout_ms=policy.max_timeout_ms,
+            expected_revision=policy.revision,
+        )
+        removed = client.request(
+            "DELETE",
+            f"/api/v1/vpn-profiles/{profile['id']}",
+            headers=headers,
+            json={"expected_revision": profile["revision"]},
+        )
+        assert removed.status_code == 204
+        assert client.get("/api/v1/vpn-profiles", headers=headers).json() == []
+
 
 def test_default_mission_degrades_to_analysis_when_command_runtime_is_unprepared(
     tmp_path,

--- a/tests/v3/test_automation_runtime.py
+++ b/tests/v3/test_automation_runtime.py
@@ -695,6 +695,8 @@ def test_domain_scope_resolver_is_readable_by_the_non_root_runtime(tmp_path):
 def test_selected_vpn_is_frozen_and_streamed_only_to_the_namespace_launch(tmp_path):
     async def scenario():
         manager, store, _artifacts, engagement, _sessions = runtime(tmp_path)
+        manager.data_root = tmp_path / "core-data"
+        manager.data_root.mkdir()
         credentials = CredentialStore()
         secret = credentials.create(
             CredentialCreateRequest(secret="client\ndev tun0\n", persistence="session")
@@ -741,6 +743,8 @@ def test_selected_vpn_is_frozen_and_streamed_only_to_the_namespace_launch(tmp_pa
         )
 
         assert launches[0].vpn_config == "client\ndev tun0"
+        assert launches[0].workspace.resolve() in launches[0].runner.workspace_roots
+        assert tmp_path.resolve() not in launches[0].runner.workspace_roots
         session = store.get(AutomationSession, result.session_id)
         assert (session.vpn_profile_id, session.vpn_profile_revision) == (
             vpn.id,

--- a/tests/v3/test_automation_runtime.py
+++ b/tests/v3/test_automation_runtime.py
@@ -815,6 +815,7 @@ dev tun
 proto udp
 remote vpn.example.test 1194
 remote-cert-tls server
+ping-timer-rem
 <ca>
 certificate
 </ca>

--- a/tests/v3/test_container_terminal.py
+++ b/tests/v3/test_container_terminal.py
@@ -9,6 +9,7 @@ import subprocess
 import time
 import zipfile
 from functools import wraps
+from uuid import NAMESPACE_URL, uuid5
 
 import pytest
 from fastapi.testclient import TestClient
@@ -16,6 +17,7 @@ from pydantic import ValidationError
 
 from nebula.v3.api import create_app
 from nebula.v3.artifacts import ArtifactStore
+from nebula.v3.credentials import CredentialCreateRequest, CredentialStore
 from nebula.v3.container_terminal import (
     ContainerTerminalError,
     ContainerTerminalExit,
@@ -30,10 +32,12 @@ from nebula.v3.container_terminal import (
     terminal_ps0,
 )
 from nebula.v3.domain import (
+    AutomationProjectPolicy,
     Engagement,
     RunnerIsolation,
     RunnerProfile,
     RunnerRuntime,
+    VpnProfile,
 )
 from nebula.v3.exporter import export_engagement
 from nebula.v3.sandbox import (
@@ -97,12 +101,20 @@ class RecordingTerminalRunner:
     def __init__(self, *, chunks: list[bytes] | None = None) -> None:
         self.requests: list[tuple[object, str, int, int]] = []
         self.processes: list[RecordingTerminalProcess] = []
+        self.vpn_configs: list[str | None] = []
         self.chunks = chunks
 
     async def open_terminal(
-        self, request, *, container_name: str, columns: int, rows: int
+        self,
+        request,
+        *,
+        container_name: str,
+        columns: int,
+        rows: int,
+        vpn_config: str | None = None,
     ) -> RecordingTerminalProcess:
         self.requests.append((request, container_name, columns, rows))
+        self.vpn_configs.append(vpn_config)
         process = RecordingTerminalProcess(self.chunks)
         process.container_name = container_name
         self.processes.append(process)
@@ -161,11 +173,19 @@ class ControllableTerminalRunner:
     def __init__(self) -> None:
         self.requests: list[tuple[object, str, int, int]] = []
         self.processes: list[ControllableTerminalProcess] = []
+        self.vpn_configs: list[str | None] = []
 
     async def open_terminal(
-        self, request, *, container_name: str, columns: int, rows: int
+        self,
+        request,
+        *,
+        container_name: str,
+        columns: int,
+        rows: int,
+        vpn_config: str | None = None,
     ) -> ControllableTerminalProcess:
         self.requests.append((request, container_name, columns, rows))
+        self.vpn_configs.append(vpn_config)
         process = ControllableTerminalProcess()
         process.container_name = container_name
         self.processes.append(process)
@@ -612,6 +632,9 @@ async def test_reviewed_terminal_uses_only_the_fixed_container_shell(tmp_path):
             {"port": 8080, "protocol": "tcp"},
         ],
         "runtime_network": "bridge",
+        "vpn_profile_id": None,
+        "vpn_profile_name": None,
+        "vpn_profile_revision": None,
     }
     assert pending["security"]["container_user"] == "root"
     await service.shutdown()
@@ -646,6 +669,72 @@ async def test_unrestricted_kali_terminal_needs_no_runtime_or_scope_policy(tmp_p
     await service.launch(created.session_id)
     assert runner.requests[0][0].network == SandboxNetwork.UNRESTRICTED
     await service.finish(created.session_id, outcome="closed")
+
+
+@async_test
+async def test_selected_vpn_is_frozen_into_new_human_terminal_and_recovery(tmp_path):
+    store = NebulaStore(tmp_path / "vpn-terminal.db")
+    engagement = store.create(Engagement(name="VPN Terminal Lab"))
+    runner = RecordingTerminalRunner()
+    platform = StubTerminalPlatform(tmp_path / "workspace", runner)
+    credentials = CredentialStore()
+    admitted_config = "client\ndev tun0\nremote 203.0.113.8 1194\n"
+    secret = credentials.create(
+        CredentialCreateRequest(secret=admitted_config, persistence="session")
+    )
+    profile = store.create(
+        VpnProfile(
+            name="Company VPN",
+            filename="company.ovpn",
+            remote_host="vpn.example.test",
+            remote_port=1194,
+            protocol="udp",
+            fingerprint="a" * 64,
+            secret_ref=secret.reference,
+        )
+    )
+    store.create(
+        AutomationProjectPolicy(
+            id=str(uuid5(NAMESPACE_URL, f"nebula:automation-policy:{engagement.id}")),
+            engagement_id=engagement.id,
+            network_enabled=True,
+            vpn_profile_id=profile.id,
+        )
+    )
+    service = ContainerTerminalService(
+        store=store,
+        tool_platform=platform,  # type: ignore[arg-type]
+        credential_store=credentials,
+        operator_id=lambda: "operator-1",
+    )
+    request = ContainerTerminalPreflightRequest(engagement_id=engagement.id)
+
+    preview = await service.preflight(request)
+
+    assert preview.allowed is True
+    assert preview.policy_rule == "human_terminal_vpn"
+    assert preview.network.mode == "vpn"
+    assert preview.network.runtime_network == "private_namespace"
+    assert preview.network.vpn_profile_id == profile.id
+    assert preview.network.vpn_profile_revision == profile.revision
+    assert preview.network.vpn_profile_name == "Company VPN"
+    created = await service.start(
+        ContainerTerminalStartRequest(
+            **request.model_dump(),
+            preview_token=preview.preview_token,
+            preview_fingerprint=preview.preview_fingerprint,
+            client_idempotency_key="vpn-terminal",
+        )
+    )
+    await service.claim(created.session_id, created.websocket_ticket)
+    await service.launch(created.session_id)
+    assert runner.requests[0][0].network == SandboxNetwork.VPN
+    assert runner.vpn_configs == [admitted_config.rstrip()]
+    assert service.uses_vpn_profile(profile.id) is True
+    recovered = await service.recover(engagement.id)
+    assert recovered.network == preview.network
+    await service.finish(created.session_id, outcome="closed")
+    assert service.uses_vpn_profile(profile.id) is False
 
 
 @async_test
@@ -995,6 +1084,9 @@ def test_container_terminal_api_streams_container_output_with_one_use_ticket(tmp
             "mode": "unrestricted",
             "runtime_network": "bridge",
             "published_ports": [],
+            "vpn_profile_id": None,
+            "vpn_profile_name": None,
+            "vpn_profile_revision": None,
         }
         assert reviewed["security"]["container_user"] == "root"
         started = client.post(
@@ -1261,6 +1353,7 @@ def test_container_terminal_websocket_reconnects_to_the_same_process(tmp_path):
             "active": False,
             "session": None,
             "runtime": None,
+            "network": None,
         }
 
     assert len(runner.processes) == 1

--- a/tests/v3/test_container_terminal.py
+++ b/tests/v3/test_container_terminal.py
@@ -648,6 +648,29 @@ async def test_unrestricted_kali_terminal_needs_no_runtime_or_scope_policy(tmp_p
     await service.finish(created.session_id, outcome="closed")
 
 
+@async_test
+async def test_terminal_preview_is_bound_to_the_resolved_project_workspace(tmp_path):
+    _store, engagement, _runner, platform, service = continuity_fixture(tmp_path)
+    request = ContainerTerminalPreflightRequest(engagement_id=engagement.id)
+    preview = await service.preflight(request)
+    replacement = tmp_path / "replacement-workspace"
+    replacement.mkdir()
+    platform.workspace = replacement
+
+    with pytest.raises(ContainerTerminalError) as changed:
+        await service.start(
+            ContainerTerminalStartRequest(
+                **request.model_dump(),
+                preview_token=preview.preview_token,
+                preview_fingerprint=preview.preview_fingerprint,
+                client_idempotency_key="workspace-changed",
+            )
+        )
+
+    assert changed.value.code == "preview_stale"
+    assert "changed after review" in changed.value.detail
+
+
 def test_terminal_request_rejects_client_selected_network_boundary():
     with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         ContainerTerminalPreflightRequest(

--- a/tests/v3/test_egress_helper.py
+++ b/tests/v3/test_egress_helper.py
@@ -97,7 +97,7 @@ def test_policy_dns_opens_only_configured_ports_for_public_answers(monkeypatch):
     monkeypatch.setattr(
         egress_helper,
         "_install_rule",
-        lambda network, port: installed.append((str(network), port)),
+        lambda network, port, interface=None: installed.append((str(network), port)),
     )
 
     result = resolver.resolve(_query("api.example.test"))
@@ -125,7 +125,7 @@ def test_policy_dns_blocks_private_rebinding_unless_cidr_is_explicit(monkeypatch
     monkeypatch.setattr(
         egress_helper,
         "_install_rule",
-        lambda network, port: installed.append((str(network), port)),
+        lambda network, port, interface=None: installed.append((str(network), port)),
     )
     assert allowed.resolve(_query("api.example.test")) == private
     assert installed == [("10.20.30.40/32", "443")]
@@ -140,3 +140,51 @@ def test_policy_dns_stays_closed_until_the_session_grant_is_enabled(monkeypatch)
     resolver._forward = lambda _request: response  # type: ignore[method-assign]
     monkeypatch.setattr(egress_helper, "_install_rule", lambda *_args: None)
     assert resolver.resolve(_query("api.example.test")) == response
+
+
+def test_vpn_remote_is_resolved_once_and_rewritten_to_the_pinned_address(monkeypatch):
+    monkeypatch.setattr(
+        egress_helper.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (
+                egress_helper.socket.AF_INET,
+                egress_helper.socket.SOCK_DGRAM,
+                17,
+                "",
+                ("203.0.113.9", 1194),
+            )
+        ],
+    )
+
+    rewritten, address, port, protocol = egress_helper._vpn_material(
+        "client\ndev tun0\nproto udp\nremote vpn.example.test 1194\n"
+    )
+
+    assert "remote 203.0.113.9 1194" in rewritten
+    assert str(address) == "203.0.113.9"
+    assert (port, protocol) == (1194, "udp")
+
+
+def test_vpn_scoped_dns_rules_are_bound_to_the_tunnel(monkeypatch):
+    monkeypatch.setattr(egress_helper, "_upstream_resolvers", lambda: ["8.8.8.8"])
+    resolver = egress_helper.PolicyResolver(
+        domains=["api.example.test"],
+        ports=[443],
+        explicit_networks=[],
+        enabled=True,
+        interface="tun0",
+    )
+    resolver._forward = lambda _request: _response("api.example.test", "8.8.4.4")  # type: ignore[method-assign]
+    installed = []
+    monkeypatch.setattr(
+        egress_helper,
+        "_install_rule",
+        lambda network, port, interface=None: installed.append(
+            (str(network), port, interface)
+        ),
+    )
+
+    resolver.resolve(_query("api.example.test"))
+
+    assert installed == [("8.8.4.4/32", "443", "tun0")]

--- a/tests/v3/test_egress_helper.py
+++ b/tests/v3/test_egress_helper.py
@@ -185,6 +185,14 @@ operator-secret-password
     assert "operator-secret" not in detail
 
 
+def test_openvpn_uses_the_writable_private_runtime_directory():
+    arguments = egress_helper._openvpn_arguments(
+        egress_helper.Path("/run/nebula-client.ovpn")
+    )
+
+    assert arguments[-2:] == ["--tmp-dir", "/run"]
+
+
 def test_vpn_scoped_dns_rules_are_bound_to_the_tunnel(monkeypatch):
     monkeypatch.setattr(egress_helper, "_upstream_resolvers", lambda: ["8.8.8.8"])
     resolver = egress_helper.PolicyResolver(

--- a/tests/v3/test_egress_helper.py
+++ b/tests/v3/test_egress_helper.py
@@ -166,6 +166,25 @@ def test_vpn_remote_is_resolved_once_and_rewritten_to_the_pinned_address(monkeyp
     assert (port, protocol) == (1194, "udp")
 
 
+def test_vpn_log_detail_is_bounded_and_redacts_inline_credentials(tmp_path):
+    log = tmp_path / "openvpn.log"
+    log.write_text(
+        "operator-secret-user\noperator-secret-password\nAUTH_FAILED\n",
+        encoding="utf-8",
+    )
+    config = """client
+<auth-user-pass>
+operator-secret-user
+operator-secret-password
+</auth-user-pass>
+"""
+
+    detail = egress_helper._vpn_log_detail(config, log)
+
+    assert detail == "[REDACTED]\n[REDACTED]\nAUTH_FAILED"
+    assert "operator-secret" not in detail
+
+
 def test_vpn_scoped_dns_rules_are_bound_to_the_tunnel(monkeypatch):
     monkeypatch.setattr(egress_helper, "_upstream_resolvers", lambda: ["8.8.8.8"])
     resolver = egress_helper.PolicyResolver(

--- a/tests/v3/test_human_terminal_integration.py
+++ b/tests/v3/test_human_terminal_integration.py
@@ -165,6 +165,7 @@ def test_real_kali_terminal_is_root_writable_networked_and_ephemeral(tmp_path):
             b"getent hosts kali.org >/dev/null && echo network-ok\n"
             b"command -v nmap >/dev/null && echo nmap-ok\n"
             b"command -v ping >/dev/null && echo ping-installed\n"
+            b"command -v openvpn >/dev/null && echo openvpn-installed\n"
             b"apt-get update -qq && echo apt-ok\n"
             b"exit\n",
             before_commands=lambda: (workspace / "editor-script.py").write_text(
@@ -175,6 +176,7 @@ def test_real_kali_terminal_is_root_writable_networked_and_ephemeral(tmp_path):
         assert b"network-ok" in first
         assert b"nmap-ok" in first
         assert b"ping-installed" in first
+        assert b"openvpn-installed" in first
         assert b"apt-ok" in first
         assert b"editor-volume-ok" in first
         assert (workspace / "kali-workspace.txt").read_text() == "persisted"

--- a/tests/v3/test_sandbox.py
+++ b/tests/v3/test_sandbox.py
@@ -923,6 +923,71 @@ def test_egress_helper_creates_one_filtered_namespace_and_cleans_it_up(
     assert calls[1][0][-3:] == ["stop", "--time=0", "nebula-call-egress"]
 
 
+def test_vpn_profile_is_streamed_to_privileged_namespace_without_argv_exposure(
+    tmp_path, monkeypatch
+):
+    calls = []
+    written = bytearray()
+
+    class FakeInput:
+        def write(self, value):
+            written.extend(value)
+
+        async def drain(self):
+            return None
+
+        def close(self):
+            return None
+
+    class FakeProcess:
+        returncode = None
+
+        def __init__(self, ready=False):
+            self.stdout = asyncio.StreamReader() if ready else None
+            self.stdin = FakeInput() if ready else None
+            if self.stdout is not None:
+                self.stdout.feed_data(b"READY\n")
+
+        async def wait(self):
+            self.returncode = 0
+            return 0
+
+        def kill(self):
+            self.returncode = -9
+
+    async def create_process(*argv, **kwargs):
+        calls.append((list(argv), kwargs))
+        return FakeProcess(ready=len(calls) == 1)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_process)
+    controller = ContainerEgressController(
+        helper_image="example.invalid/helper@sha256:" + "b" * 64
+    )
+
+    async def scenario():
+        lease = await controller.acquire(
+            runtime_argv=["/usr/bin/podman"],
+            runtime_environment={"HOME": "/tmp/home"},
+            request=_request(
+                tmp_path,
+                network=SandboxNetwork.SCOPED,
+                execution_kind=SandboxExecutionKind.NETWORK_TOOL,
+                egress_rules=[EgressRule(address="203.0.113.1", ports=[443])],
+            ),
+            container_name="nebula-vpn",
+            seccomp_profile=None,
+            vpn_config="client\ndev tun0\nsecret material\n",
+        )
+        await lease.close()
+
+    asyncio.run(scenario())
+    helper_argv = calls[0][0]
+    assert "--device=/dev/net/tun" in helper_argv
+    assert "--vpn-stdin" in helper_argv
+    assert "secret material" not in " ".join(helper_argv)
+    assert written == b"client\ndev tun0\nsecret material\n"
+
+
 def test_egress_helper_creates_loopback_only_namespace_without_external_network(
     monkeypatch,
 ):
@@ -1008,7 +1073,7 @@ def test_human_terminal_verified_podman_cache_makes_no_registry_or_build_request
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v5"}}}',
+            + '"org.nebula.human-terminal.recipe":"v6"}}}',
             "",
             0,
         )
@@ -1033,6 +1098,7 @@ def test_human_terminal_verified_podman_cache_makes_no_registry_or_build_request
         "ripgrep",
         "git",
         "curl",
+        "openvpn",
     )
     assert image.security_tools == ("hashcat", "nmap")
     assert image.security_tool_provenance == (
@@ -1145,7 +1211,7 @@ def test_human_terminal_cold_preparation_pulls_builds_and_verifies(monkeypatch):
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v5"}}}',
+            + '"org.nebula.human-terminal.recipe":"v6"}}}',
             "",
             0,
         )
@@ -1178,7 +1244,7 @@ def test_human_terminal_cold_preparation_pulls_builds_and_verifies(monkeypatch):
     assert build[0][1] == "--platform=linux/amd64"
     assert build[0][2] == "--pull=false"
     assert build[0][3] == "--quiet"
-    assert build[0][4].startswith("--tag=localhost/nebula-kali-headless:v5-")
+    assert build[0][4].startswith("--tag=localhost/nebula-kali-headless:v6-")
     assert "FROM docker.io/kalilinux/kali-rolling@sha256:" + "e" * 64 in dockerfiles[0]
     assert "apt-get install -y kali-linux-headless iputils-ping" in dockerfiles[0]
     assert "COPY egress_helper.py /usr/local/bin/nebula-egress" in dockerfiles[0]
@@ -1237,7 +1303,7 @@ def test_human_terminal_cold_pull_failure_can_be_retried(monkeypatch):
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v5"}}}',
+            + '"org.nebula.human-terminal.recipe":"v6"}}}',
             "",
             0,
         )

--- a/tests/v3/test_sandbox.py
+++ b/tests/v3/test_sandbox.py
@@ -19,6 +19,7 @@ from nebula.v3.sandbox import (
     SandboxError,
     SandboxExecutionKind,
     SandboxNetwork,
+    SandboxPublishedPort,
     SandboxRequest,
     SandboxRootFilesystem,
     SandboxTerminalProcess,
@@ -988,6 +989,79 @@ def test_vpn_profile_is_streamed_to_privileged_namespace_without_argv_exposure(
     assert written == b"client\ndev tun0\nsecret material\n"
 
 
+def test_vpn_terminal_uses_fail_closed_namespace_and_publishes_on_owner(
+    tmp_path, monkeypatch
+):
+    calls = []
+    written = bytearray()
+
+    class FakeInput:
+        def write(self, value):
+            written.extend(value)
+
+        async def drain(self):
+            return None
+
+        def close(self):
+            return None
+
+    class FakeProcess:
+        returncode = None
+
+        def __init__(self, ready=False):
+            self.stdout = asyncio.StreamReader() if ready else None
+            self.stdin = FakeInput() if ready else None
+            if self.stdout is not None:
+                self.stdout.feed_data(b"READY\n")
+
+        async def wait(self):
+            self.returncode = 0
+            return 0
+
+        def kill(self):
+            self.returncode = -9
+
+    async def create_process(*argv, **kwargs):
+        calls.append((list(argv), kwargs))
+        return FakeProcess(ready=len(calls) == 1)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_process)
+    controller = ContainerEgressController(
+        helper_image="example.invalid/helper@sha256:" + "b" * 64
+    )
+    request = _request(
+        tmp_path,
+        network=SandboxNetwork.VPN,
+        execution_kind=SandboxExecutionKind.HUMAN_TERMINAL,
+        container_user=SandboxContainerUser.ROOT,
+        root_filesystem=SandboxRootFilesystem.WRITABLE,
+        published_ports=[SandboxPublishedPort(port=8080)],
+    )
+
+    async def scenario():
+        lease = await controller.acquire(
+            runtime_argv=["/usr/bin/podman"],
+            runtime_environment={"HOME": "/tmp/home"},
+            request=request,
+            container_name="nebula-terminal-vpn",
+            seccomp_profile=None,
+            vpn_config="client\ndev tun0\nsecret material\n",
+        )
+        await lease.close()
+
+    asyncio.run(scenario())
+    helper_argv = calls[0][0]
+    image_index = helper_argv.index("example.invalid/helper@sha256:" + "b" * 64)
+    assert "--device=/dev/net/tun" in helper_argv[:image_index]
+    assert "--publish=127.0.0.1:8080:8080/tcp" in helper_argv[:image_index]
+    assert helper_argv[image_index + 1 :] == [
+        "serve",
+        "--vpn-stdin",
+        "--vpn-unrestricted",
+    ]
+    assert written == b"client\ndev tun0\nsecret material\n"
+
+
 def test_egress_helper_creates_loopback_only_namespace_without_external_network(
     monkeypatch,
 ):
@@ -1073,7 +1147,7 @@ def test_human_terminal_verified_podman_cache_makes_no_registry_or_build_request
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v6"}}}',
+            + '"org.nebula.human-terminal.recipe":"v7"}}}',
             "",
             0,
         )
@@ -1211,7 +1285,7 @@ def test_human_terminal_cold_preparation_pulls_builds_and_verifies(monkeypatch):
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v6"}}}',
+            + '"org.nebula.human-terminal.recipe":"v7"}}}',
             "",
             0,
         )
@@ -1244,7 +1318,7 @@ def test_human_terminal_cold_preparation_pulls_builds_and_verifies(monkeypatch):
     assert build[0][1] == "--platform=linux/amd64"
     assert build[0][2] == "--pull=false"
     assert build[0][3] == "--quiet"
-    assert build[0][4].startswith("--tag=localhost/nebula-kali-headless:v6-")
+    assert build[0][4].startswith("--tag=localhost/nebula-kali-headless:v7-")
     assert "FROM docker.io/kalilinux/kali-rolling@sha256:" + "e" * 64 in dockerfiles[0]
     assert "apt-get install -y kali-linux-headless iputils-ping" in dockerfiles[0]
     assert "COPY egress_helper.py /usr/local/bin/nebula-egress" in dockerfiles[0]
@@ -1303,7 +1377,7 @@ def test_human_terminal_cold_pull_failure_can_be_retried(monkeypatch):
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v6"}}}',
+            + '"org.nebula.human-terminal.recipe":"v7"}}}',
             "",
             0,
         )

--- a/tests/v3/test_sandbox.py
+++ b/tests/v3/test_sandbox.py
@@ -947,7 +947,10 @@ def test_vpn_profile_is_streamed_to_privileged_namespace_without_argv_exposure(
             self.stdout = asyncio.StreamReader() if ready else None
             self.stdin = FakeInput() if ready else None
             if self.stdout is not None:
-                self.stdout.feed_data(b"READY\n")
+                self.stdout.feed_data(
+                    b"WARNING: IPv4 forwarding is disabled. Networking will not work.\n"
+                    b"READY\n"
+                )
 
         async def wait(self):
             self.returncode = 0
@@ -987,6 +990,56 @@ def test_vpn_profile_is_streamed_to_privileged_namespace_without_argv_exposure(
     assert "--vpn-stdin" in helper_argv
     assert "secret material" not in " ".join(helper_argv)
     assert written == b"client\ndev tun0\nsecret material\n"
+
+
+def test_failed_egress_helper_is_removed_after_bounded_startup_error(
+    tmp_path, monkeypatch
+):
+    calls = []
+
+    class FakeProcess:
+        returncode = None
+
+        def __init__(self, *, helper=False):
+            self.stdout = asyncio.StreamReader() if helper else None
+            self.stdin = None
+            if self.stdout is not None:
+                self.stdout.feed_data(b"RuntimeError: OpenVPN exited before ready\n")
+                self.stdout.feed_eof()
+
+        async def wait(self):
+            self.returncode = 1
+            return 1
+
+        def kill(self):
+            self.returncode = -9
+
+    async def create_process(*argv, **kwargs):
+        calls.append((list(argv), kwargs))
+        return FakeProcess(helper=len(calls) == 1)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_process)
+    controller = ContainerEgressController(
+        helper_image="example.invalid/helper@sha256:" + "b" * 64
+    )
+
+    async def scenario():
+        with pytest.raises(SandboxUnavailable, match="OpenVPN exited before ready"):
+            await controller.acquire(
+                runtime_argv=["/usr/bin/podman"],
+                runtime_environment={"HOME": "/tmp/home"},
+                request=_request(
+                    tmp_path,
+                    network=SandboxNetwork.SCOPED,
+                    execution_kind=SandboxExecutionKind.NETWORK_TOOL,
+                    egress_rules=[EgressRule(address="203.0.113.1", ports=[443])],
+                ),
+                container_name="nebula-failed-egress",
+                seccomp_profile=None,
+            )
+
+    asyncio.run(scenario())
+    assert calls[1][0][-3:] == ["rm", "--force", "nebula-failed-egress-egress"]
 
 
 def test_vpn_terminal_uses_fail_closed_namespace_and_publishes_on_owner(

--- a/tests/v3/test_sandbox.py
+++ b/tests/v3/test_sandbox.py
@@ -1200,7 +1200,7 @@ def test_human_terminal_verified_podman_cache_makes_no_registry_or_build_request
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v8"}}}',
+            + '"org.nebula.human-terminal.recipe":"v9"}}}',
             "",
             0,
         )
@@ -1338,7 +1338,7 @@ def test_human_terminal_cold_preparation_pulls_builds_and_verifies(monkeypatch):
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v8"}}}',
+            + '"org.nebula.human-terminal.recipe":"v9"}}}',
             "",
             0,
         )
@@ -1371,7 +1371,7 @@ def test_human_terminal_cold_preparation_pulls_builds_and_verifies(monkeypatch):
     assert build[0][1] == "--platform=linux/amd64"
     assert build[0][2] == "--pull=false"
     assert build[0][3] == "--quiet"
-    assert build[0][4].startswith("--tag=localhost/nebula-kali-headless:v8-")
+    assert build[0][4].startswith("--tag=localhost/nebula-kali-headless:v9-")
     assert "FROM docker.io/kalilinux/kali-rolling@sha256:" + "e" * 64 in dockerfiles[0]
     assert "apt-get install -y kali-linux-headless iputils-ping" in dockerfiles[0]
     assert "COPY egress_helper.py /usr/local/bin/nebula-egress" in dockerfiles[0]
@@ -1430,7 +1430,7 @@ def test_human_terminal_cold_pull_failure_can_be_retried(monkeypatch):
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v8"}}}',
+            + '"org.nebula.human-terminal.recipe":"v9"}}}',
             "",
             0,
         )

--- a/tests/v3/test_sandbox.py
+++ b/tests/v3/test_sandbox.py
@@ -1200,7 +1200,7 @@ def test_human_terminal_verified_podman_cache_makes_no_registry_or_build_request
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v7"}}}',
+            + '"org.nebula.human-terminal.recipe":"v8"}}}',
             "",
             0,
         )
@@ -1338,7 +1338,7 @@ def test_human_terminal_cold_preparation_pulls_builds_and_verifies(monkeypatch):
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v7"}}}',
+            + '"org.nebula.human-terminal.recipe":"v8"}}}',
             "",
             0,
         )
@@ -1371,7 +1371,7 @@ def test_human_terminal_cold_preparation_pulls_builds_and_verifies(monkeypatch):
     assert build[0][1] == "--platform=linux/amd64"
     assert build[0][2] == "--pull=false"
     assert build[0][3] == "--quiet"
-    assert build[0][4].startswith("--tag=localhost/nebula-kali-headless:v7-")
+    assert build[0][4].startswith("--tag=localhost/nebula-kali-headless:v8-")
     assert "FROM docker.io/kalilinux/kali-rolling@sha256:" + "e" * 64 in dockerfiles[0]
     assert "apt-get install -y kali-linux-headless iputils-ping" in dockerfiles[0]
     assert "COPY egress_helper.py /usr/local/bin/nebula-egress" in dockerfiles[0]
@@ -1430,7 +1430,7 @@ def test_human_terminal_cold_pull_failure_can_be_retried(monkeypatch):
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v7"}}}',
+            + '"org.nebula.human-terminal.recipe":"v8"}}}',
             "",
             0,
         )

--- a/tests/v3/test_setup.py
+++ b/tests/v3/test_setup.py
@@ -394,6 +394,7 @@ def test_human_terminal_runner_admits_only_the_exact_linked_workspace(tmp_path):
     resolution = asyncio.run(platform.resolve_human_terminal_runtime(engagement.id))
 
     assert resolution.workspace == linked_workspace.resolve()
+    assert resolution.runner.egress_controller.certified is True
     assert linked_workspace.resolve() in resolution.runner.workspace_roots
     assert (tmp_path / "linked").resolve() not in resolution.runner.workspace_roots
     allowed = SandboxRequest(

--- a/tests/v3/test_setup.py
+++ b/tests/v3/test_setup.py
@@ -20,7 +20,13 @@ from nebula.v3.api import create_app
 from nebula.v3.artifacts import ArtifactStore
 from nebula.v3.database import BootstrapStateRow, Database
 from nebula.v3.domain import Engagement, RunnerProfile, ScopePolicy
-from nebula.v3.sandbox import ContainerSandboxRunner
+from nebula.v3.sandbox import (
+    ContainerSandboxRunner,
+    PreparedContainerImage,
+    SandboxError,
+    SandboxRequest,
+    SandboxWorkspaceAccess,
+)
 from nebula.v3.setup import (
     ImagePreparationCancellationRequest,
     ImagePreparationRequest,
@@ -348,6 +354,79 @@ def test_prepared_runtime_survives_health_refresh_but_not_runner_config_change(
     with pytest.raises(RuntimePlatformError, match="runner has changed"):
         platform.resolve_operator_runtime(engagement.id, "bash", network=False)
     assert changed.revision > profile.revision
+
+
+def test_human_terminal_runner_admits_only_the_exact_linked_workspace(tmp_path):
+    store = NebulaStore(tmp_path / "linked-workspace.db")
+    linked_workspace = tmp_path / "linked" / "project"
+    linked_workspace.mkdir(parents=True)
+    sibling_workspace = tmp_path / "linked" / "other-project"
+    sibling_workspace.mkdir()
+    engagement = store.create(
+        Engagement(name="Linked workspace", workspace_path=str(linked_workspace))
+    )
+    profile = store.create(
+        RunnerProfile(
+            id="local",
+            name="Local Docker",
+            runtime="docker",
+            executable="/usr/bin/docker",
+            platform="linux/amd64",
+            isolation="rootless",
+            healthy=True,
+        )
+    )
+    platform = _platform(tmp_path, store)
+    image = PreparedContainerImage(
+        source_reference="docker.io/kalilinux/kali-rolling:latest",
+        base_resolved_reference=("docker.io/kalilinux/kali-rolling@sha256:" + "b" * 64),
+        base_digest="sha256:" + "b" * 64,
+        resolved_reference="sha256:" + "c" * 64,
+        digest="sha256:" + "c" * 64,
+        platform="linux/amd64",
+        configured_user="",
+        installed_packages=("kali-linux-headless",),
+        refreshed=False,
+        detail="verified cached image",
+    )
+    platform._prepared_images[(profile.id, profile.revision)] = image
+
+    resolution = asyncio.run(platform.resolve_human_terminal_runtime(engagement.id))
+
+    assert resolution.workspace == linked_workspace.resolve()
+    assert linked_workspace.resolve() in resolution.runner.workspace_roots
+    assert (tmp_path / "linked").resolve() not in resolution.runner.workspace_roots
+    allowed = SandboxRequest(
+        image=image.digest,
+        trusted_local_image=True,
+        command=["/bin/true"],
+        workspace=linked_workspace,
+        workspace_access=SandboxWorkspaceAccess.WRITE,
+    )
+    assert resolution.runner._validate(allowed) == linked_workspace.resolve()
+    denied = allowed.model_copy(update={"workspace": sibling_workspace})
+    with pytest.raises(SandboxError, match="outside the configured workspace roots"):
+        resolution.runner._validate(denied)
+
+    platform.runtime_metadata_path.write_text(
+        json.dumps(
+            {
+                "schema": KALI_RUNTIME_METADATA_SCHEMA,
+                "image_digest": image.digest,
+                "runner_profile_id": profile.id,
+                "runner_profile_revision": profile.revision,
+                "runner_profile_fingerprint": _runner_profile_fingerprint(profile),
+                "binary_inventory": [
+                    {"name": "bash", "path": "/usr/bin/bash", "version": "5"}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    operator = platform.resolve_operator_runtime(engagement.id, "bash", network=False)
+    assert operator.workspace == linked_workspace.resolve()
+    assert linked_workspace.resolve() in operator.runner.workspace_roots
+    assert (tmp_path / "linked").resolve() not in operator.runner.workspace_roots
 
 
 def test_exactly_one_verified_fixed_runtime_is_persisted_as_local(

--- a/tests/v3/test_vpn.py
+++ b/tests/v3/test_vpn.py
@@ -1,0 +1,60 @@
+import pytest
+
+from nebula.v3.vpn import VpnProfileError, parse_openvpn_profile
+
+
+BASE = """client
+dev tun
+proto udp
+remote vpn.example.com 1194
+remote-cert-tls server
+<ca>
+certificate
+</ca>
+"""
+
+
+def test_admits_inline_tun_profile_and_forces_full_tunnel():
+    parsed = parse_openvpn_profile(BASE)
+
+    assert parsed.remote_host == "vpn.example.com"
+    assert parsed.remote_port == 1194
+    assert parsed.protocol == "udp"
+    assert "dev tun0" in parsed.config
+    assert "redirect-gateway def1" in parsed.config
+    assert "redirect-gateway ipv6" in parsed.config
+
+
+@pytest.mark.parametrize(
+    "directive",
+    [
+        "up /tmp/script",
+        "plugin /tmp/plugin.so",
+        "route-nopull",
+        "route 10.0.0.0 255.0.0.0",
+        "management 0.0.0.0 7505",
+        "config nested.ovpn",
+        "dev tap",
+    ],
+)
+def test_rejects_profile_escape_hatches(directive: str):
+    with pytest.raises(VpnProfileError):
+        parse_openvpn_profile(BASE.replace("dev tun", directive))
+
+
+def test_requires_credentials_without_accepting_a_file_path():
+    profile = BASE + "auth-user-pass\n"
+    parsed = parse_openvpn_profile(profile, username="operator", password="secret")
+    assert "<auth-user-pass>\noperator\nsecret\n</auth-user-pass>" in parsed.config
+
+    with pytest.raises(VpnProfileError, match="requires"):
+        parse_openvpn_profile(profile)
+    with pytest.raises(VpnProfileError, match="file paths"):
+        parse_openvpn_profile(BASE + "auth-user-pass credentials.txt\n")
+
+
+def test_requires_server_identity_verification_and_one_remote():
+    with pytest.raises(VpnProfileError, match="verify"):
+        parse_openvpn_profile(BASE.replace("remote-cert-tls server\n", ""))
+    with pytest.raises(VpnProfileError, match="exactly one remote"):
+        parse_openvpn_profile(BASE + "remote backup.example.com 1194\n")

--- a/tests/v3/test_vpn.py
+++ b/tests/v3/test_vpn.py
@@ -33,6 +33,23 @@ def test_admits_ping_timer_rem_without_arguments():
         parse_openvpn_profile(BASE + "ping-timer-rem unexpected\n")
 
 
+def test_common_safe_client_timing_options_are_admitted():
+    parsed = parse_openvpn_profile(
+        BASE
+        + "reneg-sec 0\nreneg-bytes 0\nreneg-pkts 0\n"
+        + "remote-random\nfast-io\nmute-replay-warnings\nsuppress-timestamps\n"
+    )
+
+    assert "reneg-sec 0\n" in parsed.config
+    assert "remote-random\n" in parsed.config
+
+
+@pytest.mark.parametrize("value", ["-1", "forever", "1 2"])
+def test_renegotiation_options_reject_invalid_values(value):
+    with pytest.raises(VpnProfileError, match="reneg-sec requires"):
+        parse_openvpn_profile(BASE + f"reneg-sec {value}\n")
+
+
 @pytest.mark.parametrize(
     "directive",
     [

--- a/tests/v3/test_vpn.py
+++ b/tests/v3/test_vpn.py
@@ -25,6 +25,14 @@ def test_admits_inline_tun_profile_and_forces_full_tunnel():
     assert "redirect-gateway ipv6" in parsed.config
 
 
+def test_admits_ping_timer_rem_without_arguments():
+    parsed = parse_openvpn_profile(BASE + "ping 10\nping-restart 60\nping-timer-rem\n")
+
+    assert "ping-timer-rem\n" in parsed.config
+    with pytest.raises(VpnProfileError, match="does not accept arguments"):
+        parse_openvpn_profile(BASE + "ping-timer-rem unexpected\n")
+
+
 @pytest.mark.parametrize(
     "directive",
     [

--- a/tests/v3/test_vpn.py
+++ b/tests/v3/test_vpn.py
@@ -21,8 +21,7 @@ def test_admits_inline_tun_profile_and_forces_full_tunnel():
     assert parsed.remote_port == 1194
     assert parsed.protocol == "udp"
     assert "dev tun0" in parsed.config
-    assert "redirect-gateway def1" in parsed.config
-    assert "redirect-gateway ipv6" in parsed.config
+    assert "redirect-gateway def1 ipv6" in parsed.config
 
 
 def test_admits_ping_timer_rem_without_arguments():

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
     {
       name: "mobile-chromium",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|VPN settings keep|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|VPN settings keep|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|terminal VPN boundary|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"] },
     },
     {
@@ -58,31 +58,31 @@ export default defineConfig({
     {
       name: "mobile-chromium-small",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|terminal VPN boundary|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"], viewport: { width: 320, height: 700 } },
     },
     {
       name: "mobile-chromium-wide",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output/,
+      grep: /universal search opens|theme picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output|terminal VPN boundary/,
       use: { ...devices["Pixel 5"], viewport: { width: 430, height: 932 } },
     },
     {
       name: "mobile-webkit-small",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output/,
+      grep: /universal search opens|theme picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output|terminal VPN boundary/,
       use: { ...devices["iPhone 13"], viewport: { width: 320, height: 700 } },
     },
     {
       name: "mobile-webkit",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|terminal VPN boundary|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["iPhone 13"] },
     },
     {
       name: "mobile-webkit-wide",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|terminal VPN boundary|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["iPhone 13"], viewport: { width: 430, height: 932 } },
     },
     {

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
     {
       name: "mobile-chromium",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|VPN settings keep|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"] },
     },
     {

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -58,31 +58,31 @@ export default defineConfig({
     {
       name: "mobile-chromium-small",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|terminal VPN boundary|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|VPN settings keep|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|terminal VPN boundary|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["Pixel 5"], viewport: { width: 320, height: 700 } },
     },
     {
       name: "mobile-chromium-wide",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output|terminal VPN boundary/,
+      grep: /universal search opens|VPN settings keep|theme picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output|terminal VPN boundary/,
       use: { ...devices["Pixel 5"], viewport: { width: 430, height: 932 } },
     },
     {
       name: "mobile-webkit-small",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output|terminal VPN boundary/,
+      grep: /universal search opens|VPN settings keep|theme picker|mission result actions|activity ledger groups repeated work|browser research tools expose durable workflows|completed harness output|terminal VPN boundary/,
       use: { ...devices["iPhone 13"], viewport: { width: 320, height: 700 } },
     },
     {
       name: "mobile-webkit",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|terminal VPN boundary|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|VPN settings keep|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant follow-up queue|assistant live guidance|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|terminal VPN boundary|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["iPhone 13"] },
     },
     {
       name: "mobile-webkit-wide",
       testMatch: "**/interface.spec.ts",
-      grep: /universal search opens|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|terminal VPN boundary|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
+      grep: /universal search opens|VPN settings keep|theme picker|host folder picker|project scope normalizes|mission workflow|mission result actions|completed harness output|activity ledger groups repeated work|assistant context pack|conversation switching|harness model controls|AI writing submits the visible supported model|New chat detaches|oversized harness activity|audit every primary workspace view|audit primary mutation dialogs|paired-device settings|mobile Workbench navigation|browser research tools expose durable workflows|product typography and touch contracts|shared actions keep sleek geometry|terminal screenshot capture|terminal VPN boundary|code editor keeps its caret|terminal and notes keep a visible focused caret|Zero keeps one navigable panoramic shell/,
       use: { ...devices["iPhone 13"], viewport: { width: 430, height: 932 } },
     },
     {

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -1673,8 +1673,11 @@ interface WireContainerTerminalRuntime extends JsonObject {
 }
 
 interface WireContainerTerminalNetwork extends JsonObject {
-  mode: "unrestricted";
-  runtime_network: "bridge";
+  mode: "unrestricted" | "vpn";
+  runtime_network: "bridge" | "private_namespace";
+  vpn_profile_id?: string | null;
+  vpn_profile_revision?: number | null;
+  vpn_profile_name?: string | null;
   published_ports: Array<{ port: number; protocol: "tcp" | "udp" }>;
 }
 
@@ -1720,12 +1723,14 @@ interface WireContainerTerminalRecovery extends JsonObject {
   active: boolean;
   session?: WireContainerTerminalSession | null;
   runtime?: WireContainerTerminalRuntime | null;
+  network?: WireContainerTerminalNetwork | null;
 }
 
 interface WireContainerTerminalRecoveryList extends JsonObject {
   sessions: Array<{
     session: WireContainerTerminalSession;
     runtime: WireContainerTerminalRuntime;
+    network?: WireContainerTerminalNetwork | null;
   }>;
 }
 
@@ -2872,6 +2877,9 @@ function mapContainerTerminalNetwork(value: WireContainerTerminalNetwork) {
   return {
     mode: value.mode,
     runtimeNetwork: value.runtime_network,
+    vpnProfileId: value.vpn_profile_id ?? undefined,
+    vpnProfileRevision: value.vpn_profile_revision ?? undefined,
+    vpnProfileName: value.vpn_profile_name ?? undefined,
     publishedPorts: value.published_ports,
   };
 }
@@ -6668,6 +6676,9 @@ export class ApiClient {
       runtime: value.runtime
         ? mapContainerTerminalRuntime(value.runtime)
         : undefined,
+      network: value.network
+        ? mapContainerTerminalNetwork(value.network)
+        : undefined,
     }));
   }
 
@@ -6682,6 +6693,9 @@ export class ApiClient {
       sessions: value.sessions.map((item) => ({
         session: mapContainerTerminalSession(item.session),
         runtime: mapContainerTerminalRuntime(item.runtime),
+        network: item.network
+          ? mapContainerTerminalNetwork(item.network)
+          : { mode: "unrestricted", runtimeNetwork: "bridge", publishedPorts: [] },
       })),
     }));
   }

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -5273,6 +5273,7 @@ export class ApiClient {
       approvalPolicy: value.approval_policy as "always" | "on_boundary" | "never",
       networkEnabled: value.network_enabled === true,
       runnerProfileId: typeof value.runner_profile_id === "string" ? value.runner_profile_id : undefined,
+      vpnProfileId: typeof value.vpn_profile_id === "string" ? value.vpn_profile_id : undefined,
       maxTimeoutMs: Number(value.max_timeout_ms ?? 300000),
       revision: Number(value.revision ?? 1),
     }));
@@ -5280,7 +5281,7 @@ export class ApiClient {
 
   updateAutomationPolicy(
     engagementId: string,
-    request: { approvalPolicy: "always" | "on_boundary" | "never"; networkEnabled: boolean; runnerProfileId?: string; maxTimeoutMs: number; expectedRevision: number },
+    request: { approvalPolicy: "always" | "on_boundary" | "never"; networkEnabled: boolean; runnerProfileId?: string; vpnProfileId?: string; maxTimeoutMs: number; expectedRevision: number },
   ): Promise<import("./types").AutomationProjectPolicy> {
     return this.request<Record<string, unknown>>(`engagements/${encodeURIComponent(engagementId)}/automation-policy`, {
       method: "PUT",
@@ -5288,10 +5289,33 @@ export class ApiClient {
         approval_policy: request.approvalPolicy,
         network_enabled: request.networkEnabled,
         runner_profile_id: request.runnerProfileId ?? null,
+        vpn_profile_id: request.vpnProfileId ?? null,
         max_timeout_ms: request.maxTimeoutMs,
         expected_revision: request.expectedRevision,
       }),
     }).then(() => this.getAutomationPolicy(engagementId));
+  }
+
+  listVpnProfiles(): Promise<import("./types").VpnProfile[]> {
+    return this.request<Array<Record<string, unknown>>>("vpn-profiles").then((items) => items.map((value) => ({
+      id: String(value.id), name: String(value.name), filename: String(value.filename),
+      remoteHost: String(value.remote_host), remotePort: Number(value.remote_port),
+      protocol: value.protocol === "tcp" ? "tcp" : "udp", fingerprint: String(value.fingerprint),
+      requiresCredentials: value.requires_credentials === true, available: value.available === true,
+      revision: Number(value.revision ?? 1),
+    })));
+  }
+
+  createVpnProfile(request: { name: string; filename: string; config: string; username?: string; password?: string; persistence: "vault" | "session" }): Promise<import("./types").VpnProfile> {
+    return this.request<Record<string, unknown>>("vpn-profiles", { method: "POST", body: JSON.stringify(request) }).then((value) => ({
+      id: String(value.id), name: String(value.name), filename: String(value.filename), remoteHost: String(value.remote_host),
+      remotePort: Number(value.remote_port), protocol: value.protocol === "tcp" ? "tcp" : "udp", fingerprint: String(value.fingerprint),
+      requiresCredentials: value.requires_credentials === true, available: value.available === true, revision: Number(value.revision ?? 1),
+    }));
+  }
+
+  deleteVpnProfile(id: string, revision: number): Promise<void> {
+    return this.request<void>(`vpn-profiles/${encodeURIComponent(id)}`, { method: "DELETE", body: JSON.stringify({ expected_revision: revision }) });
   }
 
   listMcpServers(signal?: AbortSignal): Promise<McpServerProfile[]> {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -2295,8 +2295,11 @@ export interface ContainerTerminalRuntimeSnapshot {
 }
 
 export interface ContainerTerminalNetworkSnapshot {
-  mode: "unrestricted";
-  runtimeNetwork: "bridge";
+  mode: "unrestricted" | "vpn";
+  runtimeNetwork: "bridge" | "private_namespace";
+  vpnProfileId?: Identifier;
+  vpnProfileRevision?: number;
+  vpnProfileName?: string;
   publishedPorts: ContainerTerminalPublishedPort[];
 }
 
@@ -2359,11 +2362,13 @@ export interface ContainerTerminalRecovery {
   active: boolean;
   session?: ContainerTerminalSession;
   runtime?: ContainerTerminalRuntimeSnapshot;
+  network?: ContainerTerminalNetworkSnapshot;
 }
 
 export interface ContainerTerminalRecoveredSession {
   session: ContainerTerminalSession;
   runtime: ContainerTerminalRuntimeSnapshot;
+  network: ContainerTerminalNetworkSnapshot;
 }
 
 export interface ContainerTerminalRecoveryList {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -215,7 +215,21 @@ export interface AutomationProjectPolicy {
   approvalPolicy: "always" | "on_boundary" | "never";
   networkEnabled: boolean;
   runnerProfileId?: Identifier;
+  vpnProfileId?: Identifier;
   maxTimeoutMs: number;
+  revision: number;
+}
+
+export interface VpnProfile {
+  id: Identifier;
+  name: string;
+  filename: string;
+  remoteHost: string;
+  remotePort: number;
+  protocol: "udp" | "tcp";
+  fingerprint: string;
+  requiresCredentials: boolean;
+  available: boolean;
   revision: number;
 }
 

--- a/ui/src/components-domain.css
+++ b/ui/src/components-domain.css
@@ -448,6 +448,18 @@
 .policy-form-body > footer > .button { flex: 0 0 auto; white-space: nowrap; }
 .runner-status { overflow: hidden; }
 .runner-status article { display: flex; align-items: flex-start; gap: 8px; padding: 11px 13px; border-top: 1px solid var(--border-soft); }
+.vpn-heading { margin-top: 24px; }
+.vpn-profile-form { grid-template-columns: 1fr; }
+.vpn-profile-form > * { grid-column: 1 / -1; }
+.vpn-file-drop { display: flex !important; align-items: center; gap: 11px; min-height: 76px; padding: 14px; border: 1px dashed var(--border); border-radius: var(--radius-panel); background: color-mix(in srgb, var(--accent) 4%, var(--surface-raised)); cursor: pointer; }
+.vpn-file-drop:hover { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 7%, var(--surface-raised)); }
+.vpn-file-drop input { position: absolute; width: 1px !important; height: 1px; opacity: 0; pointer-events: none; }
+.vpn-file-drop span, .vpn-options summary span { display: grid; gap: 3px; }
+.vpn-file-drop small, .vpn-options small { color: var(--muted); font-weight: var(--weight-regular); }
+.vpn-options { border: 1px solid var(--border-soft); border-radius: var(--radius-control); }
+.vpn-options summary { display: flex; align-items: center; justify-content: space-between; padding: 10px; cursor: pointer; }
+.vpn-options .policy-form-body { padding: 0 10px 10px; }
+.runner-status article .icon-button { margin-left: auto; flex: 0 0 auto; }
 .runner-status article > div { display: flex; min-width: 0; flex-direction: column; }
 .runner-status article strong { font-size: 11px; }
 .runner-status article small, .runner-status article p { margin: 3px 0 0; color: var(--muted); font-size: 11px; line-height: 1.4; }

--- a/ui/src/components-domain.css
+++ b/ui/src/components-domain.css
@@ -463,6 +463,9 @@
 .runner-status article > div { display: flex; min-width: 0; flex-direction: column; }
 .runner-status article strong { font-size: 11px; }
 .runner-status article small, .runner-status article p { margin: 3px 0 0; color: var(--muted); font-size: 11px; line-height: 1.4; }
+.runner-status article .vpn-profile-actions { align-items: flex-end; margin-left: auto; gap: 6px; flex: 0 0 auto; }
+.vpn-profile-actions .icon-button { margin-left: 0 !important; }
+.vpn-selected-label { display: inline-flex; align-items: center; gap: 4px; min-height: 28px; color: var(--success); font-size: 11px; font-weight: var(--weight-semibold); }
 .policy-revision { color: var(--muted); font-size: 11px; }
 .policy-editor-grid { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(300px, .75fr); gap: 12px; }
 .policy-form { min-width: 0; max-width: 100%; overflow: hidden; }
@@ -616,6 +619,8 @@
   .resource-form-grid { grid-template-columns: 1fr; }
   .runner-form { grid-template-columns: 1fr; }
   .runner-form label, .runner-form label:nth-of-type(3), .runner-form label:nth-of-type(5), .runner-form footer { grid-column: auto; }
+  .runner-status article:has(.vpn-profile-actions) { flex-wrap: wrap; }
+  .runner-status article .vpn-profile-actions { width: 100%; align-items: center; flex-direction: row; justify-content: flex-end; }
   .operator-profile-list article { grid-template-columns: 36px minmax(0, 1fr) 30px 30px; }
   .operator-profile-list article > .operator-active,
   .operator-profile-list article > .button.quiet { grid-column: 2; grid-row: 2; justify-self: start; }

--- a/ui/src/components/ContainerTerminalPanel.test.tsx
+++ b/ui/src/components/ContainerTerminalPanel.test.tsx
@@ -134,6 +134,36 @@ describe("ContainerTerminalPanel", () => {
     terminalSpies.selection = "";
   });
 
+  it("shows the frozen VPN boundary for a recovered terminal", async () => {
+    const api = {
+      baseUrl: "http://127.0.0.1:8765/api/v1",
+      getToken: () => "test-token",
+      containerTerminalCapabilities: vi.fn().mockResolvedValue({ ready: true }),
+      recoverContainerTerminals: vi.fn().mockResolvedValue({
+        sessions: [{
+          session: session("terminal-vpn"),
+          runtime,
+          network: {
+            mode: "vpn",
+            runtimeNetwork: "private_namespace",
+            vpnProfileId: "vpn-1",
+            vpnProfileRevision: 1,
+            vpnProfileName: "Company VPN",
+            publishedPorts: [],
+          },
+        }],
+      }),
+      containerTerminalCapacity: vi.fn().mockResolvedValue(capacity(1)),
+      terminalCommandHistoryStatus: vi.fn().mockResolvedValue({}),
+    } as unknown as ApiClient;
+
+    renderPanel(api);
+
+    expect(await screen.findByText(/VPN enforced · Company VPN/)).toBeVisible();
+    expect(screen.getByText(/blocked until OpenVPN is ready/)).toBeVisible();
+    expect(screen.queryByText(/Bridge networking is permitted/)).not.toBeInTheDocument();
+  });
+
   it("explains a workspace limit before attempting a terminal start", async () => {
     const api = {
       baseUrl: "http://127.0.0.1:8765/api/v1",

--- a/ui/src/components/ContainerTerminalPanel.tsx
+++ b/ui/src/components/ContainerTerminalPanel.tsx
@@ -20,6 +20,7 @@ import type {
   ContainerTerminalRequest,
   ContainerTerminalPublishedPort,
   ContainerTerminalRuntimeSnapshot,
+  ContainerTerminalNetworkSnapshot,
   ContainerTerminalSession,
   EvidenceSummary,
   EvidenceUploadRequest,
@@ -59,6 +60,7 @@ interface StartingTerminalTab {
   imagePreparation?: SetupImagePreparation;
   error?: string;
   publishedPorts: ContainerTerminalPublishedPort[];
+  network?: ContainerTerminalNetworkSnapshot;
 }
 
 interface LiveTerminalTab {
@@ -67,12 +69,19 @@ interface LiveTerminalTab {
   ordinal: number;
   session: ContainerTerminalSession;
   runtime: ContainerTerminalRuntimeSnapshot;
+  network: ContainerTerminalNetworkSnapshot;
   socketState: ContainerTerminalSocketState;
   exit?: ContainerTerminalExit;
   error?: string;
 }
 
 type TerminalTab = StartingTerminalTab | LiveTerminalTab;
+
+const DIRECT_TERMINAL_NETWORK: ContainerTerminalNetworkSnapshot = {
+  mode: "unrestricted",
+  runtimeNetwork: "bridge",
+  publishedPorts: [],
+};
 
 function idempotencyKey(): string {
   return `container-terminal-${globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`}`;
@@ -114,6 +123,7 @@ function LiveContainerTerminal({
   onUploadEvidence,
   session,
   runtime,
+  network,
 }: {
   api: ApiClient;
   active: boolean;
@@ -128,6 +138,7 @@ function LiveContainerTerminal({
   onUploadEvidence?: (request: EvidenceUploadRequest) => Promise<EvidenceSummary>;
   session: ContainerTerminalSession;
   runtime: ContainerTerminalRuntimeSnapshot;
+  network: ContainerTerminalNetworkSnapshot;
 }) {
   const hostRef = useRef<HTMLDivElement>(null);
   const selectionActions = useOptionalSelectionActions();
@@ -346,7 +357,9 @@ function LiveContainerTerminal({
       {(auditWarningCount > 0 || auditHealthUnavailable) && <p className="terminal-audit-warning" role="alert"><AlertTriangle size={14} /> {auditHealthUnavailable ? "Terminal audit health is unavailable. Capture failures cannot be ruled out." : `${auditWarningCount} terminal audit warning${auditWarningCount === 1 ? "" : "s"} detected. Review Terminal Audit for classification, truncation, interruption, recovery, or persistence gaps.`}</p>}
       {networkWarning && <p className="terminal-audit-warning" role="alert"><AlertTriangle size={14} /> {networkWarning}</p>}
       <p><code>kali-linux-headless</code> · <code title={runtime.baseImage}>{runtime.baseImageDigest.slice(0, 19)}…</code></p>
-      {networkBoundaryVisible && <p className="terminal-network-warning"><AlertTriangle size={14} /><span>Bridge networking is permitted, not guaranteed. Host IPv4 and IPv6 availability can differ. Inbound TCP or UDP ports are granted only when explicitly published on host loopback. No raw-packet capabilities, host shell, or runtime socket are granted.</span><button className="icon-button subtle" type="button" aria-label="Dismiss network boundary notice" onClick={() => setNetworkBoundaryVisible(false)}><X size={14} /></button></p>}
+      {networkBoundaryVisible && (network.mode === "vpn"
+        ? <p className="terminal-network-warning"><ShieldCheck size={14} /><span><strong>VPN enforced · {network.vpnProfileName ?? "Selected profile"}</strong> All container traffic remains blocked until OpenVPN is ready and fails closed if the tunnel stops. No VPN capability or profile secret is exposed to this shell.</span><button className="icon-button subtle" type="button" aria-label="Dismiss VPN boundary notice" onClick={() => setNetworkBoundaryVisible(false)}><X size={14} /></button></p>
+        : <p className="terminal-network-warning"><AlertTriangle size={14} /><span>Bridge networking is permitted, not guaranteed. Host IPv4 and IPv6 availability can differ. Inbound TCP or UDP ports are granted only when explicitly published on host loopback. No raw-packet capabilities, host shell, or runtime socket are granted.</span><button className="icon-button subtle" type="button" aria-label="Dismiss network boundary notice" onClick={() => setNetworkBoundaryVisible(false)}><X size={14} /></button></p>)}
     </div>
     <div className="xterm-shell" ref={hostRef} aria-label="Terminal output" />
     <footer><ShieldCheck size={14} /> Additional system changes and packages disappear when this content-pinned container closes; the Kali headless baseline and <code>/workspace</code> remain available in new sessions.{exit?.exitCode !== undefined ? ` Exit code ${exit.exitCode}.` : ""}</footer>
@@ -396,7 +409,7 @@ function StartingTerminalPanel({
     <section className="container-terminal-intro">
       <span className="terminal-hero-icon"><SquareTerminal size={23} /></span>
       <div><small>Kali shell · {engagementName}</small><h2>Terminal {tab.ordinal}</h2><p><code>kali-linux-headless</code> · disposable · shared <code>/workspace</code></p></div>
-      <span className="terminal-boundary"><AlertTriangle size={15} /> Root · bridge permitted</span>
+      <span className="terminal-boundary">{tab.network?.mode === "vpn" ? <><ShieldCheck size={15} /> VPN · {tab.network.vpnProfileName ?? "selected profile"}</> : <><AlertTriangle size={15} /> Root · bridge permitted</>}</span>
     </section>
     <section className="terminal-auto-start" aria-live="polite">
       {tab.error ? <><SquareTerminal size={27} /><strong>Terminal could not start</strong><DiagnosticErrorNotice error={tab.error} fallback="The terminal operation could not be completed." compact /><div className="terminal-start-actions"><button className="button secondary" type="button" onClick={onClose}>Close</button><button className="button primary" type="button" onClick={onRetry}><RotateCcw size={15} /> Retry</button></div></> : <><LoaderCircle className="spin" size={27} /><strong>{status}</strong><div
@@ -591,7 +604,8 @@ export function ContainerTerminalPanel({
       if (!preview.allowed || !preview.previewToken || !preview.previewFingerprint || !preview.runtime) {
         throw new Error(preview.detail || "Core denied the terminal preflight.");
       }
-      updateStartingTab(key, { phase: "starting" });
+      const previewNetwork = preview.network ?? DIRECT_TERMINAL_NETWORK;
+      updateStartingTab(key, { phase: "starting", network: previewNetwork, phaseDetail: previewNetwork.mode === "vpn" ? `Establishing ${previewNetwork.vpnProfileName ?? "the selected VPN"} before opening the shell.` : undefined });
       const created = await api.startContainerTerminal(
         request,
         preview,
@@ -605,6 +619,7 @@ export function ContainerTerminalPanel({
           ordinal,
           session: created,
           runtime: preview.runtime!,
+          network: previewNetwork,
           socketState: "connecting",
         } : tab));
         setupReadyRef.current = true;
@@ -690,6 +705,7 @@ export function ContainerTerminalPanel({
           ordinal: index + 1,
           session: item.session,
           runtime: item.runtime,
+          network: item.network ?? DIRECT_TERMINAL_NETWORK,
           socketState: "connecting",
         }));
         nextOrdinalRef.current = recoveredTabs.length + 1;
@@ -942,6 +958,7 @@ export function ContainerTerminalPanel({
         onSocketState={(socketState) => setTabs((current) => current.map((item) => item.key === tab.key && item.kind === "live" ? { ...item, socketState } : item))}
         onUploadEvidence={onUploadEvidence}
         runtime={tab.runtime}
+        network={tab.network}
         session={tab.session}
       />}
     </div>)}

--- a/ui/src/components/EngagementPolicySettings.tsx
+++ b/ui/src/components/EngagementPolicySettings.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { Save, ShieldCheck, TerminalSquare } from "lucide-react";
-import type { AutomationProjectPolicy, EngagementScopePolicy } from "../api/types";
+import type { AutomationProjectPolicy, EngagementScopePolicy, VpnProfile } from "../api/types";
+import { ApiError } from "../api/client";
 import { useWorkspace } from "../state/WorkspaceContext";
 import { DiagnosticErrorNotice, logCaughtDiagnostic } from "../diagnostics";
 import { announceSettingsSaved } from "./SettingsSaveFeedback";
@@ -88,6 +89,8 @@ export function EngagementPolicySettings() {
   const [maxConcurrency, setMaxConcurrency] = useState(1);
   const [approvalPolicy, setApprovalPolicy] = useState<AutomationProjectPolicy["approvalPolicy"]>("on_boundary");
   const [networkEnabled, setNetworkEnabled] = useState(false);
+  const [vpnProfileId, setVpnProfileId] = useState("");
+  const [vpnProfiles, setVpnProfiles] = useState<VpnProfile[]>([]);
   const [maxTimeoutMs, setMaxTimeoutMs] = useState(300_000);
   const [saving, setSaving] = useState<"scope" | "runtime">();
   const [error, setError] = useState<unknown>();
@@ -111,6 +114,7 @@ export function EngagementPolicySettings() {
     setPolicy(next);
     setApprovalPolicy(next.approvalPolicy);
     setNetworkEnabled(next.networkEnabled);
+    setVpnProfileId(next.vpnProfileId ?? "");
     setMaxTimeoutMs(next.maxTimeoutMs);
   };
 
@@ -118,12 +122,18 @@ export function EngagementPolicySettings() {
     if (!api || coreState !== "online" || !engagement) return;
     setError(undefined);
     try {
-      const [nextScope, nextPolicy] = await Promise.all([
+      const [nextScope, nextPolicy, nextVpnProfiles] = await Promise.all([
         api.getEngagementScope(engagement.id),
         api.getAutomationPolicy(engagement.id),
+        api.listVpnProfiles().catch((vpnError) => {
+          if (vpnError instanceof ApiError && (vpnError.status === 404 || vpnError.status === 501)) return [];
+          void logCaughtDiagnostic("interface.engagement_policy.vpn_profiles_unavailable", "VPN profiles are unavailable in this Core build.", vpnError, "engagement_policy");
+          return Promise.reject(vpnError);
+        }),
       ]);
       applyScope(nextScope);
       applyPolicy(nextPolicy);
+      setVpnProfiles(nextVpnProfiles);
     } catch (loadError) {
       void logCaughtDiagnostic("interface.execution_policy.caught_failure_01", "A handled interface operation failed.", loadError, "execution_policy");
       setError(loadError instanceof Error ? loadError.message : "Could not load project execution policy.");
@@ -200,6 +210,7 @@ export function EngagementPolicySettings() {
         approvalPolicy,
         networkEnabled,
         runnerProfileId: policy.runnerProfileId,
+        vpnProfileId: vpnProfileId || undefined,
         maxTimeoutMs,
         expectedRevision: policy.revision,
       }));
@@ -221,6 +232,7 @@ export function EngagementPolicySettings() {
           <label>Approval policy<select value={approvalPolicy} onChange={(event) => setApprovalPolicy(event.target.value as AutomationProjectPolicy["approvalPolicy"])}><option value="on_boundary">On boundary · prompt once for project networking</option><option value="always">Always · prompt before every command</option><option value="never">Never · run without prompts</option></select></label>
           <label>Maximum command timeout (milliseconds)<input type="number" min={1000} max={86400000} value={maxTimeoutMs} onChange={(event) => setMaxTimeoutMs(Number(event.target.value))} /></label>
           <label className="provider-consent"><input type="checkbox" checked={networkEnabled} onChange={(event) => setNetworkEnabled(event.target.checked)} /><span><strong>Make project-scoped networking available</strong><small>The session receives the complete validated CIDR/domain/port policy. An approval never expands that scope.</small></span></label>
+          <label>VPN route<select value={vpnProfileId} disabled={!networkEnabled} onChange={(event) => setVpnProfileId(event.target.value)}><option value="">Direct, scope-filtered egress</option>{vpnProfiles.map((profile) => <option key={profile.id} value={profile.id} disabled={!profile.available}>{profile.name} · {profile.protocol.toUpperCase()} {profile.remoteHost}</option>)}</select><small>{vpnProfileId ? "New command sessions must establish this tunnel before network access is released." : "Select a saved profile to route authorized container traffic through OpenVPN."}</small></label>
           <footer><span>Existing sessions keep their frozen policy revision.</span><button className="button primary" type="submit" disabled={previewMode || !policy || saving === "runtime"}><Save size={14} /> {saving === "runtime" ? "Saving…" : "Save runtime policy"}</button></footer>
         </div>
       </form>

--- a/ui/src/components/ToolingSettings.tsx
+++ b/ui/src/components/ToolingSettings.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { AlertTriangle, CheckCircle2, ChevronDown, RefreshCw, Server, ShieldCheck, TerminalSquare, Trash2, UploadCloud } from "lucide-react";
 import { ApiError } from "../api/client";
-import type { AutomationRuntimeInfo, RunnerProfile, RunnerIsolation, RunnerRuntime, VpnProfile } from "../api/types";
+import type { AutomationProjectPolicy, AutomationRuntimeInfo, RunnerProfile, RunnerIsolation, RunnerRuntime, VpnProfile } from "../api/types";
 import { useWorkspace } from "../state/WorkspaceContext";
 import { DiagnosticErrorNotice, logCaughtDiagnostic } from "../diagnostics";
 import { announceSettingsSaved } from "./SettingsSaveFeedback";
@@ -26,7 +26,7 @@ function profileSetup(profile: RunnerProfile): RunnerSetupKind {
 }
 
 export function AutomationRuntimeSettings() {
-  const { api, coreState, previewMode } = useWorkspace();
+  const { api, coreState, engagement, previewMode } = useWorkspace();
   const [runtime, setRuntime] = useState<AutomationRuntimeInfo>();
   const [loading, setLoading] = useState(true);
   const [preparing, setPreparing] = useState(false);
@@ -38,6 +38,8 @@ export function AutomationRuntimeSettings() {
   const [vpnPassword, setVpnPassword] = useState("");
   const [vpnPersistence, setVpnPersistence] = useState<"vault" | "session">("vault");
   const [savingVpn, setSavingVpn] = useState(false);
+  const [projectPolicy, setProjectPolicy] = useState<AutomationProjectPolicy>();
+  const [selectingVpn, setSelectingVpn] = useState<string>();
 
   const load = useCallback(async () => {
     if (!api || coreState !== "online") {
@@ -47,23 +49,25 @@ export function AutomationRuntimeSettings() {
     setLoading(true);
     setError(undefined);
     try {
-      const [nextRuntime, nextVpnProfiles] = await Promise.all([
+      const [nextRuntime, nextVpnProfiles, nextProjectPolicy] = await Promise.all([
         api.getAutomationRuntime(),
         api.listVpnProfiles().catch((vpnError) => {
           if (unavailable(vpnError)) return [];
           void logCaughtDiagnostic("interface.automation_runtime.vpn_profiles_unavailable", "VPN profiles are unavailable in this Core build.", vpnError, "automation_runtime");
           return Promise.reject(vpnError);
         }),
+        engagement ? api.getAutomationPolicy(engagement.id) : Promise.resolve(undefined),
       ]);
       setRuntime(nextRuntime);
       setVpnProfiles(nextVpnProfiles);
+      setProjectPolicy(nextProjectPolicy);
     } catch (loadError) {
       void logCaughtDiagnostic("interface.automation_runtime.caught_failure_01", "A handled interface operation failed.", loadError, "automation_runtime");
       setError(loadError instanceof Error ? loadError.message : "Could not load the automation runtime.");
     } finally {
       setLoading(false);
     }
-  }, [api, coreState]);
+  }, [api, coreState, engagement?.id]);
 
   useEffect(() => { void load(); }, [load]);
 
@@ -109,6 +113,26 @@ export function AutomationRuntimeSettings() {
     }
   };
 
+  const useVpnForProject = async (profile: VpnProfile) => {
+    if (!api || !engagement || !projectPolicy) return;
+    setSelectingVpn(profile.id); setError(undefined);
+    try {
+      const updated = await api.updateAutomationPolicy(engagement.id, {
+        approvalPolicy: projectPolicy.approvalPolicy,
+        networkEnabled: true,
+        runnerProfileId: projectPolicy.runnerProfileId,
+        vpnProfileId: profile.id,
+        maxTimeoutMs: projectPolicy.maxTimeoutMs,
+        expectedRevision: projectPolicy.revision,
+      });
+      setProjectPolicy(updated);
+      announceSettingsSaved(`${profile.name} will protect new terminals in ${engagement.name}.`);
+    } catch (selectError) {
+      void logCaughtDiagnostic("interface.automation_runtime.vpn_select_failed", "VPN profile could not be selected for this project.", selectError, "automation_runtime");
+      setError(selectError instanceof Error ? selectError.message : "Could not select the VPN profile for this project.");
+    } finally { setSelectingVpn(undefined); }
+  };
+
   return <section className="settings-section" id="automation-runtime-settings">
     <div className="section-heading"><div><h2>Automation runtime</h2><p>One digest-pinned Bash container per agent session. Commands use ordinary binaries on PATH.</p></div><button className="button secondary" type="button" disabled={loading || preparing} onClick={() => void load()}><RefreshCw size={14} /> Refresh</button></div>
     {error && <DiagnosticErrorNotice error={error} fallback="The automation runtime could not be inspected." compact />}
@@ -122,7 +146,10 @@ export function AutomationRuntimeSettings() {
         <details className="inventory-disclosure vpn-options"><summary><span><strong>Credentials and storage</strong><small>Only needed when the profile requests username/password authentication.</small></span><ChevronDown size={17} /></summary><div className="policy-form-body"><label>Username<input autoComplete="username" value={vpnUsername} onChange={(event) => setVpnUsername(event.target.value)} /></label><label>Password<input type="password" autoComplete="new-password" value={vpnPassword} onChange={(event) => setVpnPassword(event.target.value)} /></label><label>Storage<select value={vpnPersistence} onChange={(event) => setVpnPersistence(event.target.value as "vault" | "session")}><option value="vault">Operating-system vault</option><option value="session">This Core session only</option></select></label></div></details>
         <footer><span>Scripts, plugins, TAP, split routes, and external file paths are rejected.</span><button className="button primary" type="submit" disabled={!vpnFile || savingVpn || previewMode}>{savingVpn ? "Checking…" : "Save profile"}</button></footer>
       </form>
-      <section className="panel runner-status"><header className="panel-header compact"><div><h3>Saved profiles</h3><p>Raw configuration and credentials are never displayed again.</p></div><span className="inventory-count">{vpnProfiles.length}</span></header>{vpnProfiles.length ? vpnProfiles.map((profile) => <article key={profile.id}><span className={`status-dot ${profile.available ? "healthy" : "unavailable"}`} /><div><strong>{profile.name}</strong><small>{profile.protocol.toUpperCase()} · {profile.remoteHost}:{profile.remotePort}</small><p>{profile.available ? "Stored securely; the tunnel is verified when a new session starts." : "Secret is unavailable; upload the profile again."}</p></div><button className="icon-button" type="button" aria-label={`Remove ${profile.name}`} onClick={() => void removeVpn(profile)}><Trash2 size={15} /></button></article>) : <div className="empty-state compact"><ShieldCheck size={21} /><strong>No VPN profiles</strong><p>Upload one here, then select it in a project’s command runtime policy.</p></div>}</section>
+      <section className="panel runner-status"><header className="panel-header compact"><div><h3>Saved profiles</h3><p>{engagement ? `Choose the route for new terminals in ${engagement.name}.` : "Open a project to choose where a profile is used."}</p></div><span className="inventory-count">{vpnProfiles.length}</span></header>{vpnProfiles.length ? vpnProfiles.map((profile) => {
+        const selected = projectPolicy?.vpnProfileId === profile.id;
+        return <article key={profile.id}><span className={`status-dot ${profile.available ? "healthy" : "unavailable"}`} /><div><strong>{profile.name}</strong><small>{profile.protocol.toUpperCase()} · {profile.remoteHost}:{profile.remotePort}</small><p>{!profile.available ? "Secret is unavailable; upload the profile again." : selected ? `Selected for ${engagement?.name ?? "this project"}. New terminals wait for the tunnel before opening.` : "Saved only — not connected to this project."}</p></div><div className="vpn-profile-actions">{profile.available && engagement && !selected && <button className="button quiet" type="button" disabled={!projectPolicy || selectingVpn === profile.id || previewMode} onClick={() => void useVpnForProject(profile)}>{selectingVpn === profile.id ? "Selecting…" : "Use for this project"}</button>}{selected && <span className="vpn-selected-label"><CheckCircle2 size={14} /> In use</span>}<button className="icon-button" type="button" aria-label={`Remove ${profile.name}`} disabled={selected} title={selected ? "Choose a different route before removing this profile." : undefined} onClick={() => void removeVpn(profile)}><Trash2 size={15} /></button></div></article>;
+      }) : <div className="empty-state compact"><ShieldCheck size={21} /><strong>No VPN profiles</strong><p>Upload one here, then select it for the open project.</p></div>}</section>
     </div>
   </section>;
 }

--- a/ui/src/components/ToolingSettings.tsx
+++ b/ui/src/components/ToolingSettings.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState, type FormEvent } from "react";
-import { AlertTriangle, CheckCircle2, ChevronDown, RefreshCw, Server, TerminalSquare } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ChevronDown, RefreshCw, Server, ShieldCheck, TerminalSquare, Trash2, UploadCloud } from "lucide-react";
 import { ApiError } from "../api/client";
-import type { AutomationRuntimeInfo, RunnerProfile, RunnerIsolation, RunnerRuntime } from "../api/types";
+import type { AutomationRuntimeInfo, RunnerProfile, RunnerIsolation, RunnerRuntime, VpnProfile } from "../api/types";
 import { useWorkspace } from "../state/WorkspaceContext";
 import { DiagnosticErrorNotice, logCaughtDiagnostic } from "../diagnostics";
 import { announceSettingsSaved } from "./SettingsSaveFeedback";
@@ -31,6 +31,13 @@ export function AutomationRuntimeSettings() {
   const [loading, setLoading] = useState(true);
   const [preparing, setPreparing] = useState(false);
   const [error, setError] = useState<string>();
+  const [vpnProfiles, setVpnProfiles] = useState<VpnProfile[]>([]);
+  const [vpnFile, setVpnFile] = useState<File>();
+  const [vpnName, setVpnName] = useState("");
+  const [vpnUsername, setVpnUsername] = useState("");
+  const [vpnPassword, setVpnPassword] = useState("");
+  const [vpnPersistence, setVpnPersistence] = useState<"vault" | "session">("vault");
+  const [savingVpn, setSavingVpn] = useState(false);
 
   const load = useCallback(async () => {
     if (!api || coreState !== "online") {
@@ -40,7 +47,16 @@ export function AutomationRuntimeSettings() {
     setLoading(true);
     setError(undefined);
     try {
-      setRuntime(await api.getAutomationRuntime());
+      const [nextRuntime, nextVpnProfiles] = await Promise.all([
+        api.getAutomationRuntime(),
+        api.listVpnProfiles().catch((vpnError) => {
+          if (unavailable(vpnError)) return [];
+          void logCaughtDiagnostic("interface.automation_runtime.vpn_profiles_unavailable", "VPN profiles are unavailable in this Core build.", vpnError, "automation_runtime");
+          return Promise.reject(vpnError);
+        }),
+      ]);
+      setRuntime(nextRuntime);
+      setVpnProfiles(nextVpnProfiles);
     } catch (loadError) {
       void logCaughtDiagnostic("interface.automation_runtime.caught_failure_01", "A handled interface operation failed.", loadError, "automation_runtime");
       setError(loadError instanceof Error ? loadError.message : "Could not load the automation runtime.");
@@ -65,11 +81,49 @@ export function AutomationRuntimeSettings() {
     }
   };
 
+  const uploadVpn = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!api || !vpnFile) return;
+    setSavingVpn(true); setError(undefined);
+    try {
+      const saved = await api.createVpnProfile({
+        name: vpnName.trim() || vpnFile.name.replace(/\.ovpn$/i, ""), filename: vpnFile.name,
+        config: await vpnFile.text(), username: vpnUsername || undefined, password: vpnPassword || undefined,
+        persistence: vpnPersistence,
+      });
+      setVpnProfiles((items) => [saved, ...items]); setVpnFile(undefined); setVpnName(""); setVpnUsername(""); setVpnPassword("");
+      announceSettingsSaved("VPN profile saved. Select it from a project's command runtime policy.");
+    } catch (uploadError) {
+      void logCaughtDiagnostic("interface.automation_runtime.vpn_upload_failed", "VPN profile could not be saved.", uploadError, "automation_runtime");
+      setError(uploadError instanceof Error ? uploadError.message : "Could not save the VPN profile.");
+    } finally { setSavingVpn(false); }
+  };
+
+  const removeVpn = async (profile: VpnProfile) => {
+    if (!api) return;
+    setError(undefined);
+    try { await api.deleteVpnProfile(profile.id, profile.revision); setVpnProfiles((items) => items.filter((item) => item.id !== profile.id)); }
+    catch (deleteError) {
+      void logCaughtDiagnostic("interface.automation_runtime.vpn_delete_failed", "VPN profile could not be removed.", deleteError, "automation_runtime");
+      setError(deleteError instanceof Error ? deleteError.message : "Could not remove the VPN profile.");
+    }
+  };
+
   return <section className="settings-section" id="automation-runtime-settings">
     <div className="section-heading"><div><h2>Automation runtime</h2><p>One digest-pinned Bash container per agent session. Commands use ordinary binaries on PATH.</p></div><button className="button secondary" type="button" disabled={loading || preparing} onClick={() => void load()}><RefreshCw size={14} /> Refresh</button></div>
     {error && <DiagnosticErrorNotice error={error} fallback="The automation runtime could not be inspected." compact />}
     {!runtime ? <div className="feature-unavailable" role="status"><AlertTriangle size={22} /><div><strong>{loading ? "Checking runtime…" : "Runtime unavailable"}</strong><p>Configure a pinned automation image and a verified local runner.</p></div></div> :
       <div className="runner-layout"><section className="panel runner-status"><header className="panel-header compact"><div><h3>{runtime.ready ? "Ready" : "Preparation required"}</h3><p>{runtime.detail}</p></div>{runtime.ready ? <CheckCircle2 size={18} /> : <AlertTriangle size={18} />}</header><article><TerminalSquare size={17} /><div><strong>{runtime.digest ?? "No prepared digest"}</strong><small>{runtime.runnerProfileId ? `Runner ${runtime.runnerProfileId}` : "No healthy runner selected"}</small><p>{runtime.image ?? "Prepare Nebula's existing Kali headless image."}</p></div></article><footer><button className="button primary" type="button" disabled={previewMode || preparing || !runtime.configured} onClick={() => void prepare()}>{preparing ? "Preparing Kali…" : runtime.ready ? "Verify Kali runtime" : "Prepare Kali runtime"}</button></footer></section><section className="panel inventory-panel"><details className="inventory-disclosure"><summary><div><h3>Binary inventory</h3><p>Generated from the exact prepared Kali image.</p></div><span className="inventory-count">{runtime.inventory.length.toLocaleString()}</span><ChevronDown className="inventory-chevron" size={18} aria-hidden="true" /></summary><div className="runtime-resource-list">{runtime.inventory.length ? runtime.inventory.map((binary) => <article className="runtime-resource-card" key={`${binary.path}-${binary.name}`}><header><div><strong>{binary.name}</strong><code>{binary.path}</code></div><small>{binary.version}</small></header></article>) : <div className="empty-state compact"><TerminalSquare size={21} /><strong>No verified inventory</strong><p>Prepare the Kali runtime to validate its installed binaries.</p></div>}</div></details></section></div>}
+    <div className="section-heading vpn-heading"><div><h2>VPN egress</h2><p>Reusable OpenVPN profiles for project command containers. Traffic remains scope-limited inside the tunnel.</p></div><ShieldCheck size={20} /></div>
+    <div className="runner-layout">
+      <form className="panel runner-form vpn-profile-form" onSubmit={(event) => void uploadVpn(event)}>
+        <label className="vpn-file-drop"><UploadCloud size={22} /><span><strong>{vpnFile?.name ?? "Choose an OpenVPN profile"}</strong><small>.ovpn · TUN client · inline certificates · up to 15 KB</small></span><input type="file" accept=".ovpn,application/x-openvpn-profile" required onChange={(event) => { const file = event.target.files?.[0]; setVpnFile(file); if (file && !vpnName) setVpnName(file.name.replace(/\.ovpn$/i, "")); }} /></label>
+        <label>Profile name<input value={vpnName} placeholder="Company VPN" onChange={(event) => setVpnName(event.target.value)} /></label>
+        <details className="inventory-disclosure vpn-options"><summary><span><strong>Credentials and storage</strong><small>Only needed when the profile requests username/password authentication.</small></span><ChevronDown size={17} /></summary><div className="policy-form-body"><label>Username<input autoComplete="username" value={vpnUsername} onChange={(event) => setVpnUsername(event.target.value)} /></label><label>Password<input type="password" autoComplete="new-password" value={vpnPassword} onChange={(event) => setVpnPassword(event.target.value)} /></label><label>Storage<select value={vpnPersistence} onChange={(event) => setVpnPersistence(event.target.value as "vault" | "session")}><option value="vault">Operating-system vault</option><option value="session">This Core session only</option></select></label></div></details>
+        <footer><span>Scripts, plugins, TAP, split routes, and external file paths are rejected.</span><button className="button primary" type="submit" disabled={!vpnFile || savingVpn || previewMode}>{savingVpn ? "Checking…" : "Save profile"}</button></footer>
+      </form>
+      <section className="panel runner-status"><header className="panel-header compact"><div><h3>Saved profiles</h3><p>Raw configuration and credentials are never displayed again.</p></div><span className="inventory-count">{vpnProfiles.length}</span></header>{vpnProfiles.length ? vpnProfiles.map((profile) => <article key={profile.id}><span className={`status-dot ${profile.available ? "healthy" : "unavailable"}`} /><div><strong>{profile.name}</strong><small>{profile.protocol.toUpperCase()} · {profile.remoteHost}:{profile.remotePort}</small><p>{profile.available ? "Stored securely; the tunnel is verified when a new session starts." : "Secret is unavailable; upload the profile again."}</p></div><button className="icon-button" type="button" aria-label={`Remove ${profile.name}`} onClick={() => void removeVpn(profile)}><Trash2 size={15} /></button></article>) : <div className="empty-state compact"><ShieldCheck size={21} /><strong>No VPN profiles</strong><p>Upload one here, then select it in a project’s command runtime policy.</p></div>}</section>
+    </div>
   </section>;
 }
 

--- a/ui/src/settingsCatalog.ts
+++ b/ui/src/settingsCatalog.ts
@@ -66,6 +66,15 @@ export const settingCatalog: SettingCatalogEntry[] = [
     keywords: ["automation", "runtime", "command", "container", "execution"],
   },
   {
+    id: "settings.vpn-egress",
+    label: "VPN egress profiles",
+    description: "Upload OpenVPN profiles and route project command containers through a tunnel",
+    category: "Automation",
+    scope: "Security",
+    target: "automation-runtime-settings",
+    keywords: ["vpn", "openvpn", "ovpn", "tunnel", "egress", "profile", "kill switch"],
+  },
+  {
     id: "settings.runners",
     label: "Sandbox runners",
     description: "Configure trusted Docker or Podman execution profiles",

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -1916,6 +1916,26 @@ test("project scope normalizes root URLs and confirms all-target mode", async ({
   await expect(page.getByLabel("Allowed domains")).toBeDisabled();
 });
 
+test("VPN settings keep upload and project routing calm at every width", async ({ page }) => {
+  await openWorkspace(page, "/settings", "Settings");
+  await page.getByRole("link", { name: "Advanced settings", exact: true }).click();
+  await page.locator("details.settings-group > summary", { hasText: "Automation" }).click();
+  const section = page.locator("#automation-runtime-settings");
+  await expect(section.getByRole("heading", { name: "VPN egress" })).toBeVisible();
+  await expect(section.getByText("Choose an OpenVPN profile")).toBeVisible();
+  await expect(section.getByText("Credentials and storage")).toBeVisible();
+  await expect(section.getByLabel("Username")).not.toBeVisible();
+  const geometry = await section.evaluate((element) => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+    buttonHeights: [...element.querySelectorAll<HTMLElement>("button")].map((button) => button.getBoundingClientRect().height),
+  }));
+  expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth + 1);
+  expect(geometry.buttonHeights.every((height) => height >= 30)).toBe(true);
+  const accessibility = await new AxeBuilder({ page }).include("#automation-runtime-settings").analyze();
+  expect(accessibility.violations).toEqual([]);
+});
+
 test("streaming chat follows the bottom without overriding reader scroll intent", async ({ page }, testInfo) => {
   test.skip(!["desktop", "webkit"].includes(testInfo.project.name), "Scroll intent needs one desktop interaction run.");
   const provider = {

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -1956,6 +1956,42 @@ test("project scope normalizes root URLs and confirms all-target mode", async ({
 });
 
 test("VPN settings keep upload and project routing calm at every width", async ({ page }) => {
+  let selectedVpnProfile: string | null = null;
+  await page.route("**/api/v1/vpn-profiles", async (route) => route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify([{
+      ...entity,
+      id: "vpn-preview",
+      name: "Company VPN",
+      filename: "company.ovpn",
+      remote_host: "vpn.example.test",
+      remote_port: 1194,
+      protocol: "udp",
+      fingerprint: "a".repeat(64),
+      requires_credentials: true,
+      available: true,
+    }]),
+  }));
+  await page.route("**/api/v1/engagements/*/automation-policy", async (route) => {
+    if (route.request().method() === "PUT") {
+      selectedVpnProfile = String(route.request().postDataJSON().vpn_profile_id);
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ...entity,
+        id: "runtime-policy-preview",
+        engagement_id: "engagement-1",
+        approval_policy: "on_boundary",
+        network_enabled: selectedVpnProfile !== null,
+        runner_profile_id: "local",
+        vpn_profile_id: selectedVpnProfile,
+        max_timeout_ms: 300000,
+      }),
+    });
+  });
   await openWorkspace(page, "/settings", "Settings");
   await page.getByRole("link", { name: "Advanced settings", exact: true }).click();
   await page.locator("details.settings-group > summary", { hasText: "Automation" }).click();
@@ -1964,6 +2000,11 @@ test("VPN settings keep upload and project routing calm at every width", async (
   await expect(section.getByText("Choose an OpenVPN profile")).toBeVisible();
   await expect(section.getByText("Credentials and storage")).toBeVisible();
   await expect(section.getByLabel("Username")).not.toBeVisible();
+  await expect(section.getByText("Saved only — not connected to this project.")).toBeVisible();
+  await section.getByRole("button", { name: "Use for this project" }).click();
+  await expect(section.getByText("In use", { exact: true })).toBeVisible();
+  await expect(section.getByText(/Selected for .* New terminals wait for the tunnel/)).toBeVisible();
+  expect(selectedVpnProfile).toBe("vpn-preview");
   const geometry = await section.evaluate((element) => ({
     clientWidth: element.clientWidth,
     scrollWidth: element.scrollWidth,

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -844,6 +844,45 @@ test("terminal screenshot capture opens a full-height integrated editor", async 
   expect(dimensions.canvasHeight).toBeLessThanOrEqual(dimensions.viewportContentHeight + 1);
 });
 
+test("terminal VPN boundary stays visible in the live shell", async ({ page }) => {
+  const vpnNetwork = {
+    mode: "vpn",
+    runtime_network: "private_namespace",
+    vpn_profile_id: "vpn-preview",
+    vpn_profile_revision: 3,
+    vpn_profile_name: "Company VPN",
+    published_ports: [],
+  };
+  await page.route("**/api/v1/container-terminal/preflight", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        allowed: true,
+        detail: "All terminal egress is fail-closed through Company VPN.",
+        runtime,
+        network: vpnNetwork,
+        security,
+        limits,
+        workspace: "/workspace",
+        policy_rule: "human_terminal_vpn",
+        preview_fingerprint: "d".repeat(64),
+        preview_token: "preview.signed",
+        expires_at: "2026-07-13T21:00:00Z",
+        idle_timeout_seconds: 1800,
+        fresh_container: true,
+      }),
+    });
+  });
+
+  await openWorkspace(page, "/", "Workbench");
+
+  const liveTerminal = page.locator(".container-terminal-live");
+  await expect(liveTerminal.getByText(/VPN enforced · Company VPN/)).toBeVisible();
+  await expect(liveTerminal.getByText(/blocked until OpenVPN is ready/)).toBeVisible();
+  await expect(liveTerminal.getByText(/Bridge networking is permitted/)).toHaveCount(0);
+});
+
 test("terminal pointer selection has a visible high-contrast highlight", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "desktop", "Canvas selection rendering needs one desktop visual run.");
   await openWorkspace(page, "/", "Workbench");


### PR DESCRIPTION
## Summary
- add reusable OpenVPN profiles with credential-vault storage and project selection
- route automation and interactive container traffic through a privileged fail-closed helper
- expose calm saved/selected/in-use VPN states in Settings and terminal boundaries
- admit common NordVPN options and retain bounded credential-redacted startup diagnostics

## Verification
- 723 backend tests passed, 5 skipped
- 365 UI tests passed
- production UI build passed
- VPN Settings Playwright workflow passed desktop 1440/1024 and Chromium/WebKit mobile 320/390/430
- live NordVPN terminal exited through 194.88.100.10 while the host remained 96.241.235.86
- localhost and LAN Core health reported available/configured