### PR TITLE
Keep Assistant browser control enabled until stopped; fold page previews

### DIFF
--- a/docs/quality/browser-context-preview.md
+++ b/docs/quality/browser-context-preview.md
@@ -4,10 +4,22 @@ Journey: Browser > Ask about page/selection > inspect, fold, reopen, attach or c
 React owns the unsent capture and fold state; Core owns page revision, session and
 assistant_paused. Folding must preserve the capture and browser stream, closing
 must discard only the preview, and a fresh capture must open for review. Attaching
-keeps existing context-authority and approval behavior. Live access still requires
-explicit Resume assistant control; direct page input pauses control.
+keeps existing context-authority and approval behavior. Live access requires
+explicit Resume assistant control and remains enabled until explicitly stopped.
 
 Validation: component state/focus tests, production desktop and mobile Chromium /
 WebKit geometry and interaction checks, existing real-Core capture/attach/reload
 journey, production build and LAN publication. Physical Mac installation remains
 operator-owned. No changes to backend grants, persistence, deletion or runtime tools.
+
+## Explicit control lifetime
+
+Operator correction: resuming is a session grant, not exclusive mouse ownership.
+Normal page input, navigation, tab operations, viewport changes and removal of
+attached values must not clear that grant. Explicit Stop clears it and revokes
+pending actions before the execution lock. Manual mutations still invalidate pending
+approvals; read-only pointer motion does not cancel them. Existing page-revision,
+scope, runtime-privacy, turn-liveness, session-rebinding and browser-reset checks stay
+in force. Core metadata remains the sole durable authority; the UI mirrors it.
+Test resumed input/navigation, reload and follow-up, explicit stop, stale approvals,
+concurrent queued operations and browser reset through component/Python/real Core.

--- a/docs/quality/browser-context-preview.md
+++ b/docs/quality/browser-context-preview.md
@@ -1,0 +1,13 @@
+# Browser context preview
+
+Journey: Browser > Ask about page/selection > inspect, fold, reopen, attach or close.
+React owns the unsent capture and fold state; Core owns page revision, session and
+assistant_paused. Folding must preserve the capture and browser stream, closing
+must discard only the preview, and a fresh capture must open for review. Attaching
+keeps existing context-authority and approval behavior. Live access still requires
+explicit Resume assistant control; direct page input pauses control.
+
+Validation: component state/focus tests, production desktop and mobile Chromium /
+WebKit geometry and interaction checks, existing real-Core capture/attach/reload
+journey, production build and LAN publication. Physical Mac installation remains
+operator-owned. No changes to backend grants, persistence, deletion or runtime tools.

--- a/scripts/smoke_test_browser_companion_core.py
+++ b/scripts/smoke_test_browser_companion_core.py
@@ -363,13 +363,21 @@ async def smoke(
                         json.dumps({"kind": "resize", "width": 390, "height": 844})
                     )
                     for _ in range(100):
-                        control = await client.get(endpoint + "/control")
-                        control.raise_for_status()
-                        if control.json()["paused"]:
+                        resized = json.loads(await asyncio.wait_for(stream.recv(), 10))
+                        if resized.get("kind") == "frame" and Image.open(
+                            BytesIO(base64.b64decode(resized["data"]))
+                        ).size == (390, 844):
                             break
-                        await asyncio.sleep(0.05)
                     else:
-                        raise RuntimeError("manual stream input did not take control")
+                        raise RuntimeError("manual resize did not reach the browser")
+                    control = await client.get(endpoint + "/control")
+                    control.raise_for_status()
+                    assert control.json()["paused"] is False
+                    stopped = await client.put(endpoint + "/control?paused=true")
+                    stopped.raise_for_status()
+                    assert (await client.get(endpoint + "/control")).json()[
+                        "paused"
+                    ] is True
                     async with connect(
                         stream_url,
                         subprotocols=["nebula.browser.v1", f"nebula.auth.{secret}"],
@@ -954,7 +962,7 @@ async def smoke(
                     "approved_scoped_file_upload": True,
                     "durable_binding_reopen": True,
                     "transport": "Core loopback HTTP and WebSocket to browserd loopback HTTP and WebSocket",
-                    "frame_relay_and_takeover": True,
+                    "frame_relay_persistent_grant_and_explicit_stop": True,
                     "concurrent_viewer_disconnect": True,
                     "stream_touch_and_keyboard": True,
                     "stream_touch_scroll": True,

--- a/src/nebula/v3/api.py
+++ b/src/nebula/v3/api.py
@@ -9733,7 +9733,11 @@ def create_app(
                         if len(json.dumps(event)) > 8000:
                             await websocket.close(code=4400, reason="input too large")
                             return
-                        browser_companion.takeover(session_id, True)
+                        if not (
+                            event.get("kind") == "mouse"
+                            and event.get("type") == "mouseMoved"
+                        ):
+                            browser_companion.invalidate_pending_actions(session_id)
                         async with browser_companion._locks.setdefault(
                             session_id, asyncio.Lock()
                         ):

--- a/src/nebula/v3/browser_companion.py
+++ b/src/nebula/v3/browser_companion.py
@@ -146,7 +146,7 @@ class BrowserCompanion:
         return self.file_catalog(session_id)
 
     def remove_file(self, session_id: str, reference: str) -> list[dict[str, Any]]:
-        self.takeover(session_id, True)
+        self.invalidate_pending_actions(session_id)
         session = self.session(session_id)
         entries = dict(session.metadata.get("browser_files", {}))
         if entries.pop(reference, None) is None:
@@ -236,7 +236,7 @@ class BrowserCompanion:
     def remove_credential(
         self, session_id: str, reference: str
     ) -> list[dict[str, Any]]:
-        self.takeover(session_id, True)
+        self.invalidate_pending_actions(session_id)
         session = self.session(session_id)
         entries = dict(session.metadata.get("browser_credentials", {}))
         removed = entries.pop(reference, None)
@@ -419,9 +419,9 @@ class BrowserCompanion:
                 "File uploads require an inline approval. Propose an upload before execution."
             )
         if not assistant and request.operation not in {"tabs", "capture"}:
-            # Takeover must precede the control queue so waiting assistant actions
-            # see the pause before they can mutate the page.
-            self.takeover(session_id, True)
+            # Manual edits invalidate old approvals, but the explicit session
+            # grant remains enabled until the operator stops it.
+            self.invalidate_pending_actions(session_id)
         async with self._locks.setdefault(session_id, asyncio.Lock()):
             session = self.session(session_id)
             if not self.turn_active(chat_turn_id):
@@ -614,14 +614,18 @@ class BrowserCompanion:
                 expected_revision=session.revision,
             )
         if paused:
-            for action in self.actions(session_id):
-                if action.status == "pending":
-                    self.store.update(
-                        CompanionAction,
-                        action.id,
-                        {"status": "revoked"},
-                        expected_revision=action.revision,
-                    )
+            self.invalidate_pending_actions(session_id)
+
+    def invalidate_pending_actions(self, session_id: str) -> None:
+        """Invalidate approvals without changing the operator's control grant."""
+        for action in self.actions(session_id):
+            if action.status == "pending":
+                self.store.update(
+                    CompanionAction,
+                    action.id,
+                    {"status": "revoked"},
+                    expected_revision=action.revision,
+                )
 
     async def decide(
         self, session_id: str, action_id: str, decision: str

--- a/tests/v3/test_browser_companion.py
+++ b/tests/v3/test_browser_companion.py
@@ -375,7 +375,7 @@ def test_assistant_waits_for_inline_approval_and_receives_actual_result(
     asyncio.run(run())
 
 
-def test_manual_action_pauses_assistant_before_waiting_for_control(tmp_path):
+def test_manual_action_revokes_approvals_without_clearing_control_grant(tmp_path):
     store, _, _, session, service = setup(tmp_path)
     pending = service.propose(
         session.id,
@@ -402,7 +402,7 @@ def test_manual_action_pauses_assistant_before_waiting_for_control(tmp_path):
             )
             await asyncio.sleep(0)
             assert not task.done()
-            assert service.session(session.id).metadata["assistant_paused"] is True
+            assert service.session(session.id).metadata["assistant_paused"] is False
             assert store.get(CompanionAction, pending.id).status == "revoked"
             task.cancel()
             with pytest.raises(asyncio.CancelledError):

--- a/ui/src/browser-assistant.css
+++ b/ui/src/browser-assistant.css
@@ -125,3 +125,8 @@
   .managed-browser-actions { flex: 1 1 auto; min-width: 0; overflow-x: auto; }
   .managed-browser-utilities { flex: 0 0 auto; margin-left: 4px; border-left: 1px solid var(--border-soft); }
 }
+
+.managed-browser-capture > header { display: flex; align-items: center; gap: 4px; }
+.managed-browser-capture > header > strong { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.managed-browser-capture:has([aria-expanded="false"]) { padding-block: 4px; }
+.managed-browser-capture > [hidden] { display: none; }

--- a/ui/src/components/ManagedAssistantBrowser.test.tsx
+++ b/ui/src/components/ManagedAssistantBrowser.test.tsx
@@ -40,6 +40,19 @@ function fixture(active = true, fail = false, protectedField = false, fileField 
 }
 
 describe("ManagedAssistantBrowser", () => {
+  it("allows explicit stop while a manual navigation is still loading", async () => {
+    const { request, onControlChange } = fixture();
+    await waitFor(() => expect(screen.getByRole("button", { name: "Resume assistant control" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Resume assistant control" }));
+    await waitFor(() => expect(onControlChange).toHaveBeenLastCalledWith(true));
+    request.mockImplementationOnce(() => new Promise(() => {}));
+    fireEvent.click(screen.getByRole("button", { name: "Go" }));
+    const stop = screen.getByRole("button", { name: "Stop assistant control" });
+    expect(stop).toBeEnabled();
+    fireEvent.click(stop);
+    await waitFor(() => expect(onControlChange).toHaveBeenLastCalledWith(false));
+    expect(request).toHaveBeenCalledWith(expect.stringContaining("control?paused=true"), expect.anything());
+  });
   it("folds a capture without losing it, reopens fresh captures and closes without stopping the stream", async () => {
     const { connection } = fixture();
     const captureButton = screen.getByRole("button", { name: "Ask about page" });

--- a/ui/src/components/ManagedAssistantBrowser.test.tsx
+++ b/ui/src/components/ManagedAssistantBrowser.test.tsx
@@ -141,7 +141,7 @@ describe("ManagedAssistantBrowser", () => {
     expect(onControlChange).toHaveBeenLastCalledWith(false);
     fireEvent.click(screen.getByRole("button", { name: "Resume assistant control" }));
     await waitFor(() => expect(onControlChange).toHaveBeenLastCalledWith(true));
-    fireEvent.click(screen.getByRole("button", { name: "Take control" }));
+    fireEvent.click(screen.getByRole("button", { name: "Stop assistant control" }));
     await waitFor(() => expect(onControlChange).toHaveBeenLastCalledWith(false));
   });
   it("does not let an older control poll overwrite an explicit resume", async () => {
@@ -154,14 +154,16 @@ describe("ManagedAssistantBrowser", () => {
     await act(async () => { resolveControl({ paused: true }); await controlRead; });
     expect(onControlChange).toHaveBeenLastCalledWith(true);
   });
-  it("shows manual navigation takeover immediately after assistant control was resumed", async () => {
+  it("keeps the explicit grant through manual navigation until stopped", async () => {
     const { onControlChange } = fixture();
     await waitFor(() => expect(screen.getByRole("button", { name: "Resume assistant control" })).toBeEnabled());
     fireEvent.click(screen.getByRole("button", { name: "Resume assistant control" }));
     await waitFor(() => expect(onControlChange).toHaveBeenLastCalledWith(true));
     fireEvent.click(screen.getByRole("button", { name: "Go" }));
+    await screen.findByRole("region", { name: "Browser context preview" });
+    expect(onControlChange).toHaveBeenLastCalledWith(true);
+    fireEvent.click(screen.getByRole("button", { name: "Stop assistant control" }));
     await waitFor(() => expect(onControlChange).toHaveBeenLastCalledWith(false));
-    expect(screen.getByRole("button", { name: "Resume assistant control" })).toBeInTheDocument();
   });
   it("does not start a browser when the operator is using another workspace view", () => {
     const { request } = fixture(false);

--- a/ui/src/components/ManagedAssistantBrowser.test.tsx
+++ b/ui/src/components/ManagedAssistantBrowser.test.tsx
@@ -40,6 +40,24 @@ function fixture(active = true, fail = false, protectedField = false, fileField 
 }
 
 describe("ManagedAssistantBrowser", () => {
+  it("folds a capture without losing it, reopens fresh captures and closes without stopping the stream", async () => {
+    const { connection } = fixture();
+    const captureButton = screen.getByRole("button", { name: "Ask about page" });
+    await waitFor(() => expect(captureButton).toBeEnabled());
+    fireEvent.click(captureButton);
+    await screen.findByText("Selected page content");
+    fireEvent.click(screen.getByRole("button", { name: "Collapse page context" }));
+    expect(screen.getByText("Selected page content")).not.toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Expand page context" }));
+    expect(screen.getByText("Selected page content")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Collapse page context" }));
+    fireEvent.click(captureButton);
+    await waitFor(() => expect(screen.getByText("Selected page content")).toBeVisible());
+    fireEvent.click(screen.getByRole("button", { name: "Close page context" }));
+    expect(screen.queryByRole("region", { name: "Browser context preview" })).not.toBeInTheDocument();
+    expect(captureButton).toHaveFocus();
+    expect(connection.close).not.toHaveBeenCalled();
+  });
   it("hides chrome without losing the address draft, captured context or browser stream", async () => {
     const { setControlsOpen, connection } = fixture();
     await waitFor(() => expect(screen.getByRole("button", { name: "Ask about page" })).toBeEnabled());

--- a/ui/src/components/ManagedAssistantBrowser.tsx
+++ b/ui/src/components/ManagedAssistantBrowser.tsx
@@ -41,7 +41,6 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
   const [mode, setMode] = useState<"browse" | "element" | "region">("browse");
   const [paused, setPaused] = useState(true);
   const controlRevision = useRef(0);
-  const recordTakeover = () => { controlRevision.current += 1; setPaused(true); };
   const [text, setText] = useState("");
   const [connected, setConnected] = useState(false);
   const [credentials, setCredentials] = useState<BrowserCredential[]>([]);
@@ -135,7 +134,6 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
     if (!session || busy) return;
     setBusy(true); setError("");
     try {
-      if (operation !== "capture" && operation !== "tabs") recordTakeover();
       const next = await request<Capture>(`browser-companion/${session.session_id}/operations`, { operation, tab_id: tabId, page_revision: capture?.page_revision, ...extra });
       if (currentTabRef.current !== tabId) return;
       setCapture(next); if (operation === "navigate") addressEdited.current = false; if (!addressEdited.current) setAddress(next.url); return next;
@@ -146,7 +144,6 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
     if (!session || busy) return;
     setBusy(true); setError("");
     try {
-      recordTakeover();
       const next = await request<Pick<Session, "tabs" | "active_tab_id">>(`browser-companion/${session.session_id}/operations`, { operation, tab_id: tabId });
       const selected = next.tabs.find(tab => tab.id === next.active_tab_id) ?? next.tabs[0];
       setSession({ ...session, ...next }); setTabs(next.tabs); setTabId(selected?.id ?? ""); addressEdited.current = false; setAddress(selected?.url === "about:blank" ? "" : selected?.url ?? ""); setCapture(undefined);
@@ -171,7 +168,7 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
     setBusy(true); setError("");
     try {
       const action = await request<Action>(`browser-companion/${session.session_id}/actions`, { operation: "upload", file_ref: fileRef, tab_id: tabId, page_revision: capture.page_revision, element_id: elementId, url: capture.url });
-      recordTakeover(); setActions(current => [...current.filter(item => item.status !== "pending"), action]);
+      setActions(current => [...current.filter(item => item.status !== "pending"), action]);
     } catch (caught) { logCaughtDiagnosticFailure(caught); }
     finally { setBusy(false); }
   };
@@ -193,7 +190,7 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
   };
   const send = (event: Record<string, unknown>) => {
     if (socket.current?.readyState !== WebSocket.OPEN) return;
-    recordTakeover(); socket.current.send(JSON.stringify(event));
+    socket.current.send(JSON.stringify(event));
   };
   const requiredActions = <>
     {actions.filter(action => action.status === "pending").map(action => <section className="managed-browser-approval" key={action.id} aria-label="Browser action approval">
@@ -225,7 +222,7 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
       <button className="button quiet managed-browser-icon" disabled={!session || busy} onClick={() => void operate("capture", { capture_kind: "selection" })} aria-label="Ask about selected text" title="Ask about selected text"><TextSelect size={18} aria-hidden="true" /></button>
       <button className="button quiet managed-browser-icon" aria-pressed={mode === "element"} onClick={() => setMode(mode === "element" ? "browse" : "element")} aria-label="Pick element" title="Pick element"><MousePointer2 size={18} aria-hidden="true" /></button>
       <button className="button quiet managed-browser-icon" disabled={!imageSupported} title={imageSupported ? "Select a visual region" : "Choose an image-capable Assistant model"} aria-pressed={mode === "region"} onClick={() => setMode(mode === "region" ? "browse" : "region")} aria-label="Select region"><Scan size={18} aria-hidden="true" /></button>
-      <button className="button quiet managed-browser-icon managed-browser-control" aria-label={paused ? "Resume assistant control" : "Take control"} title={paused ? "Resume assistant control" : "Take control"} disabled={busy || !session} onClick={() => {
+      <button className="button quiet managed-browser-icon managed-browser-control" aria-label={paused ? "Resume assistant control" : "Stop assistant control"} title={paused ? "Resume assistant control" : "Stop assistant control"} disabled={busy || !session} onClick={() => {
         if (!session) return;
         const nextPaused = !paused;
         const revision = ++controlRevision.current;
@@ -252,7 +249,7 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
       <label>Protected value to fill<select value={credentialRef} onChange={event => setCredentialRef(event.target.value)}><option value="">Choose a saved value</option>{credentials.map(item => <option key={item.reference} value={item.reference} disabled={!item.available}>{item.label}{item.available ? "" : " · expired; add again"}</option>)}</select></label>
       {credentials.map(item => <div key={item.reference}><span>{item.label}{item.available ? "" : " · expired"}</span><button className="button quiet" disabled={credentialBusy} onClick={() => { if (!session) return; setCredentialBusy(true);
         void request<BrowserCredential[]>(`browser-companion/${session.session_id}/credentials/${encodeURIComponent(item.reference)}`, undefined, "DELETE")
-          .then(next => { setCredentials(next); setCredentialRef(""); recordTakeover(); }).catch(caught => logCaughtDiagnosticFailure(caught)).finally(() => setCredentialBusy(false)); }}>Remove {item.label}</button></div>)}
+          .then(next => { setCredentials(next); setCredentialRef(""); }).catch(caught => logCaughtDiagnosticFailure(caught)).finally(() => setCredentialBusy(false)); }}>Remove {item.label}</button></div>)}
     </div></details>
     <details className="managed-browser-credentials"><summary title={`Files for this page (${files.length})`} aria-label={`Files for this page (${files.length})`}><Paperclip size={18} aria-hidden="true" /><span className="sr-only">Files for this page ({files.length})</span></summary><div className="managed-browser-utility-panel">
       <p>Choose a file from this device for a page upload. Files stay attached to this browser until removed. Up to eight files, 4 MiB each; the page receives bytes only after approval.</p>
@@ -261,7 +258,7 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
       <label>File to upload<select value={fileRef} onChange={event => setFileRef(event.target.value)}><option value="">Choose an attached file</option>{files.map(file => <option key={file.reference} value={file.reference}>{file.filename} · {file.size.toLocaleString()} bytes</option>)}</select></label>
       {files.map(file => <div key={file.reference}><span>{file.filename} · {file.size.toLocaleString()} bytes</span><button className="button quiet" disabled={fileBusy} onClick={() => { if (!session) return; setFileBusy(true);
         void request<BrowserFile[]>(`browser-companion/${session.session_id}/files/${encodeURIComponent(file.reference)}`, undefined, "DELETE")
-          .then(next => { setFiles(next); setFileRef(""); recordTakeover(); }).catch(caught => logCaughtDiagnosticFailure(caught)).finally(() => setFileBusy(false)); }}>Remove {file.filename}</button></div>)}
+          .then(next => { setFiles(next); setFileRef(""); }).catch(caught => logCaughtDiagnosticFailure(caught)).finally(() => setFileBusy(false)); }}>Remove {file.filename}</button></div>)}
     </div></details>
     </div>
     </div>

--- a/ui/src/components/ManagedAssistantBrowser.tsx
+++ b/ui/src/components/ManagedAssistantBrowser.tsx
@@ -40,6 +40,7 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
   const [actions, setActions] = useState<Action[]>([]);
   const [mode, setMode] = useState<"browse" | "element" | "region">("browse");
   const [paused, setPaused] = useState(true);
+  const [controlBusy, setControlBusy] = useState(false);
   const controlRevision = useRef(0);
   const [text, setText] = useState("");
   const [connected, setConnected] = useState(false);
@@ -222,14 +223,14 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
       <button className="button quiet managed-browser-icon" disabled={!session || busy} onClick={() => void operate("capture", { capture_kind: "selection" })} aria-label="Ask about selected text" title="Ask about selected text"><TextSelect size={18} aria-hidden="true" /></button>
       <button className="button quiet managed-browser-icon" aria-pressed={mode === "element"} onClick={() => setMode(mode === "element" ? "browse" : "element")} aria-label="Pick element" title="Pick element"><MousePointer2 size={18} aria-hidden="true" /></button>
       <button className="button quiet managed-browser-icon" disabled={!imageSupported} title={imageSupported ? "Select a visual region" : "Choose an image-capable Assistant model"} aria-pressed={mode === "region"} onClick={() => setMode(mode === "region" ? "browse" : "region")} aria-label="Select region"><Scan size={18} aria-hidden="true" /></button>
-      <button className="button quiet managed-browser-icon managed-browser-control" aria-label={paused ? "Resume assistant control" : "Stop assistant control"} title={paused ? "Resume assistant control" : "Stop assistant control"} disabled={busy || !session} onClick={() => {
+      <button className="button quiet managed-browser-icon managed-browser-control" aria-label={paused ? "Resume assistant control" : "Stop assistant control"} title={paused ? "Resume assistant control" : "Stop assistant control"} disabled={controlBusy || !session} onClick={() => {
         if (!session) return;
         const nextPaused = !paused;
         const revision = ++controlRevision.current;
-        setBusy(true);
+        setControlBusy(true);
         void request(`browser-companion/${session.session_id}/control?paused=${nextPaused}`, undefined, "PUT")
           .then(() => { if (revision === controlRevision.current) { controlRevision.current += 1; setPaused(nextPaused); } })
-          .catch(caught => logCaughtDiagnosticFailure(caught)).finally(() => setBusy(false));
+          .catch(caught => logCaughtDiagnosticFailure(caught)).finally(() => setControlBusy(false));
       }}>{paused ? <Play size={18} aria-hidden="true" /> : <Hand size={18} aria-hidden="true" />}</button>
     </div>
 

--- a/ui/src/components/ManagedAssistantBrowser.tsx
+++ b/ui/src/components/ManagedAssistantBrowser.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, Plus, X, RefreshCw, MessageSquareText, TextSelect, MousePointer2, Scan, Hand, Play, Settings2, KeyRound, Paperclip } from "lucide-react";
+import { ArrowRight, ChevronDown, ChevronUp, Plus, X, RefreshCw, MessageSquareText, TextSelect, MousePointer2, Scan, Hand, Play, Settings2, KeyRound, Paperclip } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { BrowserPageSurface } from "./BrowserPageSurface";
@@ -35,6 +35,8 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
   const [busy, setBusy] = useState(false);
   const [frame, setFrame] = useState("");
   const [capture, setCapture] = useState<Capture>();
+  const [captureCollapsed, setCaptureCollapsed] = useState(false);
+  useEffect(() => { setCaptureCollapsed(false); }, [capture]);
   const [actions, setActions] = useState<Action[]>([]);
   const [mode, setMode] = useState<"browse" | "element" | "region">("browse");
   const [paused, setPaused] = useState(true);
@@ -173,6 +175,10 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
     } catch (caught) { logCaughtDiagnosticFailure(caught); }
     finally { setBusy(false); }
   };
+  const discardCapture = () => {
+    setCapture(undefined);
+    document.querySelector<HTMLButtonElement>(controlsOpen ? 'button[aria-label="Ask about page"]' : 'button[aria-label="Show browser controls"]')?.focus({ preventScroll: true });
+  };
   const attach = () => {
     if (!capture || !session) return;
     const sourceUrl = new URL(capture.url);
@@ -264,9 +270,15 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
     {error && <div className="managed-browser-error" role="alert">{error}<button className="button quiet" disabled={busy} onClick={() => void open()}>Reconnect view</button></div>}
     {active && (actionContainer ? createPortal(requiredActions, actionContainer) : requiredActions)}
     {actions.filter(action => action.status === "complete" || action.status === "revoked").sort((a, b) => Date.parse(b.expires_at) - Date.parse(a.expires_at)).slice(0, 1).map(action => <p role="status" key={action.id}>{action.request.operation === "upload" ? "File upload" : "Browser action"} {action.status === "complete" ? "completed" : "cancelled"}.</p>)}
-    {capture && <section className="managed-browser-capture" aria-label="Browser context preview"><strong>{capture.title || capture.url}</strong><small>{capture.captured_at}</small><pre>{capture.text}</pre>
+    {capture && <section className="managed-browser-capture" aria-label="Browser context preview">
+      <header role="presentation"><strong>{capture.title || capture.url}</strong>
+        <button className="button quiet managed-browser-icon" type="button" aria-label={captureCollapsed ? "Expand page context" : "Collapse page context"} title={captureCollapsed ? "Expand page context" : "Collapse page context"} aria-expanded={!captureCollapsed} aria-controls="browser-context-preview-content" onClick={() => setCaptureCollapsed(value => !value)}>{captureCollapsed ? <ChevronDown size={18} aria-hidden="true" /> : <ChevronUp size={18} aria-hidden="true" />}</button>
+        <button className="button quiet managed-browser-icon" type="button" aria-label="Close page context" title="Discard page context" onClick={discardCapture}><X size={18} aria-hidden="true" /></button>
+      </header>
+      <div id="browser-context-preview-content" hidden={captureCollapsed}>
+      <small>{new Date(capture.captured_at).toLocaleString()}</small><pre>{capture.text}</pre>
       {capture.image && <img src={`data:image/png;base64,${capture.image}`} alt="Selected page region" />}
-      <button className="button primary" onClick={attach}>Attach to Assistant</button><button className="button quiet" onClick={() => setCapture(undefined)}>Discard</button>
+      <button className="button primary" onClick={attach}>Attach to Assistant</button><button className="button quiet" onClick={discardCapture}>Discard</button>
       <details><summary>Accessible page controls ({capture.elements.length})</summary><input aria-label="Text for selected page control" value={text} onChange={event => setText(event.target.value)} />
         {capture.elements.map(element => {
           const editable = element.tag === "textarea" || (element.tag === "input" && !["button", "submit", "reset", "checkbox", "radio", "file", "range", "color", "hidden"].includes(element.type));
@@ -283,6 +295,7 @@ export function ManagedAssistantBrowser({ api, projectId, active, conversationId
           </div>;
         })}
       </details>
+      </div>
     </section>}
     <BrowserPageSurface frame={frame} mode={mode} connected={connected} send={send} onCapture={(captureKind, area) => {
       void operate("capture", { capture_kind: captureKind, ...area }); setMode("browse");

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -5371,6 +5371,18 @@ test(`browser Assistant stays beside the page through an answer and follow-up${d
   await page.getByRole("button", { name: "Go", exact: true }).click();
   await page.getByRole("button", { name: "Ask about page", exact: true }).click();
   await expect(page.getByRole("region", { name: "Browser context preview" })).toContainText("Save button");
+  const contextPreview = page.getByRole("region", { name: "Browser context preview" });
+  const previewHeight = (await contextPreview.boundingBox())!.height;
+  await page.getByRole("button", { name: "Collapse page context" }).click();
+  await expect(page.getByRole("button", { name: "Attach to Assistant", exact: true })).toBeHidden();
+  expect((await contextPreview.boundingBox())!.height).toBeLessThan(previewHeight);
+  await page.getByRole("button", { name: "Expand page context" }).click();
+  await expect(contextPreview).toContainText("Save button");
+  await page.getByRole("button", { name: "Close page context" }).click();
+  await expect(contextPreview).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Ask about page", exact: true })).toBeFocused();
+  await page.getByRole("button", { name: "Ask about page", exact: true }).click();
+  await expect(contextPreview).toContainText("Save button");
   await page.getByRole("button", { name: "Attach to Assistant", exact: true }).click();
   const panel = page.getByRole("complementary", { name: "Browser Assistant", exact: true });
   if (await page.locator(".browser-assistant-sheet").count()) expect(await panel.evaluate(element => getComputedStyle(element).backgroundColor)).toMatch(/^rgb\(\d+, \d+, \d+\)$/);

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -5287,8 +5287,8 @@ test("calm structure avoids duplicate hierarchy and decorative nesting", async (
 });
 
 for (const degradedBrowserCore of [false, true]) {
-test(`browser Assistant stays beside the page through an answer and follow-up${degradedBrowserCore ? " with degraded Core" : ""}`, async ({ page }) => {
-  test.setTimeout(90000);
+test(`browser Assistant stays beside the page through an answer and follow-up${degradedBrowserCore ? " with degraded Core" : ""}`, async ({ page, browserName }) => {
+  test.setTimeout(browserName === "webkit" ? 180000 : 90000);
   await page.route("**/api/v1/**", async route => {
     const path = new URL(route.request().url()).pathname;
     if (degradedBrowserCore && path.endsWith("/health")) {
@@ -5368,7 +5368,12 @@ test(`browser Assistant stays beside the page through an answer and follow-up${d
   await expect(page.getByLabel("Page viewport")).toBeHidden();
   await page.screenshot({ path: test.info().outputPath("quiet-browser.png") });
   await page.getByLabel("Browser address").fill("https://example.test/");
+  await page.getByRole("button", { name: "Resume assistant control", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Stop assistant control", exact: true })).toBeEnabled();
   await page.getByRole("button", { name: "Go", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Stop assistant control", exact: true })).toBeEnabled();
+  await page.getByRole("button", { name: "Stop assistant control", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Resume assistant control", exact: true })).toBeEnabled();
   await page.getByRole("button", { name: "Ask about page", exact: true }).click();
   await expect(page.getByRole("region", { name: "Browser context preview" })).toContainText("Save button");
   const contextPreview = page.getByRole("region", { name: "Browser context preview" });


### PR DESCRIPTION
Browser input previously cleared the Assistant's control grant—even moving the pointer required another resume. Captured page context also occupied a large, persistent preview.

Keep the explicit control grant enabled through normal input, navigation and tab operations. Stop remains available while navigation is loading and explicitly revokes control. Manual mutations still invalidate pending approvals; pointer movement does not. Existing page-revision, scope, privacy, turn-liveness, browser-reset and conversation-rebinding checks remain enforced.

Add fold/unfold and close icons to the context preview. Folding preserves the capture; a fresh capture opens for review; closing discards the preview and restores focus. Theme variables and icon tooltips remain intact.

Validation:
- 14 focused component tests passed, including stopping while navigation is loading; 23 companion Python tests passed, including revocation, page-revision checks, reset and queued-operation boundaries.
- Production LAN browser journey passed in 10 profiles: Chromium 1440/1024 desktop; Chromium and WebKit 320/390/430 mobile emulation; both engines 844x390 landscape. Checks include fold/expand/close, focus restoration, capture/attach/follow-up, grant preservation through navigation and explicit Stop. WebKit timeouts under host load were resolved with a larger test budget; the final matrix passed.
- After the final Stop-availability adjustment, the final production bundle passed desktop, 320px Chromium and 390px WebKit journeys again.
- Authenticated real-Core smoke passed with live Codex and production LAN UI at 1440x900 and 1024x700: stream resize preserved the grant, explicit Stop cleared it, capture/attachment/approval/upload/input/reconnect and durable conversation reload passed.
- Production build, frontend diagnostic audit, ruff and all seven required CI jobs passed.

Physical Mac and physical phone testing were not run. The installed Mac app needs the updated bundled UI installed by its operator. A restarted browser or different conversation retains its existing fresh-grant boundary.

Final UI SHA-256: `5ab23d57cb7adbcffe473bbefb18883c81d26c7b8db1b6bdc3fa6b42893fcd8b`.
