### PR TITLE
Show terminal container public IP in the top bar

### DIFF
--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -152,6 +152,7 @@ from .container_terminal import (
     ContainerTerminalOutput,
     ContainerTerminalPreflightRequest,
     ContainerTerminalPreflightResponse,
+    ContainerTerminalPublicIpStatus,
     ContainerTerminalRecoveryListResponse,
     ContainerTerminalRecoveryResponse,
     ContainerTerminalService,
@@ -4007,6 +4008,32 @@ def create_app(
     ) -> ContainerTerminalCapacity:
         response.headers["Cache-Control"] = "private, no-store"
         return await require_container_terminal_service().capacity()
+
+    @app.get(
+        f"{API_PREFIX}/container-terminals/{{session_id}}/public-ip",
+        response_model=ContainerTerminalPublicIpStatus,
+        tags=["container-terminal"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def container_terminal_public_ip(
+        session_id: str, response: Response
+    ) -> ContainerTerminalPublicIpStatus:
+        response.headers["Cache-Control"] = "private, no-store"
+        return await require_container_terminal_service().public_ip(session_id)
+
+    @app.get(
+        f"{API_PREFIX}/engagements/{{engagement_id}}/container-terminal/public-ip",
+        response_model=ContainerTerminalPublicIpStatus,
+        tags=["container-terminal"],
+        dependencies=[Depends(require_auth)],
+    )
+    async def engagement_container_terminal_public_ip(
+        engagement_id: str, response: Response
+    ) -> ContainerTerminalPublicIpStatus:
+        response.headers["Cache-Control"] = "private, no-store"
+        return await require_container_terminal_service().engagement_public_ip(
+            engagement_id
+        )
 
     @app.post(
         f"{API_PREFIX}/engagements/{{engagement_id}}/container-terminal/recover",

--- a/src/nebula/v3/container_terminal.py
+++ b/src/nebula/v3/container_terminal.py
@@ -12,6 +12,7 @@ import asyncio
 import base64
 import hashlib
 import hmac
+import ipaddress
 import json
 import logging
 import os
@@ -19,7 +20,7 @@ import secrets
 from collections import deque
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from time import monotonic
 from typing import AsyncIterator, Callable, Literal
 from uuid import NAMESPACE_URL, uuid4, uuid5
@@ -315,6 +316,12 @@ class ContainerTerminalCapacity(NebulaModel):
     max_active_sessions: int = Field(ge=1, le=32)
 
 
+class ContainerTerminalPublicIpStatus(NebulaModel):
+    address: str
+    observed_at: datetime
+    stale: bool = False
+
+
 @dataclass(frozen=True)
 class _PreparedTerminal:
     resolution: HumanTerminalRuntimeResolution
@@ -553,6 +560,55 @@ class ContainerTerminalService:
                 available_sessions=max(0, self.max_active - active),
                 max_active_sessions=self.max_active,
             )
+
+    async def public_ip(self, session_id: str) -> ContainerTerminalPublicIpStatus:
+        async with self._lock:
+            session = self._require_session_locked(session_id)
+            process = session.process
+            if process is None or session.state != "running":
+                raise ContainerTerminalError(
+                    "public_ip_pending",
+                    "public IP is still being checked inside the container",
+                    status_code=503,
+                )
+        try:
+            raw = await process.read_public_ip_status()
+            lines = raw.splitlines()
+            if len(lines) != 2:
+                raise ValueError("unexpected public IP status shape")
+            address = str(ipaddress.ip_address(lines[0].strip()))
+            observed_at = datetime.fromtimestamp(int(lines[1]), tz=timezone.utc)
+        except (OSError, ValueError, SandboxError) as exc:
+            raise ContainerTerminalError(
+                "public_ip_unavailable",
+                "the container has not reported a valid public IP yet",
+                status_code=503,
+            ) from exc
+        return ContainerTerminalPublicIpStatus(
+            address=address,
+            observed_at=observed_at,
+            stale=(utc_now() - observed_at).total_seconds() > 600,
+        )
+
+    async def engagement_public_ip(
+        self, engagement_id: str
+    ) -> ContainerTerminalPublicIpStatus:
+        async with self._lock:
+            candidates = [
+                session
+                for session in self._sessions.values()
+                if session.request.engagement_id == engagement_id
+                and session.state == "running"
+                and session.process is not None
+            ]
+            if not candidates:
+                raise ContainerTerminalError(
+                    "public_ip_unavailable",
+                    "start a terminal to observe its container public IP",
+                    status_code=404,
+                )
+            session_id = max(candidates, key=lambda item: item.created_at).id
+        return await self.public_ip(session_id)
 
     @asynccontextmanager
     async def guard_workspace_operation(
@@ -2257,6 +2313,7 @@ __all__ = [
     "ContainerTerminalOutput",
     "ContainerTerminalPreflightRequest",
     "ContainerTerminalPreflightResponse",
+    "ContainerTerminalPublicIpStatus",
     "ContainerTerminalRecoveryResponse",
     "ContainerTerminalRuntimeSnapshot",
     "ContainerTerminalSecuritySnapshot",

--- a/src/nebula/v3/public_ip_update.py
+++ b/src/nebula/v3/public_ip_update.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+"""Refresh the terminal container's public egress address atomically."""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import pathlib
+import time
+import urllib.request
+
+
+STATUS_DIR = pathlib.Path("/run/nebula")
+STATUS_PATH = STATUS_DIR / "public-ip"
+TEMP_PATH = STATUS_DIR / "public-ip.next"
+
+
+def main() -> None:
+    request = urllib.request.Request(
+        "https://api.ipify.org",
+        headers={"Accept": "text/plain", "User-Agent": "Nebula-Terminal/1"},
+    )
+    with urllib.request.urlopen(request, timeout=8) as response:
+        address = str(ipaddress.ip_address(response.read(128).decode().strip()))
+    STATUS_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    TEMP_PATH.write_text(f"{address}\n{int(time.time())}\n", encoding="ascii")
+    os.chmod(TEMP_PATH, 0o600)
+    TEMP_PATH.replace(STATUS_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nebula/v3/sandbox.py
+++ b/src/nebula/v3/sandbox.py
@@ -1079,6 +1079,30 @@ class SandboxTerminalProcess:
     async def wait(self) -> int:
         return int(await self.process.wait())
 
+    async def read_public_ip_status(self) -> str:
+        """Read the bounded status produced inside this terminal container."""
+
+        process = await asyncio.create_subprocess_exec(
+            *self.runner._runtime_argv(),
+            "exec",
+            self.container_name,
+            "/bin/cat",
+            "/run/nebula/public-ip",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=_runtime_environment(),
+        )
+        try:
+            stdout, _stderr = await _communicate_limited(
+                process, timeout_seconds=3, output_bytes=512
+            )
+        except asyncio.TimeoutError as exc:
+            raise SandboxUnavailable("public IP status read timed out") from exc
+        if process.returncode != 0:
+            raise SandboxUnavailable("public IP has not been observed yet")
+        return stdout.decode("ascii", errors="strict")
+
     async def close(self) -> None:
         assert self._close_lock is not None
         async with self._close_lock:
@@ -1859,8 +1883,20 @@ class ContainerSandboxRunner(SandboxRunner):
         master_fd: int | None = None
         slave_fd: int | None = None
         try:
+            terminal_request = (
+                request.model_copy(
+                    update={
+                        "command": [
+                            "/usr/local/bin/nebula-terminal-entrypoint",
+                            *request.command,
+                        ]
+                    }
+                )
+                if request.execution_kind == SandboxExecutionKind.HUMAN_TERMINAL
+                else request
+            )
             argv = self._argv(
-                request,
+                terminal_request,
                 workspace,
                 container_name=container_name,
                 network_mode=lease.network_mode if lease else None,
@@ -2212,7 +2248,7 @@ class ContainerImagePreparer:
     """Verify official Kali and prepare a pinned local headless-tool image."""
 
     _derived_repository = "localhost/nebula-kali-headless"
-    _recipe_version = "v9"
+    _recipe_version = "v10"
     _installed_packages = (
         "kali-linux-headless",
         "iputils-ping",
@@ -2221,6 +2257,7 @@ class ContainerImagePreparer:
         "ripgrep",
         "git",
         "curl",
+        "cron",
         "openvpn",
     )
     _security_tool_manifest_path = "/usr/local/share/nebula/security-tools.json"
@@ -2834,12 +2871,17 @@ class ContainerImagePreparer:
 ARG DEBIAN_FRONTEND=noninteractive
 COPY kali_tool_inventory.py /usr/local/lib/nebula-kali-tool-inventory.py
 COPY egress_helper.py /usr/local/bin/nebula-egress
+COPY public_ip_update.py /usr/local/lib/nebula-public-ip-update
+COPY terminal_entrypoint.sh /usr/local/bin/nebula-terminal-entrypoint
+COPY public_ip.cron /etc/cron.d/nebula-public-ip
 RUN apt-get update \\
  && apt-get install -y {" ".join(self._installed_packages)} \\
  && if getcap /usr/lib/nmap/nmap | grep -q .; then setcap -r /usr/lib/nmap/nmap; fi \\
  && test -z "$(getcap /usr/lib/nmap/nmap)" \\
  && python3 /usr/local/lib/nebula-kali-tool-inventory.py --output {self._security_tool_manifest_path} \\
  && chmod 0500 /usr/local/bin/nebula-egress \\
+ && chmod 0500 /usr/local/lib/nebula-public-ip-update /usr/local/bin/nebula-terminal-entrypoint \\
+ && chmod 0600 /etc/cron.d/nebula-public-ip \\
  && rm -f /usr/local/lib/nebula-kali-tool-inventory.py \\
  && printf '%s\\n' 'APT::Sandbox::User "root";' > /etc/apt/apt.conf.d/99-nebula-terminal \\
  && apt-get clean \\
@@ -2858,6 +2900,16 @@ CMD ["/bin/bash"]
             )
             (context / "egress_helper.py").write_bytes(
                 Path(__file__).with_name("egress_helper.py").read_bytes()
+            )
+            (context / "public_ip_update.py").write_bytes(
+                Path(__file__).with_name("public_ip_update.py").read_bytes()
+            )
+            (context / "terminal_entrypoint.sh").write_bytes(
+                Path(__file__).with_name("terminal_entrypoint.sh").read_bytes()
+            )
+            (context / "public_ip.cron").write_text(
+                "*/5 * * * * root /usr/local/lib/nebula-public-ip-update >/dev/null 2>&1\n",
+                encoding="utf-8",
             )
             return await self._runtime_command(
                 "build",

--- a/src/nebula/v3/terminal_entrypoint.sh
+++ b/src/nebula/v3/terminal_entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+mkdir -p -m 0700 /run/nebula
+/usr/local/lib/nebula-public-ip-update >/dev/null 2>&1 &
+/usr/sbin/cron
+exec "$@"

--- a/tests/v3/test_container_terminal.py
+++ b/tests/v3/test_container_terminal.py
@@ -150,6 +150,9 @@ class ControllableTerminalProcess:
         await self._exited.wait()
         return self._exit_code
 
+    async def read_public_ip_status(self) -> str:
+        return "203.0.113.42\n1788518400\n"
+
     async def emit(self, data: bytes) -> None:
         await self._chunks.put(data)
 
@@ -495,6 +498,27 @@ async def test_concurrent_same_project_starts_reserve_unique_sessions_atomically
     assert (await service.capacity()).active_sessions == 8
     for item in started:
         await service.close(item.session_id)
+
+
+@async_test
+async def test_public_ip_comes_from_the_live_project_terminal(tmp_path):
+    _store, engagement, _runner, _platform, service = continuity_fixture(tmp_path)
+    request = ContainerTerminalPreflightRequest(engagement_id=engagement.id)
+    preview = await service.preflight(request)
+    started = await service.start(ContainerTerminalStartRequest(
+        **request.model_dump(),
+        preview_token=preview.preview_token,
+        preview_fingerprint=preview.preview_fingerprint,
+        client_idempotency_key="public-ip-status",
+    ))
+    attachment = await service.attach(started.session_id, started.websocket_ticket)
+
+    status = await service.engagement_public_ip(engagement.id)
+
+    assert status.address == "203.0.113.42"
+    assert status.observed_at.isoformat() == "2026-09-04T10:40:00+00:00"
+    await service.detach(attachment)
+    await service.close(started.session_id)
 
 
 @async_test

--- a/tests/v3/test_container_terminal.py
+++ b/tests/v3/test_container_terminal.py
@@ -505,12 +505,14 @@ async def test_public_ip_comes_from_the_live_project_terminal(tmp_path):
     _store, engagement, _runner, _platform, service = continuity_fixture(tmp_path)
     request = ContainerTerminalPreflightRequest(engagement_id=engagement.id)
     preview = await service.preflight(request)
-    started = await service.start(ContainerTerminalStartRequest(
-        **request.model_dump(),
-        preview_token=preview.preview_token,
-        preview_fingerprint=preview.preview_fingerprint,
-        client_idempotency_key="public-ip-status",
-    ))
+    started = await service.start(
+        ContainerTerminalStartRequest(
+            **request.model_dump(),
+            preview_token=preview.preview_token,
+            preview_fingerprint=preview.preview_fingerprint,
+            client_idempotency_key="public-ip-status",
+        )
+    )
     attachment = await service.attach(started.session_id, started.websocket_ticket)
 
     status = await service.engagement_public_ip(engagement.id)

--- a/tests/v3/test_sandbox.py
+++ b/tests/v3/test_sandbox.py
@@ -1223,10 +1223,10 @@ def test_human_terminal_verified_podman_cache_makes_no_registry_or_build_request
         "python3",
         "python3-debugpy",
         "ripgrep",
-            "git",
-            "curl",
-            "cron",
-            "openvpn",
+        "git",
+        "curl",
+        "cron",
+        "openvpn",
     )
     assert image.security_tools == ("hashcat", "nmap")
     assert image.security_tool_provenance == (
@@ -1376,7 +1376,10 @@ def test_human_terminal_cold_preparation_pulls_builds_and_verifies(monkeypatch):
     assert "FROM docker.io/kalilinux/kali-rolling@sha256:" + "e" * 64 in dockerfiles[0]
     assert "apt-get install -y kali-linux-headless iputils-ping" in dockerfiles[0]
     assert "COPY egress_helper.py /usr/local/bin/nebula-egress" in dockerfiles[0]
-    assert "COPY public_ip_update.py /usr/local/lib/nebula-public-ip-update" in dockerfiles[0]
+    assert (
+        "COPY public_ip_update.py /usr/local/lib/nebula-public-ip-update"
+        in dockerfiles[0]
+    )
     assert "COPY public_ip.cron /etc/cron.d/nebula-public-ip" in dockerfiles[0]
     assert "cron" in dockerfiles[0]
     assert "setcap -r /usr/lib/nmap/nmap" in dockerfiles[0]

--- a/tests/v3/test_sandbox.py
+++ b/tests/v3/test_sandbox.py
@@ -1200,7 +1200,7 @@ def test_human_terminal_verified_podman_cache_makes_no_registry_or_build_request
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v9"}}}',
+            + '"org.nebula.human-terminal.recipe":"v10"}}}',
             "",
             0,
         )
@@ -1223,9 +1223,10 @@ def test_human_terminal_verified_podman_cache_makes_no_registry_or_build_request
         "python3",
         "python3-debugpy",
         "ripgrep",
-        "git",
-        "curl",
-        "openvpn",
+            "git",
+            "curl",
+            "cron",
+            "openvpn",
     )
     assert image.security_tools == ("hashcat", "nmap")
     assert image.security_tool_provenance == (
@@ -1338,7 +1339,7 @@ def test_human_terminal_cold_preparation_pulls_builds_and_verifies(monkeypatch):
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v9"}}}',
+            + '"org.nebula.human-terminal.recipe":"v10"}}}',
             "",
             0,
         )
@@ -1371,10 +1372,13 @@ def test_human_terminal_cold_preparation_pulls_builds_and_verifies(monkeypatch):
     assert build[0][1] == "--platform=linux/amd64"
     assert build[0][2] == "--pull=false"
     assert build[0][3] == "--quiet"
-    assert build[0][4].startswith("--tag=localhost/nebula-kali-headless:v9-")
+    assert build[0][4].startswith("--tag=localhost/nebula-kali-headless:v10-")
     assert "FROM docker.io/kalilinux/kali-rolling@sha256:" + "e" * 64 in dockerfiles[0]
     assert "apt-get install -y kali-linux-headless iputils-ping" in dockerfiles[0]
     assert "COPY egress_helper.py /usr/local/bin/nebula-egress" in dockerfiles[0]
+    assert "COPY public_ip_update.py /usr/local/lib/nebula-public-ip-update" in dockerfiles[0]
+    assert "COPY public_ip.cron /etc/cron.d/nebula-public-ip" in dockerfiles[0]
+    assert "cron" in dockerfiles[0]
     assert "setcap -r /usr/lib/nmap/nmap" in dockerfiles[0]
     assert 'test -z "$(getcap /usr/lib/nmap/nmap)"' in dockerfiles[0]
     assert "ENV NMAP_UNPRIVILEGED=1" in dockerfiles[0]
@@ -1430,7 +1434,7 @@ def test_human_terminal_cold_pull_failure_can_be_retried(monkeypatch):
             + '"org.nebula.human-terminal.base":"docker.io/kalilinux/kali-rolling@sha256:'
             + "e" * 64
             + '","org.nebula.human-terminal.profile":"kali-linux-headless",'
-            + '"org.nebula.human-terminal.recipe":"v9"}}}',
+            + '"org.nebula.human-terminal.recipe":"v10"}}}',
             "",
             0,
         )

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -101,7 +101,7 @@ describe("Nebula workspace", () => {
     expect(screen.getByRole("button", { name: "More Workbench actions" })).toBeVisible();
   });
 
-  it("defaults to Zero Dark and preserves the three supported preferences", () => {
+  it("defaults to Zero Dark and preserves all four supported preferences", () => {
     const firstRender = renderApp();
     expect(document.documentElement).toHaveAttribute("data-theme", "zero-dark");
     expect(document.querySelector(".app-shell")).toHaveClass("zero-layer-shell");
@@ -126,8 +126,10 @@ describe("Nebula workspace", () => {
 
     localStorage.setItem("nebula.theme", "zero-light");
     renderApp();
-    expect(document.documentElement).toHaveAttribute("data-theme", "light");
-    expect(localStorage.getItem("nebula.theme")).toBe("light");
+    expect(document.documentElement).toHaveAttribute("data-theme", "zero-light");
+    expect(document.documentElement.style.colorScheme).toBe("light");
+    expect(document.querySelector(".app-shell")).toHaveClass("zero-layer-shell");
+    expect(localStorage.getItem("nebula.theme")).toBe("zero-light");
   });
 
   it("restores legacy mission links to the Workbench mission view", async () => {
@@ -146,16 +148,17 @@ describe("Nebula workspace", () => {
     expect(await screen.findByRole("heading", { name: "Settings" })).toBeVisible();
   });
 
-  it("offers Light, Dark, and Zero Dark", async () => {
+  it("offers Light, Dark, Zero Light, and Zero Dark", async () => {
     const user = userEvent.setup();
     renderApp("/settings");
     await screen.findByRole("heading", { name: "Settings" });
     await user.click(screen.getByRole("link", { name: "Advanced settings" }));
     await user.click(screen.getByText("Identity & Security", { selector: "summary strong" }));
     const options = screen.getByRole("heading", { name: "Appearance" }).closest("section")!;
-    expect(within(options).getAllByRole("button")).toHaveLength(3);
+    expect(within(options).getAllByRole("button")).toHaveLength(4);
     expect(within(options).getByRole("button", { name: /^Light$/ })).toBeVisible();
     expect(within(options).getByRole("button", { name: /^Dark$/ })).toBeVisible();
+    expect(within(options).getByRole("button", { name: /^Zero Light$/ })).toBeVisible();
     await user.click(within(options).getByRole("button", { name: /Zero Dark/ }));
     expect(document.documentElement).toHaveAttribute("data-theme", "zero-dark");
     expect(localStorage.getItem("nebula.theme")).toBe("zero-dark");

--- a/ui/src/api/client.test.ts
+++ b/ui/src/api/client.test.ts
@@ -159,6 +159,25 @@ describe("ApiClient", () => {
     });
   });
 
+  it("maps the active terminal container public IP status", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
+      address: "203.0.113.42",
+      observed_at: "2026-09-04T10:40:00Z",
+      stale: false,
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+    const client = new ApiClient({ baseUrl: "http://127.0.0.1:8765", token: "test-token", fetch: fetchMock });
+
+    await expect(client.engagementContainerTerminalPublicIp("project/one")).resolves.toEqual({
+      address: "203.0.113.42",
+      observedAt: "2026-09-04T10:40:00Z",
+      stale: false,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8765/api/v1/engagements/project%2Fone/container-terminal/public-ip",
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+  });
+
   it("summarizes validation arrays without copying oversized inputs into the error", async () => {
     const client = new ApiClient({
       fetch: vi.fn<typeof fetch>().mockResolvedValue(

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -16,6 +16,7 @@ import type {
   ContainerTerminalCapacity,
   ContainerTerminalCapabilities,
   ContainerTerminalPreflight,
+  ContainerTerminalPublicIpStatus,
   ContainerTerminalRequest,
   ContainerTerminalRecovery,
   ContainerTerminalRecoveryList,
@@ -1738,6 +1739,12 @@ interface WireContainerTerminalCapacity extends JsonObject {
   active_sessions: number;
   available_sessions: number;
   max_active_sessions: number;
+}
+
+interface WireContainerTerminalPublicIpStatus extends JsonObject {
+  address: string;
+  observed_at: string;
+  stale: boolean;
 }
 
 interface WireWorkspaceListing extends JsonObject {
@@ -6710,6 +6717,34 @@ export class ApiClient {
       activeSessions: value.active_sessions,
       availableSessions: value.available_sessions,
       maxActiveSessions: value.max_active_sessions,
+    }));
+  }
+
+  containerTerminalPublicIp(
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<ContainerTerminalPublicIpStatus> {
+    return this.request<WireContainerTerminalPublicIpStatus>(
+      `container-terminals/${encodeURIComponent(sessionId)}/public-ip`,
+      { signal },
+    ).then((value) => ({
+      address: value.address,
+      observedAt: value.observed_at,
+      stale: value.stale,
+    }));
+  }
+
+  engagementContainerTerminalPublicIp(
+    engagementId: string,
+    signal?: AbortSignal,
+  ): Promise<ContainerTerminalPublicIpStatus> {
+    return this.request<WireContainerTerminalPublicIpStatus>(
+      `engagements/${encodeURIComponent(engagementId)}/container-terminal/public-ip`,
+      { signal },
+    ).then((value) => ({
+      address: value.address,
+      observedAt: value.observed_at,
+      stale: value.stale,
     }));
   }
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -2381,6 +2381,12 @@ export interface ContainerTerminalCapacity {
   maxActiveSessions: number;
 }
 
+export interface ContainerTerminalPublicIpStatus {
+  address: string;
+  observedAt: string;
+  stale: boolean;
+}
+
 export interface TerminalCommandRecord {
   id: Identifier;
   engagementId: Identifier;

--- a/ui/src/base.css
+++ b/ui/src/base.css
@@ -135,6 +135,14 @@ input, textarea { color: var(--text); background: transparent; caret-color: var(
 .preview-pill { padding: 4px 7px; border: 1px solid color-mix(in srgb, var(--violet) 35%, var(--border)); border-radius: 999px; color: var(--violet); background: color-mix(in srgb, var(--violet) 9%, transparent); font-size: 11px; font-weight: var(--weight-bold); text-transform: uppercase; letter-spacing: .04em; }
 .connection-chip, .command-trigger, .icon-button { display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border-soft); background: var(--surface); cursor: pointer; }
 .connection-chip { gap: 6px; min-height: 30px; padding: 0 9px; border-radius: var(--radius-control); color: var(--muted-strong); font-size: 11px; text-transform: capitalize; }
+.top-bar-public-ip { display: inline-flex; min-height: 30px; align-items: center; gap: 6px; padding: 0 9px; border: 1px solid var(--border-soft); border-radius: var(--radius-control); color: var(--muted-strong); background: var(--surface); cursor: copy; }
+.top-bar-public-ip:hover:not(:disabled), .top-bar-public-ip:focus-visible { border-color: var(--border-strong); color: var(--text); }
+.top-bar-public-ip:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
+.top-bar-public-ip:disabled { cursor: default; opacity: 1; }
+.top-bar-public-ip > span { color: var(--muted); font-size: 9px; font-weight: var(--weight-bold); letter-spacing: .08em; }
+.top-bar-public-ip code { max-width: 180px; overflow: hidden; color: inherit; font-size: 11px; text-overflow: ellipsis; }
+.top-bar-public-ip svg { color: var(--green); }
+.top-bar-public-ip.stale code { color: var(--orange); }
 .connection-chip.online { color: var(--green); }
 .connection-chip.offline { color: var(--red); }
 .command-trigger { gap: 7px; min-height: 30px; padding: 0 6px 0 9px; border-radius: var(--radius-control); color: var(--muted-strong); font-size: 11px; }

--- a/ui/src/calm-responsive.css
+++ b/ui/src/calm-responsive.css
@@ -59,6 +59,7 @@
   .button,
   .icon-button,
   .connection-chip,
+  .top-bar-public-ip,
   .command-trigger { min-height: var(--touch-target); }
   .icon-button,
   .connection-chip,

--- a/ui/src/components-domain.css
+++ b/ui/src/components-domain.css
@@ -368,7 +368,7 @@
 .security-note span { display: flex; flex-direction: column; }
 .security-note strong { font-size: 11px; }
 .security-note small { margin-top: 3px; color: var(--muted-strong); font-size: 11px; line-height: 1.4; }
-.theme-options { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 6px; padding: 14px; }
+.theme-options { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 6px; padding: 14px; }
 .theme-options button { display: flex; min-width: 0; align-items: center; flex-direction: column; gap: 6px; padding: 9px 3px; border: 1px solid var(--border); border-radius: var(--radius-control); color: var(--muted); background: var(--surface-muted); cursor: pointer; }
 .theme-options button[aria-pressed="true"] { color: var(--blue); border-color: var(--blue); background: var(--blue-muted); }
 .theme-options button > span { display: grid; height: 23px; place-items: center; }

--- a/ui/src/components-domain.css
+++ b/ui/src/components-domain.css
@@ -561,7 +561,8 @@
   :root { --side-width: 58px; }
   .page { padding: 20px 15px 42px; }
   .top-bar { padding-inline: 11px; }
-  .top-bar-title, .command-trigger span, .connection-chip span { display: none; }
+  .top-bar-title, .command-trigger span, .connection-chip span, .top-bar-public-ip > span { display: none; }
+  .top-bar-public-ip { max-width: 142px; padding-inline: 7px; }
   .connection-chip { width: 32px; justify-content: center; padding-inline: 0; }
   .page-header { align-items: flex-start; flex-direction: column; }
   .mission-stage-builder > header { align-items: flex-start; flex-direction: column; }

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -2329,7 +2329,7 @@ button.harness-status-summary:focus-visible { outline: 2px solid var(--focus); o
   .resource-inspector { top: var(--top-height); width: 100vw; border-left: 0; }
   .page-header p, .eyebrow { display: none; }
   .page-header { margin-bottom: 18px; }
-  .button, .icon-button, .connection-chip, .command-trigger { min-height: 44px; }
+  .button, .icon-button, .connection-chip, .command-trigger, .top-bar-public-ip { min-height: 44px; }
   .icon-button, .connection-chip, .command-trigger { width: 44px; height: 44px; }
   .settings-tabs a { min-height: 44px; }
   .settings-section { scroll-margin-top: 190px; }

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -42,7 +42,7 @@ export function AppShell() {
     setupStatus,
     workspaceState,
   } = useWorkspace();
-  const zero = resolvedTheme === "zero-dark";
+  const zero = resolvedTheme === "zero-dark" || resolvedTheme === "zero-light";
   const [activityOpen, setActivityOpen] = useState(false);
   const [activityView, setActivityView] = useState<ActivityCenterView>("activity");
   const [paletteOpen, setPaletteOpen] = useState(false);

--- a/ui/src/components/TopBar.test.tsx
+++ b/ui/src/components/TopBar.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TopBar } from "./TopBar";
+
+const workspace = vi.hoisted(() => ({
+  api: { engagementContainerTerminalPublicIp: vi.fn() },
+  coreError: undefined,
+  engagement: { id: "project-1" },
+  reconnect: vi.fn(),
+  workspaceState: "ready",
+}));
+
+vi.mock("../state/WorkspaceContext", () => ({ useWorkspace: () => workspace }));
+
+describe("TopBar public IP", () => {
+  beforeEach(() => {
+    workspace.api.engagementContainerTerminalPublicIp.mockReset();
+    workspace.api.engagementContainerTerminalPublicIp.mockResolvedValue({
+      address: "203.0.113.42",
+      observedAt: "2026-09-04T10:40:00Z",
+      stale: false,
+    });
+  });
+
+  it("shows the active terminal container address beside Ready", async () => {
+    render(<MemoryRouter><TopBar
+      activityOpen={false}
+      approvalsCount={0}
+      onToggleActivity={vi.fn()}
+      onToggleSidebar={vi.fn()}
+      onOpenPalette={vi.fn()}
+      setToolbarHost={vi.fn()}
+      sidebarCollapsed={false}
+    /></MemoryRouter>);
+
+    const ready = screen.getByRole("button", { name: "Nebula Core ready" });
+    const ip = await screen.findByRole("button", { name: /Terminal container public IP 203\.0\.113\.42/ });
+    expect(ready.nextElementSibling).toBe(ip);
+    expect(ip).toHaveTextContent("IP203.0.113.42");
+  });
+});

--- a/ui/src/components/TopBar.tsx
+++ b/ui/src/components/TopBar.tsx
@@ -1,5 +1,7 @@
 import {
+  Check,
   Command,
+  Copy,
   PanelLeftClose,
   PanelLeftOpen,
   RefreshCw,
@@ -7,9 +9,12 @@ import {
   Wifi,
   WifiOff,
 } from "lucide-react";
+import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { navigationItems } from "../navigation";
 import { useWorkspace } from "../state/WorkspaceContext";
+import type { ContainerTerminalPublicIpStatus } from "../api/types";
+import { copySelectionText } from "./selection";
 
 interface TopBarProps {
   activityOpen: boolean;
@@ -34,8 +39,41 @@ export function TopBar({
 }: TopBarProps) {
   const location = useLocation();
   const page = navigationItems.find((item) => item.path === location.pathname) ?? navigationItems[0];
-  const { coreError, reconnect, workspaceState } = useWorkspace();
+  const { api, coreError, engagement, reconnect, workspaceState } = useWorkspace();
+  const [publicIp, setPublicIp] = useState<ContainerTerminalPublicIpStatus>();
+  const [publicIpCopied, setPublicIpCopied] = useState(false);
   const canRetry = workspaceState === "failed" || workspaceState === "degraded";
+
+  useEffect(() => {
+    if (!api || typeof api.engagementContainerTerminalPublicIp !== "function" || !engagement || !["ready", "degraded"].includes(workspaceState)) {
+      setPublicIp(undefined);
+      return;
+    }
+    const controller = new AbortController();
+    let timer: number | undefined;
+    const refresh = async () => {
+      try {
+        const status = await api.engagementContainerTerminalPublicIp(engagement.id, controller.signal);
+        if (!controller.signal.aborted) setPublicIp(status);
+      } catch {
+        if (!controller.signal.aborted) setPublicIp(undefined);
+      } finally {
+        if (!controller.signal.aborted) timer = globalThis.setTimeout(refresh, 15_000);
+      }
+    };
+    void refresh();
+    return () => {
+      controller.abort();
+      if (timer !== undefined) globalThis.clearTimeout(timer);
+    };
+  }, [api, engagement, workspaceState]);
+
+  const copyPublicIp = async () => {
+    if (!publicIp) return;
+    await copySelectionText(publicIp.address);
+    setPublicIpCopied(true);
+    globalThis.setTimeout(() => setPublicIpCopied(false), 1_500);
+  };
 
   return (
     <header className={`top-bar${variant === "zero" ? " zero-status-band" : ""}`} data-shell="shared">
@@ -74,6 +112,9 @@ export function TopBar({
             <WifiOff size={14} aria-hidden="true" />
           )}
           <span>{workspaceState === "degraded" ? "Limited" : workspaceState}</span>
+        </button>
+        <button className={`top-bar-public-ip${publicIp?.stale ? " stale" : ""}`} type="button" disabled={!publicIp} onClick={() => void copyPublicIp()} title={publicIp ? `Terminal container public IP · observed ${new Date(publicIp.observedAt).toLocaleString()}` : "Start a terminal to observe its container public IP"} aria-label={publicIp ? `Terminal container public IP ${publicIp.address}. Copy address` : "Terminal container public IP unavailable"}>
+          <span>IP</span><code>{publicIp?.address ?? "—"}</code>{publicIp && (publicIpCopied ? <Check size={13} aria-hidden="true" /> : <Copy size={13} aria-hidden="true" />)}
         </button>
         <button className="command-trigger" type="button" onClick={onOpenPalette} aria-label="Search pages, actions, and settings">
           <Command size={15} aria-hidden="true" />

--- a/ui/src/components/TopBar.tsx
+++ b/ui/src/components/TopBar.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
+import { logCaughtDiagnostic } from "../diagnostics";
 import { navigationItems } from "../navigation";
 import { useWorkspace } from "../state/WorkspaceContext";
 import type { ContainerTerminalPublicIpStatus } from "../api/types";
@@ -55,8 +56,16 @@ export function TopBar({
       try {
         const status = await api.engagementContainerTerminalPublicIp(engagement.id, controller.signal);
         if (!controller.signal.aborted) setPublicIp(status);
-      } catch {
-        if (!controller.signal.aborted) setPublicIp(undefined);
+      } catch (caught) {
+        if (!controller.signal.aborted) {
+          setPublicIp(undefined);
+          void logCaughtDiagnostic(
+            "interface.container_terminal.public_ip_load_failed",
+            "The terminal container public IP could not be refreshed.",
+            caught,
+            "container_terminal",
+          );
+        }
       } finally {
         if (!controller.signal.aborted) timer = globalThis.setTimeout(refresh, 15_000);
       }

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -22,6 +22,7 @@ import { isTauriRuntime } from "../api/runtime";
 const themeOptions: { value: ThemePreference; label: string; icon: typeof Sun }[] = [
   { value: "light", label: "Light", icon: Sun },
   { value: "dark", label: "Dark", icon: Moon },
+  { value: "zero-light", label: "Zero Light", icon: Sun },
   { value: "zero-dark", label: "Zero Dark", icon: Moon },
 ];
 

--- a/ui/src/state/ThemeContext.tsx
+++ b/ui/src/state/ThemeContext.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from "react";
 
-export type ThemePreference = "light" | "dark" | "zero-dark";
+export type ThemePreference = "light" | "dark" | "zero-light" | "zero-dark";
 
 interface ThemeContextValue {
   preference: ThemePreference;
@@ -22,8 +22,8 @@ const STORAGE_KEY = "nebula.theme";
 const DEFAULT_PREFERENCE: ThemePreference = "zero-dark";
 
 function normalizePreference(value: string | null): ThemePreference | undefined {
-  if (value === "light" || value === "dark" || value === "zero-dark") return value;
-  if (value === "zero" || value === "zero-light") return value === "zero" ? "zero-dark" : "light";
+  if (value === "light" || value === "dark" || value === "zero-light" || value === "zero-dark") return value;
+  if (value === "zero") return "zero-dark";
   if (value === "high-contrast" || value === "system") return "dark";
   return undefined;
 }
@@ -54,7 +54,7 @@ export function ThemeProvider({ children }: PropsWithChildren) {
 
   useEffect(() => {
     document.documentElement.dataset.theme = resolvedTheme;
-    document.documentElement.style.colorScheme = resolvedTheme === "light" ? "light" : "dark";
+    document.documentElement.style.colorScheme = resolvedTheme === "light" || resolvedTheme === "zero-light" ? "light" : "dark";
   }, [resolvedTheme]);
 
   const setPreference = useCallback((value: ThemePreference) => {
@@ -63,7 +63,7 @@ export function ThemeProvider({ children }: PropsWithChildren) {
   }, []);
 
   const cycleTheme = useCallback(() => {
-    setPreference(preference === "light" ? "dark" : preference === "dark" ? "zero-dark" : "light");
+    setPreference(preference === "light" ? "dark" : preference === "dark" ? "zero-light" : preference === "zero-light" ? "zero-dark" : "light");
   }, [preference, setPreference]);
 
   const value = useMemo(

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -357,6 +357,8 @@ async function installTruthfulCore(page: Page) {
         tags: [],
         metadata: { created_by: "system:bootstrap", bootstrap_kind: "scratch_project_v1" },
       }];
+    } else if (path.endsWith("/container-terminal/public-ip")) {
+      body = { address: "203.0.113.42", observed_at: "2026-09-04T10:40:00Z", stale: false };
     } else if (path.endsWith("/container-terminal/capabilities")) {
       body = {
         engagement_id: "scratch-project",
@@ -5123,6 +5125,10 @@ test("shared actions keep sleek geometry without weakening touch targets", async
   const mobile = (page.viewportSize()?.width ?? 1440) <= 760;
   for (const [route, name] of [["/findings", "New finding"], ["/?view=chat", "New chat"]] as const) {
     await openWorkspace(page, route, route === "/findings" ? "Findings" : "Workbench");
+    const connection = page.getByRole("button", { name: "Nebula Core ready" });
+    const publicIp = page.getByRole("button", { name: /Terminal container public IP 203\.0\.113\.42/ });
+    await expect(publicIp).toBeVisible();
+    expect(await connection.evaluate((element) => element.nextElementSibling?.getAttribute("aria-label"))).toContain("203.0.113.42");
     const action = page.getByRole("button", { name, exact: true }).first();
     await expect(action).toBeVisible();
     const resting = await action.evaluate((element) => {

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -1098,7 +1098,7 @@ test(firstRunThemeTest, async ({ page }) => {
   expect(await page.evaluate(() => localStorage.getItem("nebula.theme"))).toBeNull();
 });
 
-test("theme picker offers Light, Dark, and Zero Dark and persists the selection", async ({ page }) => {
+test("theme picker offers Light, Dark, Zero Light, and Zero Dark and persists the selection", async ({ page }) => {
   await openWorkspace(page, "/settings", "Settings");
   await page.getByRole("link", { name: "Advanced settings" }).click();
   await page.getByText("Identity & Security", { exact: true }).click();
@@ -1107,6 +1107,7 @@ test("theme picker offers Light, Dark, and Zero Dark and persists the selection"
   for (const [label, theme, zeroShell] of [
     ["Light", "light", false],
     ["Dark", "dark", false],
+    ["Zero Light", "zero-light", true],
     ["Zero Dark", "zero-dark", true],
   ] as const) {
     await appearance.getByRole("button", { name: label, exact: true }).click();


### PR DESCRIPTION
## Summary
- expose the terminal container public IP from Core
- show the authoritative egress address beside Core status in the top bar
- retain unavailable and refresh behavior across themes and responsive layouts

## Verification
- backend: 78 passed (`test_container_terminal.py`, `test_sandbox.py`)
- UI: 76 passed (`App`, API client, TopBar)
- production UI build passed
- targeted Playwright: desktop, compact, narrow, mobile Chromium passed; mobile WebKit reached an existing canonical-project redirect mismatch (`/?view=chat` vs `/projects/scratch-project/workbench?view=chat`) before the public-IP assertion

## Remaining quality gates
- current CI
- production LAN and physical-device checks are not claimed by this PR