### PR TITLE
Remove default Assistant execution and artifact-query caps

### DIFF
--- a/docs/quality/unlimited-chat-budgets.md
+++ b/docs/quality/unlimited-chat-budgets.md
@@ -1,0 +1,39 @@
+# Unlimited Assistant budgets
+
+Operator journey: send a tool-enabled Assistant message in an existing or new
+conversation; work continues beyond five execution calls and twenty artifact
+queries until completion, cancellation, or an actionable approval/error.
+
+Authority: Core stores nullable turn budgets and atomic usage counters. The UI
+serializes unlimited as null. Provider routing and harness gateway share those
+stored budgets. Existing completed turns retain their historical limits.
+
+Invariants: new turns default to unlimited; counters remain accurate without fixed
+ceilings; explicit finite API budgets retain enforcement; scope, approval and Stop
+remain authoritative. Model context capacity and individual operation timeouts
+are not execution budgets.
+
+Lifecycle: create/select/use/stream, approval/resume, interrupt, reconnect/refresh
+and retry apply. Fork inherits the new request defaults. Deletion and browser
+layout are unchanged and require no new behavior.
+
+Planned evidence: model/request serialization; more than five execution and twenty
+query reservations with persistence and idempotency; provider routing regression;
+existing approval/cancellation suites; frontend client tests and production build;
+real-Core workflow and production LAN checks. Physical Mac verification remains
+operator-owned because the operator will install the desktop build themselves.
+
+App-wide audit: RunBudget and mission/automation requests already default token,
+cost, duration, tool-call and artifact-query budgets to null. Explicit finite API
+budgets remain supported. Autonomous security assessment grants and crawler request
+bounds remain unchanged, as do concurrency, transport timeouts, upload limits and
+model context capacity. No completed turn is rewritten or replayed. Older desktop
+clients still explicitly send twenty artifact queries and need the updated client
+for the unlimited query default; Core's execution-call default applies immediately
+to their new turns.
+
+Validation so far: 107 storage/chat/queue/API/harness tests passed; 42 frontend API
+client tests passed; production build, Ruff and mypy passed. The regression
+reserves 210 execution calls and 210 artifact queries per turn, verifies duplicate
+reservation idempotency and independent explicit finite-budget enforcement, and
+reloads serialized counters beyond the old 205-step ceiling.

--- a/scripts/smoke_test_browser_companion_core.py
+++ b/scripts/smoke_test_browser_companion_core.py
@@ -583,7 +583,7 @@ async def smoke(
                             "messages": [
                                 {
                                     "role": "user",
-                                    "content": "Use browser.companion to list the attached tabs, then capture a screenshot region at x=0,y=0,width=300,height=200 of the attached tab. Report the visible button label. Use only the browser.companion tool; do not navigate or use any other capability.",
+                                    "content": "Use browser.companion to list the attached tabs, then make six separate sequential screenshot region capture calls at x=0,y=0,width=300,height=200 of the attached tab to verify repeated captures. Complete all six captures before replying. Report the visible button label. Use only the browser.companion tool; do not navigate or use any other capability.",
                                 }
                             ],
                             "context_attachments": [
@@ -623,7 +623,7 @@ async def smoke(
                         )
                     )
                     evidence_path.chmod(0o600)
-                    if not screenshot_calls or not all(
+                    if len(screenshot_calls) < 6 or not all(
                         call.status.value == "complete" for call in screenshot_calls
                     ):
                         raise RuntimeError(
@@ -898,6 +898,7 @@ async def smoke(
                         ]
                         == seeded.json()["session_id"],
                         "harness_model": model,
+                        "completed_region_captures_in_one_turn": len(screenshot_calls),
                         "harness_operator_image_attachment": True,
                         "harness_untrusted_page_instructions_ignored": True,
                         "harness_approved_file_upload": True,

--- a/scripts/smoke_test_browser_companion_core.py
+++ b/scripts/smoke_test_browser_companion_core.py
@@ -583,7 +583,7 @@ async def smoke(
                             "messages": [
                                 {
                                     "role": "user",
-                                    "content": "Use browser.companion to list the attached tabs, then make six separate sequential screenshot region capture calls at x=0,y=0,width=300,height=200 of the attached tab to verify repeated captures. Complete all six captures before replying. Report the visible button label. Use only the browser.companion tool; do not navigate or use any other capability.",
+                                    "content": "Use browser.companion to list the attached tabs, then make six separate sequential screenshot region capture calls of the attached tab, each at x=0,y=0,height=200 with distinct widths 300,301,302,303,304,305 respectively, to verify six distinct captures. Complete all six captures before replying. Report the visible button label. Use only the browser.companion tool; do not navigate or use any other capability.",
                                 }
                             ],
                             "context_attachments": [
@@ -609,6 +609,7 @@ async def smoke(
                         for call in calls
                         if call.tool_name == "browser.companion"
                         and call.arguments.get("capture_kind") == "region"
+                        and call.chat_turn_id == completion.json()["turn_id"]
                     ]
                     evidence_path = runtime_root.parent / "last-harness-events.json"
                     evidence_path.write_text(

--- a/src/nebula/v3/chat.py
+++ b/src/nebula/v3/chat.py
@@ -245,7 +245,7 @@ class ChatCompletionRequest(NebulaModel):
     include_knowledge: bool = True
     allow_cloud_knowledge: bool = False
     tools_enabled: bool = False
-    max_artifact_queries: int = Field(default=20, ge=0, le=200)
+    max_artifact_queries: int | None = Field(default=None, ge=0)
     allow_cloud_tool_results: bool = False
     # Optional vendor-native turn controls.  They are validated again against
     # the negotiated profile in HarnessRuntime.prepare_chat.
@@ -1400,24 +1400,29 @@ class ChatService:
                 if turn.status == ChatTurnStatus.WAITING_APPROVAL:
                     return
 
-            while (
-                turn.status != ChatTurnStatus.FINALIZING
-                and turn.next_step < turn.max_tool_calls + turn.max_artifact_queries
-            ):
+            while turn.status != ChatTurnStatus.FINALIZING:
                 available_specs = [
                     spec
                     for spec in components.specs.values()
                     if (
                         (
                             spec.budget_class == "artifact_query"
-                            and turn.artifact_queries < turn.max_artifact_queries
+                            and (
+                                turn.max_artifact_queries is None
+                                or turn.artifact_queries < turn.max_artifact_queries
+                            )
                         )
                         or (
                             spec.budget_class == "execution"
-                            and turn.execution_tool_calls < turn.max_tool_calls
+                            and (
+                                turn.max_tool_calls is None
+                                or turn.execution_tool_calls < turn.max_tool_calls
+                            )
                         )
                     )
                 ]
+                if not available_specs:
+                    break
                 routing = prepared.model_request.model_copy(
                     update={
                         "instructions": _CHAT_TOOL_INSTRUCTIONS

--- a/src/nebula/v3/domain.py
+++ b/src/nebula/v3/domain.py
@@ -3424,11 +3424,11 @@ class ChatTurn(Entity):
     model: str
     status: ChatTurnStatus = ChatTurnStatus.ROUTING
     tools_enabled: bool = False
-    max_tool_calls: int = Field(default=5, ge=0, le=5)
-    max_artifact_queries: int = Field(default=20, ge=0, le=200)
-    next_step: int = Field(default=0, ge=0, le=205)
-    execution_tool_calls: int = Field(default=0, ge=0, le=5)
-    artifact_queries: int = Field(default=0, ge=0, le=200)
+    max_tool_calls: int | None = Field(default=None, ge=0)
+    max_artifact_queries: int | None = Field(default=None, ge=0)
+    next_step: int = Field(default=0, ge=0)
+    execution_tool_calls: int = Field(default=0, ge=0)
+    artifact_queries: int = Field(default=0, ge=0)
     tool_call_ids: list[str] = Field(default_factory=list)
     tool_history: list[dict[str, Any]] = Field(default_factory=list)
     approval_id: str | None = None

--- a/src/nebula/v3/harnesses.py
+++ b/src/nebula/v3/harnesses.py
@@ -5810,7 +5810,7 @@ class HarnessRuntimeService:
         allow_remote_mcp: bool = False,
         include_knowledge: bool = False,
         allow_cloud_knowledge: bool = False,
-        max_artifact_queries: int = 20,
+        max_artifact_queries: int | None = None,
         harness_mode: str | None = None,
         harness_skill: HarnessSkillInvocation | None = None,
         harness_reasoning_effort: str | None = None,

--- a/src/nebula/v3/storage.py
+++ b/src/nebula/v3/storage.py
@@ -558,7 +558,7 @@ class NebulaStore:
                 "max_artifact_queries" if artifact_query else "max_tool_calls"
             )
             maximum_value = (
-                run["payload"].get(budget_field, 20 if artifact_query else 0)
+                run["payload"].get(budget_field)
                 if call.origin == ToolCallOrigin.CHAT
                 else run["payload"].get("budget", {}).get(budget_field)
             )

--- a/tests/v3/test_chat.py
+++ b/tests/v3/test_chat.py
@@ -874,3 +874,13 @@ def test_existing_session_cursor_and_messages_roll_back_together(tmp_path, monke
         1,
         2,
     ]
+
+
+def test_chat_request_defaults_to_unlimited_artifact_queries():
+    request = ChatCompletionRequest(
+        provider_id="fixture",
+        model="fixture",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+    assert request.max_artifact_queries is None
+    assert request.model_dump()["max_artifact_queries"] is None

--- a/tests/v3/test_harnesses.py
+++ b/tests/v3/test_harnesses.py
@@ -467,6 +467,8 @@ def test_harness_model_controls_are_validated_and_frozen_per_session(tmp_path):
         harness_reasoning_effort="high",
         harness_service_tier="fast",
     )
+    assert chat_turn.max_tool_calls is None
+    assert chat_turn.max_artifact_queries is None
     session = store.get(HarnessSession, harness_turn.harness_session_id)
     assert session.metadata["runtime_options"] == {
         "reasoning_effort": "high",

--- a/tests/v3/test_storage.py
+++ b/tests/v3/test_storage.py
@@ -29,6 +29,7 @@ from nebula.v3.domain import (
     RunBudget,
     RunStatus,
     ToolCall,
+    ToolCallOrigin,
     utc_now,
 )
 from nebula.v3.storage import (
@@ -435,3 +436,64 @@ def test_overview_counts_entities_by_engagement(store):
     overview = store.overview(first.id)
     assert overview["counts"]["engagements"] == 1
     assert overview["counts"]["assets"] == 1
+
+
+@pytest.mark.parametrize("limit", [None, 2])
+def test_chat_budgets_persist_and_count_without_legacy_ceilings(store, limit):
+    engagement = store.create(Engagement(name="Chat budget regression"))
+    turn = store.create(
+        ChatTurn(
+            engagement_id=engagement.id,
+            session_id="chat-budget-session",
+            provider_profile_id="fixture-provider",
+            model="fixture",
+            max_tool_calls=limit,
+            max_artifact_queries=limit,
+        )
+    )
+    for budget_class in ("execution", "artifact_query"):
+        count = 210 if limit is None else limit
+        for index in range(count):
+            call = ToolCall(
+                id=f"{turn.id}-{budget_class}-{index}",
+                engagement_id=engagement.id,
+                run_id=turn.id,
+                origin=ToolCallOrigin.CHAT,
+                tool_name="fixture.read",
+                risk_class=RiskClass.LOCAL_READ,
+                metadata={"budget_class": budget_class},
+            )
+            store.reserve_tool_call(call)
+            store.reserve_tool_call(call)  # Retry cannot consume a second slot.
+        if limit is not None:
+            with pytest.raises(RunBudgetExceededError):
+                store.reserve_tool_call(
+                    call.model_copy(update={"id": f"{call.id}-extra"})
+                )
+    reloaded = store.get(ChatTurn, turn.id)
+    assert reloaded.max_tool_calls == limit
+    assert reloaded.max_artifact_queries == limit
+    with store.database.session() as session:
+        counter = session.get(RunBudgetCounterRow, turn.id)
+        assert counter.tool_calls == count
+        assert counter.artifact_queries == count
+    restored = ChatTurn.model_validate(
+        {
+            **reloaded.model_dump(),
+            "next_step": 420,
+            "execution_tool_calls": 210,
+            "artifact_queries": 210,
+        }
+    )
+    assert restored.next_step == 420
+
+
+def test_new_chat_turn_budgets_are_unlimited():
+    turn = ChatTurn(
+        engagement_id="project",
+        session_id="session",
+        model="fixture",
+        provider_profile_id="fixture-provider",
+    )
+    assert turn.max_tool_calls is None
+    assert turn.max_artifact_queries is None

--- a/ui/src/api/client.test.ts
+++ b/ui/src/api/client.test.ts
@@ -1164,6 +1164,7 @@ describe("ApiClient", () => {
       stream: true,
       include_knowledge: true,
       allow_cloud_knowledge: true,
+      max_artifact_queries: null,
     });
     expect(new Headers(fetchMock.mock.calls[0][1]?.headers).get("Authorization")).toBe("Bearer token");
   });

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -3082,7 +3082,7 @@ export function chatRequestBody(
     include_knowledge: body.includeKnowledge ?? true,
     allow_cloud_knowledge: body.allowCloudKnowledge ?? false,
     tools_enabled: body.toolsEnabled ?? false,
-    max_artifact_queries: body.maxArtifactQueries ?? 20,
+    max_artifact_queries: body.maxArtifactQueries ?? null,
     allow_cloud_tool_results: body.allowCloudToolResults ?? false,
     harness_mode: body.harnessMode,
     harness_reasoning_effort: body.harnessReasoningEffort,

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -1594,7 +1594,7 @@ export interface ChatCompletionRequest {
   includeKnowledge?: boolean;
   allowCloudKnowledge?: boolean;
   toolsEnabled?: boolean;
-  maxArtifactQueries?: number;
+  maxArtifactQueries?: number | null;
   allowCloudToolResults?: boolean;
   harnessMode?: string;
   harnessReasoningEffort?: string;


### PR DESCRIPTION
Assistant browser work stopped after five tool calls even while Core retained the control grant. New provider and harness chat turns now default to unlimited tool-call and artifact-query budgets, and accumulated counters no longer have the five/200/205 validation ceilings. The client sends null for the query default; explicit finite budgets retain enforcement.

Run and mission spend/duration budgets already default to unlimited. Scope, approvals, Stop, autonomous assessment grants, crawler bounds and technical resource limits remain unchanged. Historical turns are not replayed. Older desktop clients need the updated build to stop explicitly sending the old twenty-query default.

Validation: 107 storage/chat/queue/API/harness tests; 42 frontend API tests; production build; Ruff and mypy. Added atomic/idempotent coverage for 210 calls of each budget class and extended the real-Core browser smoke journey to require six screenshot captures in one turn. Production LAN browser journey passed in desktop Chromium (1440 and 1024), emulated Android Chromium (390), and emulated iPhone WebKit (390). Real Core with the configured harness passed six distinct region captures in one turn, attachments, approval/follow-up, explicit Stop, reconnect and durable conversation reload on the production bundle at LAN origin http://192.168.1.155:54411. Physical Mac verification is not available here.

Evidence: `/tmp/nebula-unlimited-tests.log`, `/tmp/nebula-unlimited-ui-tests.log`, `/tmp/nebula-unlimited-playwright.log`, `/tmp/nebula-unlimited-core-smoke.log`. Production index SHA256: `1a4503ddde45b3d5a8c266aece72511d77bfae5c0e2c767350236cafe8061252`.
