### PR TITLE
Persist VPN selection when saving project profiles

### DIFF
--- a/tests/v3/test_automation_runtime.py
+++ b/tests/v3/test_automation_runtime.py
@@ -58,6 +58,23 @@ from nebula.v3.tool_results import (
 IMAGE = "registry.invalid/nebula-automation@sha256:" + "a" * 64
 
 
+class DurableTestKeyring:
+    __module__ = "keyring.backends.SecretService"
+    priority = 1
+
+    def __init__(self):
+        self.values = {}
+
+    def set_password(self, service_name, username, password):
+        self.values[(service_name, username)] = password
+
+    def get_password(self, service_name, username):
+        return self.values.get((service_name, username))
+
+    def delete_password(self, service_name, username):
+        self.values.pop((service_name, username), None)
+
+
 def test_all_target_scope_compiles_to_dual_stack_all_port_egress():
     rules, domains = AutomationRuntimeManager._network_boundary(
         AutomationProjectPolicy(engagement_id="eng-1", network_enabled=True),
@@ -883,6 +900,79 @@ certificate
         )
         assert removed.status_code == 204
         assert client.get("/api/v1/vpn-profiles", headers=headers).json() == []
+
+
+def test_project_vpn_selection_and_vault_secret_survive_core_restart(tmp_path):
+    manager, store, artifacts, engagement, _sessions = runtime(tmp_path)
+    backend = DurableTestKeyring()
+    credentials = CredentialStore(backend)
+    app = create_app(
+        store,
+        artifact_store=artifacts,
+        auth_token="runtime-test-token",
+        automation_runtime=manager,
+        credential_store=credentials,
+    )
+    headers = {"Authorization": "Bearer runtime-test-token"}
+    config = """client
+dev tun
+proto udp
+remote vpn.example.test 1194
+remote-cert-tls server
+auth-user-pass
+<ca>
+certificate
+</ca>
+"""
+
+    with TestClient(app) as client:
+        profile = client.post(
+            "/api/v1/vpn-profiles",
+            headers=headers,
+            json={
+                "name": "Persistent project VPN",
+                "filename": "project.ovpn",
+                "config": config,
+                "username": "project-user",
+                "password": "project-password",
+                "persistence": "vault",
+            },
+        ).json()
+        policy = client.get(
+            f"/api/v1/engagements/{engagement.id}/automation-policy",
+            headers=headers,
+        ).json()
+        selected = client.put(
+            f"/api/v1/engagements/{engagement.id}/automation-policy",
+            headers=headers,
+            json={
+                "approval_policy": policy["approval_policy"],
+                "network_enabled": True,
+                "runner_profile_id": policy["runner_profile_id"],
+                "vpn_profile_id": profile["id"],
+                "max_timeout_ms": policy["max_timeout_ms"],
+                "expected_revision": policy["revision"],
+            },
+        )
+        assert selected.status_code == 200, selected.text
+
+    restarted_store = NebulaStore(tmp_path / "nebula.db")
+    restarted_credentials = CredentialStore(backend)
+    persisted_profile = restarted_store.get(VpnProfile, profile["id"])
+    persisted_policy = restarted_store.get(
+        AutomationProjectPolicy, selected.json()["id"]
+    )
+
+    assert persisted_policy.engagement_id == engagement.id
+    assert persisted_policy.vpn_profile_id == persisted_profile.id
+    assert restarted_credentials.status(persisted_profile.secret_ref).available is True
+    assert (
+        "project-user\nproject-password"
+        in restarted_credentials.resolve(
+            persisted_profile.secret_ref
+        ).get_secret_value()
+    )
+    assert b"project-password" not in (tmp_path / "nebula.db").read_bytes()
 
 
 def test_default_mission_degrades_to_analysis_when_command_runtime_is_unprepared(

--- a/ui/src/components/ToolingSettings.tsx
+++ b/ui/src/components/ToolingSettings.tsx
@@ -95,8 +95,26 @@ export function AutomationRuntimeSettings() {
         config: await vpnFile.text(), username: vpnUsername || undefined, password: vpnPassword || undefined,
         persistence: vpnPersistence,
       });
-      setVpnProfiles((items) => [saved, ...items]); setVpnFile(undefined); setVpnName(""); setVpnUsername(""); setVpnPassword("");
-      announceSettingsSaved("VPN profile saved. Select it from a project's command runtime policy.");
+      setVpnProfiles((items) => [saved, ...items]);
+      setVpnFile(undefined); setVpnName(""); setVpnUsername(""); setVpnPassword("");
+      if (engagement && projectPolicy) {
+        try {
+          const updated = await api.updateAutomationPolicy(engagement.id, {
+            approvalPolicy: projectPolicy.approvalPolicy,
+            networkEnabled: true,
+            runnerProfileId: projectPolicy.runnerProfileId,
+            vpnProfileId: saved.id,
+            maxTimeoutMs: projectPolicy.maxTimeoutMs,
+            expectedRevision: projectPolicy.revision,
+          });
+          setProjectPolicy(updated);
+        } catch (selectionError) {
+          throw new Error(`${saved.name} was saved, but Nebula could not select it for ${engagement.name}. Use “Use for this project” to retry.`, { cause: selectionError });
+        }
+      }
+      announceSettingsSaved(engagement && projectPolicy
+        ? `${saved.name} was saved and will reconnect automatically for ${engagement.name}.`
+        : "VPN profile saved. Open a project to choose where it is used.");
     } catch (uploadError) {
       void logCaughtDiagnostic("interface.automation_runtime.vpn_upload_failed", "VPN profile could not be saved.", uploadError, "automation_runtime");
       setError(uploadError instanceof Error ? uploadError.message : "Could not save the VPN profile.");
@@ -144,7 +162,7 @@ export function AutomationRuntimeSettings() {
         <label className="vpn-file-drop"><UploadCloud size={22} /><span><strong>{vpnFile?.name ?? "Choose an OpenVPN profile"}</strong><small>.ovpn · TUN client · inline certificates · up to 15 KB</small></span><input type="file" accept=".ovpn,application/x-openvpn-profile" required onChange={(event) => { const file = event.target.files?.[0]; setVpnFile(file); if (file && !vpnName) setVpnName(file.name.replace(/\.ovpn$/i, "")); }} /></label>
         <label>Profile name<input value={vpnName} placeholder="Company VPN" onChange={(event) => setVpnName(event.target.value)} /></label>
         <details className="inventory-disclosure vpn-options"><summary><span><strong>Credentials and storage</strong><small>Only needed when the profile requests username/password authentication.</small></span><ChevronDown size={17} /></summary><div className="policy-form-body"><label>Username<input autoComplete="username" value={vpnUsername} onChange={(event) => setVpnUsername(event.target.value)} /></label><label>Password<input type="password" autoComplete="new-password" value={vpnPassword} onChange={(event) => setVpnPassword(event.target.value)} /></label><label>Storage<select value={vpnPersistence} onChange={(event) => setVpnPersistence(event.target.value as "vault" | "session")}><option value="vault">Operating-system vault</option><option value="session">This Core session only</option></select></label></div></details>
-        <footer><span>Scripts, plugins, TAP, split routes, and external file paths are rejected.</span><button className="button primary" type="submit" disabled={!vpnFile || savingVpn || previewMode}>{savingVpn ? "Checking…" : "Save profile"}</button></footer>
+        <footer><span>{engagement ? `The profile will be ${vpnPersistence === "vault" ? "kept in the OS vault" : "available for this Core session"} and selected for ${engagement.name}.` : "Open a project to select this profile automatically."} Scripts, plugins, TAP, split routes, and external file paths are rejected.</span><button className="button primary" type="submit" disabled={!vpnFile || savingVpn || previewMode}>{savingVpn ? "Checking…" : engagement ? "Save for project" : "Save profile"}</button></footer>
       </form>
       <section className="panel runner-status"><header className="panel-header compact"><div><h3>Saved profiles</h3><p>{engagement ? `Choose the route for new terminals in ${engagement.name}.` : "Open a project to choose where a profile is used."}</p></div><span className="inventory-count">{vpnProfiles.length}</span></header>{vpnProfiles.length ? vpnProfiles.map((profile) => {
         const selected = projectPolicy?.vpnProfileId === profile.id;

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -1985,10 +1985,8 @@ test("project scope normalizes root URLs and confirms all-target mode", async ({
 
 test("VPN settings keep upload and project routing calm at every width", async ({ page }) => {
   let selectedVpnProfile: string | null = null;
-  await page.route("**/api/v1/vpn-profiles", async (route) => route.fulfill({
-    status: 200,
-    contentType: "application/json",
-    body: JSON.stringify([{
+  let savedPersistence: string | null = null;
+  const savedProfiles = [{
       ...entity,
       id: "vpn-preview",
       name: "Company VPN",
@@ -1999,8 +1997,29 @@ test("VPN settings keep upload and project routing calm at every width", async (
       fingerprint: "a".repeat(64),
       requires_credentials: true,
       available: true,
-    }]),
-  }));
+  }];
+  await page.route("**/api/v1/vpn-profiles", async (route) => {
+    if (route.request().method() === "POST") {
+      const request = route.request().postDataJSON();
+      savedPersistence = String(request.persistence);
+      const uploaded = {
+        ...entity,
+        id: "vpn-uploaded",
+        name: request.name,
+        filename: request.filename,
+        remote_host: "uk.example.test",
+        remote_port: 1194,
+        protocol: "udp",
+        fingerprint: "b".repeat(64),
+        requires_credentials: true,
+        available: true,
+      };
+      savedProfiles.unshift(uploaded);
+      await route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify(uploaded) });
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(savedProfiles) });
+  });
   await page.route("**/api/v1/engagements/*/automation-policy", async (route) => {
     if (route.request().method() === "PUT") {
       selectedVpnProfile = String(route.request().postDataJSON().vpn_profile_id);
@@ -2033,6 +2052,19 @@ test("VPN settings keep upload and project routing calm at every width", async (
   await expect(section.getByText("In use", { exact: true })).toBeVisible();
   await expect(section.getByText(/Selected for .* New terminals wait for the tunnel/)).toBeVisible();
   expect(selectedVpnProfile).toBe("vpn-preview");
+  await section.locator('input[type="file"]').setInputFiles({
+    name: "project.ovpn",
+    mimeType: "application/x-openvpn-profile",
+    buffer: Buffer.from("client\ndev tun\nremote uk.example.test 1194\nremote-cert-tls server\n"),
+  });
+  await section.getByText("Credentials and storage").click();
+  await section.getByLabel("Username").fill("project-user");
+  await section.getByLabel("Password").fill("project-password");
+  await section.getByRole("button", { name: "Save for project" }).click();
+  await expect(section.getByText("project", { exact: true })).toBeVisible();
+  await expect(section.getByText(/Selected for .* New terminals wait for the tunnel/)).toBeVisible();
+  expect(savedPersistence).toBe("vault");
+  expect(selectedVpnProfile).toBe("vpn-uploaded");
   const geometry = await section.evaluate((element) => ({
     clientWidth: element.clientWidth,
     scrollWidth: element.scrollWidth,


### PR DESCRIPTION
## Summary
- automatically select a newly saved VPN profile for the open project
- keep durable credentials in the operating-system vault and make the persistence choice explicit
- add Core restart and UI workflow regression coverage

## Validation
- `git diff --check`
- `ruff check tests/v3/test_automation_runtime.py`
- `ruff format --check tests/v3/test_automation_runtime.py`
- full local browser/build gates deferred because the host is I/O-saturated; required PR checks are the merge gate