### PR TITLE
Fix release rootless runtime E2E

### DIFF
--- a/.github/workflows/nebula3-release.yml
+++ b/.github/workflows/nebula3-release.yml
@@ -93,9 +93,6 @@ jobs:
       - name: Prepare real-Core and disposable-runtime fixtures
         run: |
           podman pull docker.io/kalilinux/kali-rolling:latest
-          systemctl --user start podman.socket
-          socket_path="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
-          test -S "$socket_path"
           runner_uid="$(id -u)"
           user_service="/sys/fs/cgroup/user.slice/user-${runner_uid}.slice/user@${runner_uid}.service"
           for control_group in \
@@ -114,8 +111,10 @@ jobs:
           source_reference="docker.io/kalilinux/kali-rolling@${image_digest}"
           derived_tag="localhost/nebula-kali-headless:v5-${image_digest#sha256:}"
           printf 'NEBULA_KALI_SOURCE_IMAGE=%s\n' "$source_reference" >> "$GITHUB_ENV"
+          # Exercise the admitted local rootless CLI path. Podman's v3 remote
+          # socket transport can leave attached run/TTY clients open after the
+          # worker exits, which turns successful workloads into false timeouts.
           printf 'NEBULA_TEST_CONTAINER_RUNTIME=/usr/bin/podman\n' >> "$GITHUB_ENV"
-          printf 'NEBULA_TEST_CONTAINER_SOCKET=unix://%s\n' "$socket_path" >> "$GITHUB_ENV"
           podman build \
             --build-arg "KALI_SOURCE=${source_reference}" \
             --file tests/v3/integration/Containerfile.real-core-runtime \

--- a/tests/v3/test_sandbox_integration.py
+++ b/tests/v3/test_sandbox_integration.py
@@ -90,7 +90,7 @@ print('x' * 70000)
             on_chunk=capture,
             container_name="nebula-integration-python",
         )
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.stderr
         assert result.stdout.startswith("stdin=''\n")
         assert result.stdout.count("x") == 70_000
         assert result.stderr == ""


### PR DESCRIPTION
## Summary
- exercise the admitted local rootless Podman CLI in release E2E instead of Podman v3 remote socket transport
- preserve cgroup and real-container isolation gates
- include captured stderr when the batch integration assertion fails

## Evidence
- alpha.11 preparation run 33816945884 failed twice with both attached Podman workloads timing out through the v3 remote socket
- `poetry run pytest -q tests/v3/test_sandbox.py tests/v3/test_sandbox_integration.py` (50 passed, 2 environment-gated skips)
- `git diff --check`