### PR TITLE
Fix desktop crash check isolation and false orphan failures

### DIFF
--- a/scripts/test_desktop_crash_cleanup.py
+++ b/scripts/test_desktop_crash_cleanup.py
@@ -11,7 +11,7 @@ import time
 from pathlib import Path
 
 
-def matching_core_processes(core: Path) -> list[int]:
+def matching_core_processes(core: Path, session_id: int) -> list[int]:
     expected = core.resolve()
     matches = []
     for entry in Path("/proc").iterdir():
@@ -20,9 +20,10 @@ def matching_core_processes(core: Path) -> list[int]:
         try:
             executable = (entry / "exe").resolve()
             arguments = (entry / "cmdline").read_bytes().split(b"\0")
+            belongs_to_test = os.getsid(int(entry.name)) == session_id
         except (FileNotFoundError, PermissionError, ProcessLookupError, OSError):
             continue
-        if executable == expected and b"serve" in arguments:
+        if executable == expected and b"serve" in arguments and belongs_to_test:
             matches.append(int(entry.name))
     return matches
 
@@ -42,11 +43,12 @@ def main() -> int:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         env=os.environ.copy(),
+        start_new_session=True,
     )
     observed = []
     deadline = time.monotonic() + 60
     while time.monotonic() < deadline and process.poll() is None:
-        observed = matching_core_processes(core)
+        observed = matching_core_processes(core, process.pid)
         if observed:
             break
         time.sleep(0.02)
@@ -59,12 +61,14 @@ def main() -> int:
     process.wait()
     deadline = time.monotonic() + 15
     while time.monotonic() < deadline:
-        remaining = matching_core_processes(core)
+        remaining = matching_core_processes(core, process.pid)
         if not remaining:
             return 0
         time.sleep(0.05)
 
-    remaining = matching_core_processes(core)
+    remaining = matching_core_processes(core, process.pid)
+    if not remaining:
+        return 0
     for pid in remaining:
         try:
             os.kill(pid, signal.SIGKILL)

--- a/tests/v3/test_desktop_crash_cleanup.py
+++ b/tests/v3/test_desktop_crash_cleanup.py
@@ -1,0 +1,80 @@
+"""Keep release crash checks scoped to their own desktop invocation."""
+
+from pathlib import Path
+import subprocess
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+from scripts import test_desktop_crash_cleanup as cleanup
+
+
+@pytest.mark.skipif(not Path('/proc/self/environ').exists(), reason='Linux procfs required')
+def test_only_core_from_this_run_matches():
+    processes = []
+    try:
+        for _ in range(3):
+            processes.append(subprocess.Popen(
+                [sys.executable, '-c', 'import time; time.sleep(30)', 'serve'],
+                start_new_session=True,
+            ))
+        assert cleanup.matching_core_processes(Path(sys.executable), processes[0].pid) == [
+            processes[0].pid
+        ]
+        assert cleanup.matching_core_processes(Path(sys.executable), -1) == []
+    finally:
+        for process in processes:
+            process.kill()
+            process.wait()
+
+
+@pytest.mark.parametrize('final_matches', [[], [123456]])
+def test_deadline_rechecks_before_reporting_orphans(tmp_path, monkeypatch, final_matches):
+    desktop = tmp_path / 'nebula-ui'
+    desktop.touch()
+    desktop.with_name('nebula-core').touch()
+    monkeypatch.setattr(sys, 'argv', ['crash-check', str(desktop)])
+    process = Mock(pid=654321)
+    process.poll.return_value = None
+    launch = Mock(return_value=process)
+    monkeypatch.setattr(cleanup.subprocess, 'Popen', launch)
+    scans = Mock(side_effect=[[123456], final_matches])
+    monkeypatch.setattr(cleanup, 'matching_core_processes', scans)
+    ticks = iter([0, 0, 0, 16])
+    monkeypatch.setattr(cleanup.time, 'monotonic', lambda: next(ticks))
+    kill = Mock()
+    monkeypatch.setattr(cleanup.os, 'kill', kill)
+
+    if final_matches:
+        with pytest.raises(RuntimeError, match='orphaned Nebula Core'):
+            cleanup.main()
+        assert kill.call_count == 2
+    else:
+        assert cleanup.main() == 0
+        kill.assert_called_once_with(process.pid, cleanup.signal.SIGKILL)
+    assert launch.call_args.kwargs['start_new_session'] is True
+    assert all(call.args[1] == process.pid for call in scans.call_args_list)
+
+
+@pytest.mark.skipif(not Path('/proc/self/environ').exists(), reason='Linux procfs required')
+def test_crash_check_runs_with_isolated_session(tmp_path):
+    """Exercise launch, session inheritance, SIGKILL, and observed child exit."""
+    core = tmp_path / 'nebula-core'
+    core.symlink_to(sys.executable)
+    desktop = tmp_path / 'nebula-ui'
+    desktop.write_text(
+        f'#!{sys.executable}\n'
+        'import os, subprocess, time\n'
+        f'core = {str(core)!r}\n'
+        'parent = os.getpid()\n'
+        'code = f"import os,time\\nwhile os.getppid() == {parent}: time.sleep(0.01)"\n'
+        'subprocess.Popen([core, "-c", code, "serve"], env={}, process_group=0)\n'
+        'time.sleep(30)\n'
+    )
+    desktop.chmod(0o755)
+    result = subprocess.run(
+        [sys.executable, str(Path(cleanup.__file__).resolve()), str(desktop)],
+        capture_output=True, text=True, timeout=20,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/v3/test_desktop_crash_cleanup.py
+++ b/tests/v3/test_desktop_crash_cleanup.py
@@ -10,18 +10,22 @@ import pytest
 from scripts import test_desktop_crash_cleanup as cleanup
 
 
-@pytest.mark.skipif(not Path('/proc/self/environ').exists(), reason='Linux procfs required')
+@pytest.mark.skipif(
+    not Path("/proc/self/environ").exists(), reason="Linux procfs required"
+)
 def test_only_core_from_this_run_matches():
     processes = []
     try:
         for _ in range(3):
-            processes.append(subprocess.Popen(
-                [sys.executable, '-c', 'import time; time.sleep(30)', 'serve'],
-                start_new_session=True,
-            ))
-        assert cleanup.matching_core_processes(Path(sys.executable), processes[0].pid) == [
-            processes[0].pid
-        ]
+            processes.append(
+                subprocess.Popen(
+                    [sys.executable, "-c", "import time; time.sleep(30)", "serve"],
+                    start_new_session=True,
+                )
+            )
+        assert cleanup.matching_core_processes(
+            Path(sys.executable), processes[0].pid
+        ) == [processes[0].pid]
         assert cleanup.matching_core_processes(Path(sys.executable), -1) == []
     finally:
         for process in processes:
@@ -29,52 +33,58 @@ def test_only_core_from_this_run_matches():
             process.wait()
 
 
-@pytest.mark.parametrize('final_matches', [[], [123456]])
-def test_deadline_rechecks_before_reporting_orphans(tmp_path, monkeypatch, final_matches):
-    desktop = tmp_path / 'nebula-ui'
+@pytest.mark.parametrize("final_matches", [[], [123456]])
+def test_deadline_rechecks_before_reporting_orphans(
+    tmp_path, monkeypatch, final_matches
+):
+    desktop = tmp_path / "nebula-ui"
     desktop.touch()
-    desktop.with_name('nebula-core').touch()
-    monkeypatch.setattr(sys, 'argv', ['crash-check', str(desktop)])
+    desktop.with_name("nebula-core").touch()
+    monkeypatch.setattr(sys, "argv", ["crash-check", str(desktop)])
     process = Mock(pid=654321)
     process.poll.return_value = None
     launch = Mock(return_value=process)
-    monkeypatch.setattr(cleanup.subprocess, 'Popen', launch)
+    monkeypatch.setattr(cleanup.subprocess, "Popen", launch)
     scans = Mock(side_effect=[[123456], final_matches])
-    monkeypatch.setattr(cleanup, 'matching_core_processes', scans)
+    monkeypatch.setattr(cleanup, "matching_core_processes", scans)
     ticks = iter([0, 0, 0, 16])
-    monkeypatch.setattr(cleanup.time, 'monotonic', lambda: next(ticks))
+    monkeypatch.setattr(cleanup.time, "monotonic", lambda: next(ticks))
     kill = Mock()
-    monkeypatch.setattr(cleanup.os, 'kill', kill)
+    monkeypatch.setattr(cleanup.os, "kill", kill)
 
     if final_matches:
-        with pytest.raises(RuntimeError, match='orphaned Nebula Core'):
+        with pytest.raises(RuntimeError, match="orphaned Nebula Core"):
             cleanup.main()
         assert kill.call_count == 2
     else:
         assert cleanup.main() == 0
         kill.assert_called_once_with(process.pid, cleanup.signal.SIGKILL)
-    assert launch.call_args.kwargs['start_new_session'] is True
+    assert launch.call_args.kwargs["start_new_session"] is True
     assert all(call.args[1] == process.pid for call in scans.call_args_list)
 
 
-@pytest.mark.skipif(not Path('/proc/self/environ').exists(), reason='Linux procfs required')
+@pytest.mark.skipif(
+    not Path("/proc/self/environ").exists(), reason="Linux procfs required"
+)
 def test_crash_check_runs_with_isolated_session(tmp_path):
     """Exercise launch, session inheritance, SIGKILL, and observed child exit."""
-    core = tmp_path / 'nebula-core'
+    core = tmp_path / "nebula-core"
     core.symlink_to(sys.executable)
-    desktop = tmp_path / 'nebula-ui'
+    desktop = tmp_path / "nebula-ui"
     desktop.write_text(
-        f'#!{sys.executable}\n'
-        'import os, subprocess, time\n'
-        f'core = {str(core)!r}\n'
-        'parent = os.getpid()\n'
+        f"#!{sys.executable}\n"
+        "import os, subprocess, time\n"
+        f"core = {str(core)!r}\n"
+        "parent = os.getpid()\n"
         'code = f"import os,time\\nwhile os.getppid() == {parent}: time.sleep(0.01)"\n'
         'subprocess.Popen([core, "-c", code, "serve"], env={}, process_group=0)\n'
-        'time.sleep(30)\n'
+        "time.sleep(30)\n"
     )
     desktop.chmod(0o755)
     result = subprocess.run(
         [sys.executable, str(Path(cleanup.__file__).resolve()), str(desktop)],
-        capture_output=True, text=True, timeout=20,
+        capture_output=True,
+        text=True,
+        timeout=20,
     )
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
The packaged desktop crash check could attach to and kill an unrelated Core using the same executable. Launch the test desktop in its own OS session and restrict Core discovery and cleanup to that session. Session identity survives the launcher's cleared environment and separate Core process group.

Also accept a successful exit when the final deadline scan finds no remaining Core, instead of reporting an orphan with an empty PID list.

Validation: 5 focused tests passed (crash-check regressions and release SBOM), Ruff passed, and git diff --check passed. Includes real Linux subprocess isolation and an end-to-end script fixture that clears the child environment and creates a separate process group. The deadline regression reproduced the previous empty-list failure. Packaged desktop crash behavior was not rerun; this change validates the release checker, not the packaged product's lifecycle. No interface changes.
