### PR TITLE
Force Grok agent commands through Docker runtime

### DIFF
--- a/src/nebula/v3/harnesses.py
+++ b/src/nebula/v3/harnesses.py
@@ -4213,6 +4213,21 @@ async def _grok_model_catalog(
 class GrokAcpAdapter(HarnessAdapter):
     kind = HarnessKind.GROK_ACP
 
+    # ACP's terminal capability flag describes client-provided terminals. Grok also
+    # ships its own host-backed workspace tools, so remove those at process launch;
+    # project I/O and commands must cross the audited Nebula MCP gateway instead.
+    _DISALLOWED_HOST_TOOLS = (
+        "get_command_or_subagent_output",
+        "grep",
+        "kill_command_or_subagent",
+        "list_dir",
+        "monitor",
+        "read_file",
+        "run_terminal_command",
+        "search_replace",
+        "write",
+    )
+
     async def _connect(
         self,
         profile: HarnessProfile,
@@ -4226,7 +4241,12 @@ class GrokAcpAdapter(HarnessAdapter):
             raise HarnessConfigurationError(
                 "Grok executable must be an existing absolute file"
             )
-        command = [str(executable), "agent"]
+        command = [
+            str(executable),
+            "--disallowed-tools",
+            ",".join(self._DISALLOWED_HOST_TOOLS),
+            "agent",
+        ]
         if session is not None:
             command.extend(["--model", session.model])
             raw_options = session.metadata.get("runtime_options")

--- a/tests/v3/test_harness_adapters.py
+++ b/tests/v3/test_harness_adapters.py
@@ -342,6 +342,48 @@ def test_grok_probe_negotiates_cached_token_without_credentials():
     asyncio.run(scenario())
 
 
+def test_grok_process_removes_host_command_and_workspace_tools(monkeypatch, tmp_path):
+    observed: dict[str, Any] = {}
+
+    class Process:
+        stdin = SimpleNamespace()
+        stdout = SimpleNamespace()
+        stderr = SimpleNamespace()
+
+    async def create_process(*argv: str, **kwargs: Any) -> Process:
+        observed["argv"] = argv
+        observed["kwargs"] = kwargs
+        return Process()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_process)
+    monkeypatch.setattr(_AcpRpc, "start", lambda self: asyncio.sleep(0))
+    executable = tmp_path / "grok"
+    executable.write_text("", encoding="utf-8")
+    profile = HarnessProfile(
+        id="grok-a",
+        name="Grok",
+        kind=HarnessKind.GROK_ACP,
+        executable=str(executable),
+    )
+    session = HarnessSession(
+        id="session-a",
+        engagement_id="eng-a",
+        harness_profile_id=profile.id,
+        model="grok-test",
+    )
+
+    rpc = asyncio.run(GrokAcpAdapter()._connect(profile, tmp_path, session))
+
+    argv = observed["argv"]
+    disallowed = argv[argv.index("--disallowed-tools") + 1].split(",")
+    assert "run_terminal_command" in disallowed
+    assert "read_file" in disallowed
+    assert "write" in disallowed
+    assert argv[argv.index("--disallowed-tools") + 2] == "agent"
+    assert observed["kwargs"]["cwd"] == str(tmp_path)
+    assert isinstance(rpc, _AcpRpc)
+
+
 def test_grok_connection_normalizes_mode_plan_and_streamed_message():
     async def scenario() -> None:
         rpc = FixtureGrokRpc()


### PR DESCRIPTION
## Summary
- remove Grok host-backed terminal and workspace tools at ACP process launch
- force command and project I/O through Nebula MCP and the pinned Docker automation runtime
- add regression coverage for the hardened launch arguments

## Verification
- `.venv/bin/pytest -q tests/v3/test_harness_adapters.py` (31 passed)
- installed Grok binary accepted the hardened ACP stdio launch arguments
- live Core restarted and authenticated health returned `status: ok`