### PR TITLE
Fix new project creation leaving Assistant in the previous project

### DIFF
--- a/ui/src/components/SideNav.tsx
+++ b/ui/src/components/SideNav.tsx
@@ -2,7 +2,7 @@ import { useState, type FormEvent } from "react";
 import { Check, ChevronDown, LockKeyhole, Orbit, Plus, X } from "lucide-react";
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
 import { navigationGroups, navigationItems } from "../navigation";
-import { canonicalNavigationPath, replaceProjectInPath } from "../resourceRoutes";
+import { canonicalNavigationPath, projectSurface, replaceProjectInPath } from "../resourceRoutes";
 import { useWorkspace } from "../state/WorkspaceContext";
 import { DiagnosticErrorNotice, logCaughtDiagnostic } from "../diagnostics";
 import { HostFolderPicker } from "./HostFolderPicker";
@@ -48,7 +48,9 @@ export function SideNav({ collapsed, onNavigate, variant = "standard" }: SideNav
     setSaving(true);
     setError(undefined);
     try {
-      await createEngagement({ name, clientName: clientName || undefined, workspacePath: workspacePath || undefined });
+      const created = await createEngagement({ name, clientName: clientName || undefined, workspacePath: workspacePath || undefined });
+      navigate(`${projectSurface(created.id, "workbench")}?view=chat`);
+      onNavigate();
       setName("");
       setClientName("");
       setWorkspacePath("");

--- a/ui/tests/real-core.spec.ts
+++ b/ui/tests/real-core.spec.ts
@@ -1439,6 +1439,63 @@ test("clean real Core completes reviewed work and exposes every recovery state",
   }
 });
 
+test("assistant upgrade project creation switches canonical project and isolates chats", async ({ page }) => {
+  test.setTimeout(90_000);
+  const core = await startRealCore({ bindHost: "0.0.0.0", browserHost: localNetworkIpv4() });
+  const stub = await startLocalModelStub({ streamDelayMs: 50 });
+  const api = await playwrightRequest.newContext({ baseURL: `${core.origin}/api/v1/`, extraHTTPHeaders: { Authorization: `Bearer ${core.token}` } });
+  try {
+    const projects = await (await api.get("engagements")).json() as Array<{ id: string }>;
+    const provider = await (await api.post("providers", { data: { name: "Project navigation acceptance", provider_type: "vllm", endpoint: `${stub.origin}/v1`, enabled: true, is_local: true, model_allowlist: ["security-model"], privacy: { local_only: true, residency: [], permits_sensitive_data: false }, metadata: { default_model: "security-model" } } })).json() as { id: string };
+    const response = await api.post("chat/completions", { data: { backend: "provider", provider_id: provider.id, model: "security-model", engagement_id: projects[0].id, messages: [{ role: "user", content: "Old project conversation" }], include_knowledge: false, stream: false } });
+    expect(response.ok(), await response.text()).toBe(true);
+    const oldChat = await response.json() as { session_id: string };
+    const pairingApi = await playwrightRequest.newContext({ baseURL: `http://127.0.0.1:${new URL(core.origin).port}/api/v1/`, extraHTTPHeaders: { Authorization: `Bearer ${core.token}` } });
+    const pairingResponse = await pairingApi.post("auth/pairings", { data: { name: "Project creation browser" } });
+    expect(pairingResponse.ok(), await pairingResponse.text()).toBe(true);
+    const pairing = await pairingResponse.json() as { secret: string; confirmation_code: string };
+    await pairingApi.dispose();
+    await page.goto(`${core.origin}/#pair=${encodeURIComponent(pairing.secret)}&code=${encodeURIComponent(pairing.confirmation_code)}`);
+    await page.getByLabel("Device name").fill("Project creation browser");
+    await page.getByRole("button", { name: "Pair device" }).click();
+    await expect(page.getByRole("button", { name: "Nebula Core ready" })).toBeVisible({ timeout: 20_000 });
+    await page.goto(`${core.origin}/projects/${projects[0].id}/workbench?view=chat&session=${oldChat.session_id}`);
+    await expect(page.locator(".chat-message.operator")).toContainText("Old project conversation");
+    const sidebar = page.getByRole("button", { name: "Show sidebar" });
+    if (await sidebar.isVisible()) await sidebar.click();
+    await page.getByRole("button", { name: "Switch project" }).click();
+    const switcher = page.getByRole("dialog", { name: "Project switcher" });
+    await switcher.getByRole("button", { name: "New project" }).click();
+    await switcher.getByLabel("Name", { exact: true }).fill("New isolated project");
+    await switcher.getByRole("button", { name: "Create", exact: true }).click();
+    await expect(switcher).toBeHidden();
+    const saved = await (await api.get("engagements")).json() as Array<{ id: string; name: string }>;
+    const created = saved.find(project => project.name === "New isolated project")!;
+    expect(created).toBeTruthy();
+    await expect(page).toHaveURL(`${core.origin}/projects/${created.id}/workbench?view=chat`);
+    await expect.poll(() => page.evaluate(() => localStorage.getItem("nebula.engagement"))).toBe(created.id);
+    await expect(page.getByRole("button", { name: "Start new chat", exact: true })).toBeVisible();
+    await expect(page.locator(".chat-message.operator")).toHaveCount(0);
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Start new chat", exact: true })).toBeVisible();
+    await expect.poll(() => page.evaluate(() => localStorage.getItem("nebula.engagement"))).toBe(created.id);
+    await page.getByRole("button", { name: "Start new chat", exact: true }).click();
+    await page.getByRole("textbox", { name: "Message the analyst assistant" }).fill("New project conversation");
+    await page.getByRole("button", { name: "Send message", exact: true }).click();
+    await expect(page.locator(".chat-message.operator")).toContainText("New project conversation");
+    await expect.poll(async () => {
+      const chats = await (await api.get(`chat-sessions?engagement_id=${created.id}`)).json() as Array<{ id: string }>;
+      return chats.length;
+    }).toBe(1);
+    const oldChats = await (await api.get(`chat-sessions?engagement_id=${projects[0].id}`)).json() as Array<{ id: string }>;
+    expect(oldChats.map(chat => chat.id)).toEqual([oldChat.session_id]);
+  } finally {
+    await api.dispose();
+    await stopLocalModelStub(stub);
+    await stopRealCore(core);
+  }
+});
+
 test("assistant upgrade foundation production LAN reads durable conversation", async ({ page }, testInfo) => {
   test.setTimeout(60_000);
   const core = await startRealCore({bindHost: "0.0.0.0", browserHost: localNetworkIpv4()});


### PR DESCRIPTION
Creating a project from a canonical project URL left the old project in the URL, so workspace bootstrap selected it again and Assistant continued showing its chats. Navigate to the saved project's Assistant immediately after creation, discard the old session query, and close mobile navigation.

Adds a real-Core regression starting from an existing project's chat. It creates a project through the switcher, checks immediate canonical navigation and empty Assistant state, reloads a paired browser, sends a new message, and checks that Core stores each conversation under its own project. Runs against the production bundle on a non-loopback LAN origin using the permanent desktop and mobile browser projects.

Validation:
- Production build passed.
- WorkspaceContext unit tests: 2 passed.
- Real-Core production LAN regression: 8/8 passed, serially, using paired browsers. Desktop Chromium at 1440 and 1024 px; emulated mobile Chromium and WebKit at 320, 390, and 430 px.
- Command: `npx playwright test tests/real-core.spec.ts --project='assistant-real-*' --grep 'project creation switches' --workers=1`.
- Each test starts an isolated Core on the host LAN IPv4 address with a dynamically allocated port and serves `ui/dist`; model responses come from a local test provider.
- Physical devices not tested; mobile profiles are emulated. No deployment included.

Product rule: a successful creation must make the saved item immediately active, with URL, visible selection, and durable state agreeing.
