### PR TITLE
Fix Secret Service health stall

### DIFF
--- a/src/nebula/v3/credentials.py
+++ b/src/nebula/v3/credentials.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .diagnostics import record_caught_exception
 
 import os
+from contextlib import closing
 import re
 from dataclasses import dataclass
 from typing import Literal, Protocol, cast
@@ -215,6 +216,11 @@ class CredentialStore:
         if self.keyring_backend is None or not self.vault_available:
             return None
         try:
+            if type(self.keyring_backend).__module__ == "keyring.backends.SecretService":
+                from keyring.backends.SecretService import Keyring
+
+                if isinstance(self.keyring_backend, Keyring):
+                    return self._secret_service_value(reference)
             return self.keyring_backend.get_password(
                 _SERVICE_NAME, reference.removeprefix("vault:")
             )
@@ -227,6 +233,34 @@ class CredentialStore:
                 stage="credentials",
             )
             return None
+
+    def _secret_service_value(self, reference: str) -> str | None:
+        """Read an existing Linux vault without ever prompting to unlock/create it.
+
+        Status is also called by async API endpoints. SecretService's ordinary
+        get_password can wait indefinitely for a desktop unlock prompt there.
+        Locked collections/items must instead report unavailable.
+        """
+        import secretstorage
+
+        backend = self.keyring_backend
+        with closing(secretstorage.dbus_init()) as connection:
+            preferred = getattr(backend, "preferred_collection", None)
+            collection = (
+                secretstorage.Collection(connection, preferred)
+                if preferred is not None
+                else secretstorage.get_collection_by_alias(connection, "default")
+            )
+            if collection.is_locked():
+                return None
+            query = backend._query(  # type: ignore[union-attr]
+                _SERVICE_NAME, reference.removeprefix("vault:")
+            )
+            for item in collection.search_items(query):
+                if item.is_locked():
+                    return None
+                return item.get_secret().decode("utf-8")
+        return None
 
     @staticmethod
     def _validate_reference(reference: str) -> None:

--- a/src/nebula/v3/credentials.py
+++ b/src/nebula/v3/credentials.py
@@ -12,6 +12,8 @@ from typing import Literal, Protocol, cast
 from uuid import uuid4
 
 import keyring
+import secretstorage
+from keyring.backends.SecretService import Keyring
 from pydantic import SecretStr, field_validator
 
 from .domain import NebulaModel
@@ -216,9 +218,10 @@ class CredentialStore:
         if self.keyring_backend is None or not self.vault_available:
             return None
         try:
-            if type(self.keyring_backend).__module__ == "keyring.backends.SecretService":
-                from keyring.backends.SecretService import Keyring
-
+            if (
+                type(self.keyring_backend).__module__
+                == "keyring.backends.SecretService"
+            ):
                 if isinstance(self.keyring_backend, Keyring):
                     return self._secret_service_value(reference)
             return self.keyring_backend.get_password(
@@ -241,8 +244,6 @@ class CredentialStore:
         get_password can wait indefinitely for a desktop unlock prompt there.
         Locked collections/items must instead report unavailable.
         """
-        import secretstorage
-
         backend = self.keyring_backend
         with closing(secretstorage.dbus_init()) as connection:
             preferred = getattr(backend, "preferred_collection", None)

--- a/tests/v3/test_credentials.py
+++ b/tests/v3/test_credentials.py
@@ -170,23 +170,33 @@ def test_credential_api_is_write_only_and_persists_only_opaque_reference(tmp_pat
     assert b"never-persist-this" not in database_path.read_bytes()
 
 
-@pytest.mark.parametrize("collection_locked,item_locked,expected", [
-    (True, False, None), (False, True, None), (False, False, "test-secret"),
-])
-def test_linux_vault_reads_never_prompt(monkeypatch, collection_locked, item_locked, expected):
+@pytest.mark.parametrize(
+    "collection_locked,item_locked,expected",
+    [
+        (True, False, None),
+        (False, True, None),
+        (False, False, "test-secret"),
+    ],
+)
+def test_linux_vault_reads_never_prompt(
+    monkeypatch, collection_locked, item_locked, expected
+):
     import secretstorage
     from keyring.backends.SecretService import Keyring
 
     class Connection:
         closed = False
+
         def close(self):
             self.closed = True
 
     class Item:
         def is_locked(self):
             return item_locked
+
         def unlock(self):
             pytest.fail("must not prompt to unlock an item")
+
         def get_secret(self):
             assert not item_locked
             return b"test-secret"
@@ -194,16 +204,22 @@ def test_linux_vault_reads_never_prompt(monkeypatch, collection_locked, item_loc
     class Collection:
         def is_locked(self):
             return collection_locked
+
         def unlock(self):
             pytest.fail("must not prompt to unlock a collection")
+
         def search_items(self, query):
             assert not collection_locked
             return [Item()]
 
     connection = Connection()
     monkeypatch.setattr(secretstorage, "dbus_init", lambda: connection)
-    monkeypatch.setattr(secretstorage, "get_collection_by_alias", lambda *_: Collection())
-    monkeypatch.setattr(Keyring, "get_password", lambda *_: pytest.fail("interactive read used"))
+    monkeypatch.setattr(
+        secretstorage, "get_collection_by_alias", lambda *_: Collection()
+    )
+    monkeypatch.setattr(
+        Keyring, "get_password", lambda *_: pytest.fail("interactive read used")
+    )
     monkeypatch.setattr(CredentialStore, "vault_available", property(lambda _: True))
     store = CredentialStore(Keyring())
     assert store._vault_value("vault:" + "a" * 32) == expected

--- a/tests/v3/test_credentials.py
+++ b/tests/v3/test_credentials.py
@@ -168,3 +168,43 @@ def test_credential_api_is_write_only_and_persists_only_opaque_reference(tmp_pat
         assert removed.status_code == 204
 
     assert b"never-persist-this" not in database_path.read_bytes()
+
+
+@pytest.mark.parametrize("collection_locked,item_locked,expected", [
+    (True, False, None), (False, True, None), (False, False, "test-secret"),
+])
+def test_linux_vault_reads_never_prompt(monkeypatch, collection_locked, item_locked, expected):
+    import secretstorage
+    from keyring.backends.SecretService import Keyring
+
+    class Connection:
+        closed = False
+        def close(self):
+            self.closed = True
+
+    class Item:
+        def is_locked(self):
+            return item_locked
+        def unlock(self):
+            pytest.fail("must not prompt to unlock an item")
+        def get_secret(self):
+            assert not item_locked
+            return b"test-secret"
+
+    class Collection:
+        def is_locked(self):
+            return collection_locked
+        def unlock(self):
+            pytest.fail("must not prompt to unlock a collection")
+        def search_items(self, query):
+            assert not collection_locked
+            return [Item()]
+
+    connection = Connection()
+    monkeypatch.setattr(secretstorage, "dbus_init", lambda: connection)
+    monkeypatch.setattr(secretstorage, "get_collection_by_alias", lambda *_: Collection())
+    monkeypatch.setattr(Keyring, "get_password", lambda *_: pytest.fail("interactive read used"))
+    monkeypatch.setattr(CredentialStore, "vault_available", property(lambda _: True))
+    store = CredentialStore(Keyring())
+    assert store._vault_value("vault:" + "a" * 32) == expected
+    assert connection.closed


### PR DESCRIPTION
## Summary
- avoid interactive Secret Service unlock prompts during credential status reads
- fail closed when a collection or item is locked
- cover locked collection, locked item, and available-secret behavior

## Root cause
The VPN profile listing performs credential availability checks on the FastAPI event-loop thread. SecretService.get_password() attempted an unlock prompt and waited indefinitely on D-Bus, starving all Core HTTP endpoints, including health.

## Validation
- PYTHONPATH=/home/agent/nebula-live-2b77184/src /home/agent/nebula/.venv/bin/pytest -q tests/v3/test_credentials.py (9 passed)
- authenticated /api/v1/health: HTTP 200
- authenticated /api/v1/vpn-profiles: HTTP 200
- production UI over 127.0.0.1 and both LAN interfaces: HTTP 200