### PR TITLE
Fix managed browser loading and add app-wide icon tooltips

### DIFF
--- a/docs/quality/browser-load-input.md
+++ b/docs/quality/browser-load-input.md
@@ -1,0 +1,24 @@
+# Browser loading and direct input
+
+Journey: remote Mac > Workbench > Browser > navigate > see live page > click a field and type > reconnect/reload. Remove the separate Page keyboard form. Core owns identities and sessions; browserd owns the page; the UI owns transient input focus. Preserve scope, authentication, protected values, and explicit mutation approval.
+
+| Step | Invariant | Authority | Test |
+| --- | --- | --- | --- |
+| Discover/use | No separate keyboard form; focused stream accepts hardware text/keys | UI, host page | component + production browser |
+| Navigate | Core waits for a bounded browser operation; slow successful navigation is not reported failed after five seconds | Core/browserd | delayed real HTTP + real Core |
+| Failure/retry | Timeout has an actionable safe message; no automatic replay | browserd/Core | API/component |
+| Stream/reconnect | Missing upstream tab closes recoverably, not an unhandled exception | Core/browserd | websocket/API + real Core |
+| Refresh/select | Existing identity/conversation survive | Core/URL | existing real Core workflow |
+| Delete/revoke | Existing scope and revocation behavior stays authoritative | Core | existing browser tests |
+
+Production LAN Chromium desktop/compact and mobile Chromium/WebKit checks cover the removed control and retained focus. Physical Mac/iPhone evidence must be reported separately from emulation. No new session creation/deletion semantics or assistant streaming semantics are introduced.
+
+Diagnosis: live Core returned HTTP 500 after about five seconds while browserd later exhausted its 20-second navigation timeout. Isolated Chromium 149 navigation to Google succeeds directly; authenticated BrowserHostProxy navigation stalls with HTTP/2 and succeeds with HTTP/1.1. IPv4/IPv6 TCP/TLS and curl through the authenticated proxy succeed. Chromium netlog shows the page request cancelled before HTTP/2 request headers; the upstream Chromium/Playwright root cause is not established. The compatibility restriction applies only to Core's built-in managed browser, retaining authentication, TLS and scope enforcement. External browserd configurations keep their protocol settings. HTTP/2-specific behavior is not supported by this built-in path while the workaround remains.
+
+Companion operations now have a 30-second total browserd budget and a 35-second Core read budget; health checks keep their short deadline. Timeout failures are sanitized and actionable, and no mutation is replayed. Rejected upstream stream handshakes close recoverably.
+
+## Icon explanations
+
+All app surfaces share a tooltip layer, including lazy screens, dialogs and disabled controls. Labels come from existing titles and accessible names; themes remain the styling authority. Hover and keyboard focus expose the explanation, Escape and leaving the control dismiss it, and the fixed overlay stays inside the viewport. The native title is temporarily suppressed to avoid two competing popups. Touch input is not intercepted. Tests cover name/description preservation, dynamic controls and absence of unnamed icons in the 24-screen production audit.
+
+Evidence logs: `/tmp/nebula-load-unit.log`, `/tmp/nebula-load-ui-unit.log`, `/tmp/nebula-load-ui-matrix.log`, `/tmp/nebula-google-core.log`, `/tmp/nebula-load-core-ui.log`. Final counts and deployment identity are recorded in the pull request. No physical Mac or phone test is claimed from Linux browser emulation.

--- a/scripts/smoke_test_managed_browser_navigation.py
+++ b/scripts/smoke_test_managed_browser_navigation.py
@@ -1,0 +1,105 @@
+"""Read-only public-page navigation through an isolated authenticated Core host.
+
+Run with PYTHONPATH=src, PLAYWRIGHT_BROWSERS_PATH, and an available display.
+No existing profile, project, credentials or page state is used.
+"""
+
+import asyncio
+import base64
+import json
+import secrets
+import socket
+import tempfile
+from pathlib import Path
+
+import httpx
+import uvicorn
+from websockets.asyncio.client import connect
+
+from nebula.v3.api import create_app
+from nebula.v3.domain import Engagement, ScopePolicy
+from nebula.v3.storage import NebulaStore
+
+
+async def main():
+    with tempfile.TemporaryDirectory(prefix="nebula-navigation-") as directory:
+        store = NebulaStore(Path(directory) / "core.db")
+        project = store.create(Engagement(name="Isolated public navigation"))
+        scope = store.create(
+            ScopePolicy(
+                engagement_id=project.id,
+                allowed_domains=[
+                    "google.com",
+                    "*.google.com",
+                    "gstatic.com",
+                    "*.gstatic.com",
+                ],
+            )
+        )
+        store.update(Engagement, project.id, {"scope_policy_id": scope.id})
+        token = secrets.token_urlsafe(32)
+        app = create_app(store, auth_token=token)
+        listener = socket.socket()
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(128)
+        listener.setblocking(False)
+        port = listener.getsockname()[1]
+        server = uvicorn.Server(uvicorn.Config(app, log_level="error"))
+        task = asyncio.create_task(server.serve(sockets=[listener]))
+        try:
+            async with asyncio.timeout(10):
+                while not server.started:
+                    await asyncio.sleep(0.05)
+            async with httpx.AsyncClient(
+                base_url=f"http://127.0.0.1:{port}",
+                timeout=40,
+                headers={"Authorization": f"Bearer {token}"},
+            ) as client:
+                opened = await client.post(
+                    f"/api/v1/engagements/{project.id}/browser-companion"
+                )
+                opened.raise_for_status()
+                session = opened.json()
+                endpoint = f"/api/v1/browser-companion/{session['session_id']}"
+                result = await client.post(
+                    endpoint + "/operations",
+                    json={
+                        "operation": "navigate",
+                        "tab_id": session["active_tab_id"],
+                        "url": "https://google.com/",
+                    },
+                )
+                result.raise_for_status()
+                assert result.json()["page_revision"]
+                encoded = base64.urlsafe_b64encode(token.encode()).decode().rstrip("=")
+                url = f"ws://127.0.0.1:{port}{endpoint}/tabs/{session['active_tab_id']}/stream"
+                for _ in range(2):
+                    async with connect(
+                        url,
+                        subprotocols=["nebula.browser.v1", "nebula.auth." + encoded],
+                        max_size=8 * 1024 * 1024,
+                    ) as stream:
+                        async with asyncio.timeout(15):
+                            frame = json.loads(await stream.recv())
+                            assert (
+                                frame.get("data")
+                                or frame.get("image")
+                                or frame.get("type")
+                            )
+                print(
+                    json.dumps(
+                        {
+                            "state": "passed",
+                            "navigation": "https://google.com/",
+                            "stream_and_reconnect": True,
+                        }
+                    )
+                )
+        finally:
+            server.should_exit = True
+            await task
+            listener.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -9676,7 +9676,7 @@ def create_app(
         import base64
         from urllib.parse import quote
         from websockets.asyncio.client import connect
-        from websockets.exceptions import ConnectionClosed
+        from websockets.exceptions import ConnectionClosed, InvalidHandshake
         from websockets.typing import Subprotocol
 
         protocols = [
@@ -9754,7 +9754,13 @@ def create_app(
                     sender.cancel()
                     receiver.cancel()
                     await asyncio.gather(sender, receiver, return_exceptions=True)
-        except (ValueError, OSError, ConnectionClosed, WebSocketDisconnect):
+        except (
+            ValueError,
+            OSError,
+            ConnectionClosed,
+            InvalidHandshake,
+            WebSocketDisconnect,
+        ):
             # diagnostic-expected: detached viewers do not terminate the host browser.
             if websocket.client_state.name != "DISCONNECTED":
                 await websocket.close(

--- a/src/nebula/v3/browser_companion.py
+++ b/src/nebula/v3/browser_companion.py
@@ -15,6 +15,7 @@ from weakref import WeakKeyDictionary, ref
 from urllib.parse import quote
 from uuid import uuid4
 
+import httpx
 from pydantic import Field, SecretStr
 
 from .browser_engine import BrowserEngineRegistry, LocalBrowserdAdapter
@@ -485,11 +486,24 @@ class BrowserCompanion:
                     )
                 payload["text"] = protected[request.credential_ref]
             payload["protected_values"] = list(protected.values())
-            response = await adapter._request(
-                "POST",
-                "/v1/companion/" + quote(session.identity_id, safe=""),
-                payload,
-            )
+            try:
+                response = await adapter._request(
+                    "POST",
+                    "/v1/companion/" + quote(session.identity_id, safe=""),
+                    payload,
+                )
+            except httpx.TimeoutException as exc:
+                raise ValueError(
+                    "The host browser did not respond in time. Reconnect to check its current page before retrying; no action was replayed."
+                ) from exc
+            except httpx.TransportError as exc:
+                raise ValueError(
+                    "The host browser connection ended. Reconnect to restore the view; your conversation is saved."
+                ) from exc
+            if response.is_error and response.status_code == 504:
+                raise ValueError(
+                    "The host browser timed out loading or reading the page. Check the page and retry; no action was replayed."
+                )
             if response.is_error:
                 raise ValueError(
                     "The browser operation could not complete. Refresh the page context and retry; no action is replayed automatically."

--- a/src/nebula/v3/browser_engine.py
+++ b/src/nebula/v3/browser_engine.py
@@ -97,6 +97,9 @@ class BrowserEngineAdapter(ABC):
         raise NotImplementedError
 
 
+BROWSER_COMPANION_OPERATION_TIMEOUT_SECONDS = 30.0
+
+
 class LocalBrowserdAdapter(BrowserEngineAdapter):
     """Authenticated loopback client for the desktop-owned managed Chromium process."""
 
@@ -139,6 +142,12 @@ class LocalBrowserdAdapter(BrowserEngineAdapter):
     async def _request(
         self, method: str, path: str, payload: dict[str, Any] | None = None
     ) -> httpx.Response:
+        # Navigation plus capture outlives the short readiness/lifecycle budget.
+        timeout = (
+            max(self._timeout, BROWSER_COMPANION_OPERATION_TIMEOUT_SECONDS + 5)
+            if path.startswith("/v1/companion/")
+            else self._timeout
+        )
         headers = {
             "Authorization": f"Bearer {self._token}",
             "Accept": "application/json",
@@ -149,10 +158,10 @@ class LocalBrowserdAdapter(BrowserEngineAdapter):
                 f"{self.base_url}{path}",
                 headers=headers,
                 json=payload,
-                timeout=self._timeout,
+                timeout=timeout,
             )
         else:
-            async with httpx.AsyncClient(timeout=self._timeout) as client:
+            async with httpx.AsyncClient(timeout=timeout) as client:
                 response = await client.request(
                     method,
                     f"{self.base_url}{path}",

--- a/src/nebula/v3/browser_host.py
+++ b/src/nebula/v3/browser_host.py
@@ -87,6 +87,9 @@ class ManagedBrowserHost:
                     profile_root=self.root / "profiles",
                     policy_proxy_url=fallback_config["server"],
                     runtime_root=runtime,
+                    # Chromium 149 stalls authenticated proxy navigation with HTTP/2.
+                    # Keep this compatibility restriction local to the built-in proxy.
+                    http1_only=True,
                 )
                 manager = BrowserdManager(
                     settings, proxy_for_identity=self._identity_proxy

--- a/src/nebula/v3/browserd.py
+++ b/src/nebula/v3/browserd.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 
 from fastapi import Depends, FastAPI, Header, HTTPException, WebSocket
 from fastapi.websockets import WebSocketDisconnect
-from playwright.async_api import async_playwright
+from playwright.async_api import async_playwright, TimeoutError as BrowserTimeoutError
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
 import uvicorn
 
@@ -33,6 +33,7 @@ from .browser_companion_runtime import operate as companion_operate
 
 from .browser_engine import (
     BROWSER_ENGINE_CONTRACT_VERSION,
+    BROWSER_COMPANION_OPERATION_TIMEOUT_SECONDS,
     BrowserEngineAction,
     BrowserEngineReceipt,
 )
@@ -131,6 +132,7 @@ class BrowserdSettings:
     runtime_root: Path
     upload_root: Path | None = None
     headless: bool = False
+    http1_only: bool = False
 
     def __post_init__(self) -> None:
         if not self.token or any(character.isspace() for character in self.token):
@@ -417,6 +419,7 @@ class BrowserdManager:
                     args=[
                         "--proxy-bypass-list=<-loopback>",
                         "--disable-quic",
+                        *(["--disable-http2"] if self.settings.http1_only else []),
                         "--force-webrtc-ip-handling-policy=disable_non_proxied_udp",
                     ],
                     accept_downloads=True,
@@ -740,12 +743,18 @@ def create_browserd_app(
                         )
                     known.append(value)
                     values.add(value.get_secret_value())
-            result = await companion_operate(
-                runtime,
-                identity_id,
-                request.model_copy(update={"protected_values": list(known)}),
-            )
+            async with asyncio.timeout(BROWSER_COMPANION_OPERATION_TIMEOUT_SECONDS):
+                result = await companion_operate(
+                    runtime,
+                    identity_id,
+                    request.model_copy(update={"protected_values": list(known)}),
+                )
             return BrowserCompanion.redact_result(result, list(values))
+        except (TimeoutError, BrowserTimeoutError) as exc:
+            raise HTTPException(
+                status_code=504,
+                detail="The host browser timed out. Check the page, then retry; no action was replayed.",
+            ) from exc
         except ValueError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
 

--- a/tests/v3/test_browser_companion.py
+++ b/tests/v3/test_browser_companion.py
@@ -154,7 +154,9 @@ def test_real_chromium_capture_redacts_fields_and_rejects_changed_document():
 
     async def run():
         async with async_playwright() as playwright:
-            browser = await playwright.chromium.launch(headless=True)
+            browser = await playwright.chromium.launch(
+                headless=True, executable_path=playwright.chromium.executable_path
+            )
             try:
                 context = await browser.new_context()
                 page = await context.new_page()
@@ -241,6 +243,7 @@ def test_real_core_requires_auth_and_reports_absent_browser_runtime(
 
     monkeypatch.delenv("NEBULA_BROWSERD_URL", raising=False)
     monkeypatch.delenv("NEBULA_BROWSERD_TOKEN", raising=False)
+    monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
     store = NebulaStore(tmp_path / "core.db")
     client = TestClient(create_app(store, auth_token="test-token"))
     headers = {"Authorization": "Bearer test-token"}
@@ -811,3 +814,31 @@ def test_background_tab_poll_preserves_lost_state_until_navigation(
         assert (await service.open(project.id))["page_state_reset"] is False
 
     asyncio.run(run())
+
+
+@pytest.mark.parametrize("failure", ["transport", "timeout", "page_timeout"])
+def test_host_failure_explains_recovery_without_replaying(
+    tmp_path, monkeypatch, failure
+):
+    import httpx
+
+    _, _, _, session, service = setup(tmp_path)
+    calls = []
+
+    class Adapter:
+        async def _request(self, *args):
+            calls.append(args)
+            if failure == "transport":
+                raise httpx.ConnectError("private endpoint")
+            if failure == "timeout":
+                raise httpx.ReadTimeout("private endpoint")
+            return httpx.Response(504, json={"detail": "private upstream details"})
+
+    async def adapter():
+        return Adapter()
+
+    monkeypatch.setattr(service, "adapter", adapter)
+    with pytest.raises(ValueError, match="[Rr]econnect|[Rr]etry") as error:
+        asyncio.run(service.request(session.id, CompanionRequest(operation="tabs")))
+    assert len(calls) == 1
+    assert "private" not in str(error.value)

--- a/tests/v3/test_browser_engine.py
+++ b/tests/v3/test_browser_engine.py
@@ -120,3 +120,32 @@ def test_registry_discovers_configured_browserd_without_exposing_token(monkeypat
     registry = BrowserEngineRegistry()
     assert len(registry._adapters) == 1
     assert isinstance(registry._adapters[0], LocalBrowserdAdapter)
+
+
+def test_companion_navigation_outlives_the_health_check_deadline():
+    async def exercise():
+        async def slow_page(reader, writer):
+            await reader.readuntil(b"\r\n\r\n")
+            await asyncio.sleep(5.2)
+            writer.write(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}"
+            )
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+
+        server = await asyncio.start_server(slow_page, "127.0.0.1", 0)
+        try:
+            adapter = LocalBrowserdAdapter(
+                f"http://127.0.0.1:{server.sockets[0].getsockname()[1]}", "test-token"
+            )
+            response = await adapter._request(
+                "POST", "/v1/companion/identity", {"operation": "navigate"}
+            )
+            assert response.status_code == 200
+            assert adapter._timeout == 5.0  # readiness keeps its short deadline
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    asyncio.run(exercise())

--- a/tests/v3/test_browserd.py
+++ b/tests/v3/test_browserd.py
@@ -229,3 +229,31 @@ def test_browserd_readiness_requires_manifest_bound_full_chromium(tmp_path):
     assert capability.state == BrowserEngineState.READY
     assert capability.digest == f"sha256:{executable_sha256}"
     assert "cdp-screencast" in capability.protocols
+
+
+def test_companion_page_timeout_is_sanitized_and_not_an_unhandled_500(
+    tmp_path, monkeypatch
+):
+    from nebula.v3 import browserd
+    from playwright.async_api import TimeoutError as BrowserTimeoutError
+
+    configured = settings(tmp_path)
+    manager = BrowserdManager(configured)
+
+    async def timed_out(*args):
+        raise BrowserTimeoutError("private page URL and protected contents")
+
+    monkeypatch.setattr(browserd, "companion_operate", timed_out)
+    client = TestClient(create_browserd_app(configured, manager=manager))
+    response = client.post(
+        "/v1/companion/identity",
+        headers={"Authorization": "Bearer opaque-browserd-token"},
+        json={"operation": "navigate", "url": "https://example.test/", "tab_id": "tab"},
+    )
+    assert response.status_code == 504
+    assert "retry" in response.json()["detail"]
+    assert "private" not in response.text
+    assert (
+        client.post("/v1/companion/identity", json={"operation": "tabs"}).status_code
+        == 401
+    )

--- a/ui/src/browser-assistant.css
+++ b/ui/src/browser-assistant.css
@@ -44,8 +44,6 @@
 }
 
 .managed-browser-region { position: absolute; pointer-events: none; border: 2px solid #84caff; background: #84caff33; box-sizing: border-box; }
-.managed-browser-keyboard label { display: flex; flex-direction: column; }
-.managed-browser-keyboard textarea { min-height: 80px; width: 100%; box-sizing: border-box; }
 
 @media (pointer: coarse) and (max-height: 500px) {
   .main-content:has(> .sessions-page.screen-fit > .session-layout.browser) { overflow-y: auto; }

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -2431,4 +2431,4 @@ button.harness-status-summary:focus-visible { outline: 2px solid var(--focus); o
 .quiet-icon-action[aria-pressed="true"] { color: var(--blue); background: var(--blue-muted); }
 .quiet-icon-action:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
 
-.action-tooltip { position: fixed; z-index: 10000; max-width: min(280px, calc(100vw - 16px)); padding: 7px 10px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); color: var(--text); box-shadow: 0 4px 16px #0003; font-size: 12px; line-height: 1.4; font-weight: 400; overflow-wrap: anywhere; pointer-events: none; }
+.action-tooltip { position: fixed; z-index: 10000; max-width: min(280px, calc(100vw - 16px)); padding: 7px 10px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); color: var(--text); box-shadow: 0 4px 16px #0003; font-size: 12px; line-height: 1.4; font-weight: 400; overflow-wrap: anywhere; pointer-events: auto; }

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -2430,3 +2430,5 @@ button.harness-status-summary:focus-visible { outline: 2px solid var(--focus); o
 .quiet-icon-action.icon-button, .quiet-icon-action.button { display: inline-flex; align-items: center; justify-content: center; flex: 0 0 44px; min-width: 44px; width: 44px; min-height: 44px; height: 44px; padding: 0; border-radius: 10px; }
 .quiet-icon-action[aria-pressed="true"] { color: var(--blue); background: var(--blue-muted); }
 .quiet-icon-action:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
+
+.action-tooltip { position: fixed; z-index: 10000; max-width: min(280px, calc(100vw - 16px)); padding: 7px 10px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); color: var(--text); box-shadow: 0 4px 16px #0003; font-size: 12px; line-height: 1.4; font-weight: 400; overflow-wrap: anywhere; pointer-events: none; }

--- a/ui/src/components/ActionTooltips.test.tsx
+++ b/ui/src/components/ActionTooltips.test.tsx
@@ -36,6 +36,23 @@ describe("ActionTooltips", () => {
     act(() => vi.advanceTimersByTime(200));
     expect(screen.getByRole("tooltip")).toHaveTextContent("New conversation");
     fireEvent.pointerOut(screen.getByRole("button"));
+    act(() => vi.advanceTimersByTime(120));
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
+  it("preserves title-only accessible names and stays visible when hovered", () => {
+    vi.useFakeTimers();
+    render(<><button title="Close panel"><svg /></button><ActionTooltips /></>);
+    const button = screen.getByRole("button", { name: "Close panel" });
+    fireEvent.pointerOver(button);
+    act(() => vi.advanceTimersByTime(200));
+    expect(screen.getByRole("button", { name: "Close panel" })).toBe(button);
+    fireEvent.pointerOut(button);
+    fireEvent.pointerOver(screen.getByRole("tooltip"));
+    act(() => vi.advanceTimersByTime(150));
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Close panel");
+    fireEvent.keyDown(button, { key: "Escape" });
+    expect(button).toHaveAttribute("title", "Close panel");
+    expect(button).not.toHaveAttribute("aria-label");
+  });
+
 });

--- a/ui/src/components/ActionTooltips.test.tsx
+++ b/ui/src/components/ActionTooltips.test.tsx
@@ -1,0 +1,41 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ActionTooltips } from "./ActionTooltips";
+
+afterEach(() => vi.useRealTimers());
+
+describe("ActionTooltips", () => {
+  it("explains an icon on hover, avoids duplicate native titles, and dismisses on Escape", () => {
+    vi.useFakeTimers();
+    render(<><button aria-label="Attach files" title="Attach files"><svg /></button><ActionTooltips /></>);
+    const button = screen.getByRole("button");
+    fireEvent.pointerOver(button, { pointerType: "mouse" });
+    act(() => vi.advanceTimersByTime(200));
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Attach files");
+    expect(button).toHaveAttribute("aria-describedby", screen.getByRole("tooltip").id);
+    expect(button).not.toHaveAttribute("title");
+    fireEvent.keyDown(button, { key: "Escape" });
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(button).toHaveAttribute("title", "Attach files");
+    expect(button).not.toHaveAttribute("aria-describedby");
+  });
+  it("supports keyboard focus and restores existing descriptions", () => {
+    render(<><p id="help">Saved conversation</p><button aria-label="Results" aria-describedby="help"><svg /></button><ActionTooltips /></>);
+    const button = screen.getByRole("button");
+    fireEvent.focusIn(button);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Results");
+    fireEvent.focusOut(button);
+    expect(button).toHaveAttribute("aria-describedby", "help");
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+  it("covers disabled controls added by lazy screens and does not intercept input", () => {
+    vi.useFakeTimers();
+    const view = render(<ActionTooltips />);
+    view.rerender(<><button disabled aria-label="New conversation"><svg /></button><ActionTooltips /></>);
+    fireEvent.pointerOver(screen.getByRole("button"), { pointerType: "mouse" });
+    act(() => vi.advanceTimersByTime(200));
+    expect(screen.getByRole("tooltip")).toHaveTextContent("New conversation");
+    fireEvent.pointerOut(screen.getByRole("button"));
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ActionTooltips.tsx
+++ b/ui/src/components/ActionTooltips.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+const controls = "button, a, summary, [role=button], [role=tab]";
+
+/** One tooltip layer also covers lazy screens, dialogs and disabled icon buttons. */
+export function ActionTooltips() {
+  const id = useId();
+  const [active, setActive] = useState<{ anchor: HTMLElement; text: string } | null>(null);
+  const tip = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    let anchor: HTMLElement | null = null;
+    let originalTitle: string | null = null;
+    let originalDescription: string | null = null;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let touch = false;
+    const hide = () => {
+      clearTimeout(timer);
+      if (anchor) {
+        if (originalTitle !== null) anchor.setAttribute("title", originalTitle);
+        if (originalDescription === null) anchor.removeAttribute("aria-describedby");
+        else anchor.setAttribute("aria-describedby", originalDescription);
+      }
+      anchor = null;
+      setActive(null);
+    };
+    const show = (target: EventTarget | null, immediate = false) => {
+      const next = target instanceof Element ? target.closest<HTMLElement>(controls) : null;
+      if (next === anchor) return;
+      hide();
+      if (!next) return;
+      const text = next.getAttribute("title") || next.getAttribute("aria-label") ||
+        (next.getAttribute("aria-labelledby") || "").split(/\s+/).map(label => document.getElementById(label)?.textContent || "").join(" ").trim();
+      if (!text) return;
+      anchor = next;
+      originalTitle = next.getAttribute("title");
+      originalDescription = next.getAttribute("aria-describedby");
+      // Suppress the delayed native popup while the app tooltip is responsible.
+      next.removeAttribute("title");
+      const reveal = () => {
+        if (!next.isConnected || anchor !== next) return;
+        next.setAttribute("aria-describedby", [originalDescription, id].filter(Boolean).join(" "));
+        setActive({ anchor: next, text });
+      };
+      if (immediate) reveal();
+      else timer = setTimeout(reveal, 200);
+    };
+    const over = (event: PointerEvent) => { touch = event.pointerType === "touch"; if (!touch) show(event.target); };
+    const out = (event: PointerEvent) => {
+      if (anchor && event.relatedTarget instanceof Node && anchor.contains(event.relatedTarget)) return;
+      hide();
+    };
+    const focus = (event: FocusEvent) => { if (!touch) show(event.target, true); };
+    const key = (event: KeyboardEvent) => { touch = false; if (event.key === "Escape") hide(); };
+    document.addEventListener("pointerover", over, true);
+    document.addEventListener("pointerout", out, true);
+    document.addEventListener("pointerdown", hide, true);
+    document.addEventListener("focusin", focus, true);
+    document.addEventListener("focusout", hide, true);
+    document.addEventListener("keydown", key, true);
+    document.addEventListener("scroll", hide, true);
+    window.addEventListener("resize", hide);
+    return () => {
+      hide();
+      document.removeEventListener("pointerover", over, true);
+      document.removeEventListener("pointerout", out, true);
+      document.removeEventListener("pointerdown", hide, true);
+      document.removeEventListener("focusin", focus, true);
+      document.removeEventListener("focusout", hide, true);
+      document.removeEventListener("keydown", key, true);
+      document.removeEventListener("scroll", hide, true);
+      window.removeEventListener("resize", hide);
+    };
+  }, [id]);
+  useLayoutEffect(() => {
+    if (!active || !tip.current) return;
+    const box = active.anchor.getBoundingClientRect();
+    const label = tip.current.getBoundingClientRect();
+    tip.current.style.left = `${Math.max(8, Math.min(innerWidth - label.width - 8, box.left + (box.width - label.width) / 2))}px`;
+    const top = box.top >= label.height + 16 ? box.top - label.height - 8 : box.bottom + 8;
+    tip.current.style.top = `${Math.max(8, Math.min(innerHeight - label.height - 8, top))}px`;
+  }, [active]);
+  return active ? createPortal(<div ref={tip} id={id} role="tooltip" className="action-tooltip">{active.text}</div>, active.anchor.closest("dialog[open]") ?? document.body) : null;
+}

--- a/ui/src/components/ActionTooltips.tsx
+++ b/ui/src/components/ActionTooltips.tsx
@@ -12,12 +12,16 @@ export function ActionTooltips() {
     let anchor: HTMLElement | null = null;
     let originalTitle: string | null = null;
     let originalDescription: string | null = null;
+    let temporaryLabel = false;
+    let hideTimer: ReturnType<typeof setTimeout> | undefined;
     let timer: ReturnType<typeof setTimeout> | undefined;
     let touch = false;
     const hide = () => {
       clearTimeout(timer);
+      clearTimeout(hideTimer);
       if (anchor) {
-        if (originalTitle !== null) anchor.setAttribute("title", originalTitle);
+        if (originalTitle !== null && !anchor.hasAttribute("title")) anchor.setAttribute("title", originalTitle);
+        if (temporaryLabel && anchor.getAttribute("aria-label") === originalTitle) anchor.removeAttribute("aria-label");
         if (originalDescription === null) anchor.removeAttribute("aria-describedby");
         else anchor.setAttribute("aria-describedby", originalDescription);
       }
@@ -25,6 +29,7 @@ export function ActionTooltips() {
       setActive(null);
     };
     const show = (target: EventTarget | null, immediate = false) => {
+      clearTimeout(hideTimer);
       const next = target instanceof Element ? target.closest<HTMLElement>(controls) : null;
       if (next === anchor) return;
       hide();
@@ -35,7 +40,9 @@ export function ActionTooltips() {
       anchor = next;
       originalTitle = next.getAttribute("title");
       originalDescription = next.getAttribute("aria-describedby");
-      // Suppress the delayed native popup while the app tooltip is responsible.
+      temporaryLabel = Boolean(originalTitle && !next.hasAttribute("aria-label") && !next.hasAttribute("aria-labelledby") && !next.innerText?.trim());
+      if (temporaryLabel) next.setAttribute("aria-label", text);
+      // Suppress the delayed native popup while preserving title-only accessible names.
       next.removeAttribute("title");
       const reveal = () => {
         if (!next.isConnected || anchor !== next) return;
@@ -45,10 +52,15 @@ export function ActionTooltips() {
       if (immediate) reveal();
       else timer = setTimeout(reveal, 200);
     };
-    const over = (event: PointerEvent) => { touch = event.pointerType === "touch"; if (!touch) show(event.target); };
+    const over = (event: PointerEvent) => {
+      clearTimeout(hideTimer);
+      if (event.target instanceof Node && tip.current?.contains(event.target)) return;
+      touch = event.pointerType === "touch";
+      if (!touch) show(event.target);
+    };
     const out = (event: PointerEvent) => {
-      if (anchor && event.relatedTarget instanceof Node && anchor.contains(event.relatedTarget)) return;
-      hide();
+      if (event.relatedTarget instanceof Node && (anchor?.contains(event.relatedTarget) || tip.current?.contains(event.relatedTarget))) return;
+      hideTimer = setTimeout(hide, 120);
     };
     const focus = (event: FocusEvent) => { if (!touch) show(event.target, true); };
     const key = (event: KeyboardEvent) => { touch = false; if (event.key === "Escape") hide(); };

--- a/ui/src/components/BrowserPageSurface.test.tsx
+++ b/ui/src/components/BrowserPageSurface.test.tsx
@@ -48,13 +48,14 @@ describe("BrowserPageSurface", () => {
       { kind: "key", type: "keyUp", key: "a", code: "KeyA", modifiers: 2 },
     ]);
   });
-  it("accepts composed text through a real editable field and clears it after sending", () => {
-    const { send } = fixture();
-    fireEvent.click(screen.getByText("Page keyboard"));
-    fireEvent.change(screen.getByLabelText("Text to type on page"), { target: { value: "Hello 世界" } });
-    expect(send).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByRole("button", { name: "Type on page" }));
-    expect(send).toHaveBeenCalledWith({ kind: "text", text: "Hello 世界" });
-    expect(screen.getByLabelText("Text to type on page")).toHaveValue("");
+  it("types directly after clicking the page without a separate keyboard panel", () => {
+    const { send, page, pointer } = fixture();
+    pointer("pointerDown", 20, 40);
+    expect(page).toHaveFocus();
+    send.mockClear();
+    fireEvent.keyDown(page, { key: "a", code: "KeyA" });
+    expect(send).toHaveBeenCalledWith({ kind: "text", text: "a" });
+    expect(screen.queryByText("Page keyboard")).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 });

--- a/ui/src/components/BrowserPageSurface.tsx
+++ b/ui/src/components/BrowserPageSurface.tsx
@@ -11,7 +11,6 @@ export function BrowserPageSurface({ frame, mode, connected, send, onCapture }: 
 }) {
   const gesture = useRef<{ start: Point; pointerId: number; touch: boolean } | undefined>(undefined);
   const [region, setRegion] = useState<{ left: number; top: number; width: number; height: number }>();
-  const [typedText, setTypedText] = useState("");
   const point = (event: React.PointerEvent<HTMLImageElement>): Point => {
     const rect = event.currentTarget.getBoundingClientRect();
     return { x: (event.clientX - rect.left) * event.currentTarget.naturalWidth / rect.width,
@@ -40,8 +39,8 @@ export function BrowserPageSurface({ frame, mode, connected, send, onCapture }: 
     <div className="managed-browser-screen">
       {frame ? <img src={frame} alt="Live shared browser page. Use Ask about page for accessible controls." draggable={false} tabIndex={0}
         onKeyDown={event => {
-          // Tab remains available to leave the stream; page focus has explicit controls below.
-          if (mode !== "browse" || event.key === "Tab" || event.nativeEvent.isComposing) return;
+          // Tab remains available to leave the stream; focus can move to surrounding browser controls.
+          if (!connected || mode !== "browse" || event.key === "Tab" || event.nativeEvent.isComposing) return;
           event.preventDefault();
           const modifiers = (event.altKey ? 1 : 0) | (event.ctrlKey ? 2 : 0) | (event.metaKey ? 4 : 0) | (event.shiftKey ? 8 : 0);
           if (event.key.length === 1 && !(modifiers & 7)) send({ kind: "text", text: event.key });
@@ -88,15 +87,5 @@ export function BrowserPageSurface({ frame, mode, connected, send, onCapture }: 
       /> : <p>The page will appear here when the managed browser connects.</p>}
       {region && <div className="managed-browser-region" aria-hidden="true" style={{ left: `${region.left}%`, top: `${region.top}%`, width: `${region.width}%`, height: `${region.height}%` }} />}
     </div>
-    <details className="managed-browser-keyboard"><summary>Page keyboard</summary>
-      <p>Tap a field on the page, then type here. Use Protected values for passwords. Tab moves focus between controls on the host page.</p>
-      <form onSubmit={event => { event.preventDefault(); if (connected && typedText) { send({ kind: "text", text: typedText }); setTypedText(""); } }}>
-        <label>Text to type on page<textarea value={typedText} onChange={event => setTypedText(event.target.value)} maxLength={2000} autoComplete="off" /></label>
-        <button className="button secondary" disabled={!connected || !typedText}>Type on page</button>
-      </form>
-      <div className="managed-browser-toolbar">{["Tab", "Enter", "Backspace", "Escape", "ArrowUp", "ArrowDown"].map(key => <button key={key} className="button quiet" disabled={!connected} onClick={() => pressKey(key)}>{key}</button>)}
-        <button className="button quiet" disabled={!connected} onClick={() => pressKey("Tab", "Tab", 8)}>Shift + Tab</button>
-      </div>
-    </details>
   </>;
 }

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from "react-router-dom";
 import "@fontsource-variable/geist/wght.css";
 import "@fontsource-variable/geist-mono/wght.css";
 import { App } from "./App";
+import { ActionTooltips } from "./components/ActionTooltips";
 import { DialogProvider } from "./components/DialogSystem";
 import { PairingGate } from "./components/PairingGate";
 import {
@@ -61,6 +62,7 @@ createRoot(root).render(
           <WorkspaceProvider>
             <DialogProvider>
               <PairingGate><App /></PairingGate>
+              <ActionTooltips />
             </DialogProvider>
           </WorkspaceProvider>
         </ThemeProvider>

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -1532,6 +1532,12 @@ test("all task workspaces keep responsive content inside its owning surface", as
   test.setTimeout(60_000);
   for (const [, route, heading] of workspaces) {
     await openWorkspace(page, route, heading);
+    const unnamedIcons = await page.locator("button, a, summary, [role=button], [role=tab]").evaluateAll(nodes => nodes.filter(node => {
+      const el = node as HTMLElement;
+      return el.getBoundingClientRect().width > 0 && el.querySelector("svg") && !el.innerText.trim() &&
+        !el.getAttribute("aria-label") && !el.getAttribute("title") && !el.getAttribute("aria-labelledby");
+    }).map(node => node.outerHTML.slice(0, 240)));
+    expect(unnamedIcons, `${name} has unexplained icon controls`).toEqual([]);
     const overflow = await page.locator("body").evaluate(() => {
       const selector = [
         ".page",
@@ -5316,8 +5322,13 @@ test(`browser Assistant stays beside the page through an answer and follow-up${d
   });
   await openWorkspace(page, "/?view=browser", "Workbench");
   await expect(page.getByLabel("Browser engine")).toHaveValue("managed");
+  await expect(page.getByText("Page keyboard", { exact: true })).toHaveCount(0);
   const toggleAssistant = page.getByRole("button", { name: "Assistant", exact: true });
   await expect(toggleAssistant).toHaveAttribute("aria-expanded", "false");
+  await toggleAssistant.hover();
+  await expect(page.getByRole("tooltip")).toHaveText("Toggle Assistant");
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("tooltip")).toHaveCount(0);
   await expect(page.getByRole("complementary", { name: "Browser Assistant", exact: true })).toHaveCount(0);
   await toggleAssistant.click();
   await expect(toggleAssistant).toHaveAttribute("aria-expanded", "true");


### PR DESCRIPTION
## Change
Remote managed-browser navigation could fail after five seconds while Chromium kept loading. Companion operations now have aligned, bounded deadlines and actionable timeout/connection errors. Core's built-in authenticated proxy uses an HTTP/1.1 compatibility setting for the reproduced Chromium 149 HTTP/2 navigation stall; external browserd configurations are unchanged. Scope, authentication, TLS verification, and no-replay behavior remain enforced. Rejected upstream stream handshakes close recoverably.

The separate Page keyboard panel is removed; clicking the streamed page retains direct hardware keyboard input. A shared, theme-aware tooltip layer explains icon controls on hover and keyboard focus throughout the app, including lazy screens and disabled controls.

## Validation
- 41 focused Python tests; 18 distinct local UI component tests; all 404 frontend tests pass in CI. Production build, Ruff, mypy and diagnostic audit pass. All seven required CI checks are green.
- Isolated real Core loads Google through the built-in proxy and receives frames across stream reconnects.
- 13 production LAN Chromium/WebKit checks pass across desktop/compact and 320/390/430 emulated phone widths. The 24-screen audits found no unnamed icons. Real Core/live Codex UI workflows pass at 1440x900 and 1024x700, including direct input, protected values, approval, stream reconnect, and conversation reload. Final bundle SHA256: `2316f41b621613e33e3ebb5f19e14b6564859c91be86a0f41b92dbce3845eb8a`.
- Physical Mac/iPhone testing is not claimed; HTTP/2-specific behavior is unavailable on the built-in managed-browser path while the compatibility setting remains.
- Contract and evidence: `docs/quality/browser-load-input.md`. Local-server deployment completed at merged commit `4eaecb7a22bbc0c446ae4e8a37dfc165ae097b23`. Core runs from `/home/agent/nebula-live-4eaecb7`. An online database backup and previous unit configuration are retained under `/home/agent/.local/share/nebula/deployment-backups/20260908T122817Z-pr260`. Localhost, LAN and WireGuard serve the exact tested bundle; every bundle file matches its HTTP response hash. Core is active and unauthenticated API access remains 401. A post-deployment browser/tooltip workflow passed against the served LAN bundle using API fixtures; production operator data was not mutated by that check. Deployment record: `/tmp/nebula-load-deployment.json`; UI check: `/tmp/nebula-load-live-ui.log`. The operator confirmed an installed remote-Core Mac client and will install its updated build themselves; updating Core alone does not update the bundled Mac UI.
- Logs: `/tmp/nebula-load-unit.log`, `/tmp/nebula-load-ui-unit.log`, `/tmp/nebula-tooltip-unit.log`, `/tmp/nebula-load-ui-final.log`, `/tmp/nebula-google-core.log`, `/tmp/nebula-load-core-ui.log`.
