### PR TITLE
Enable knowledge sources automatically

### DIFF
--- a/.github/test-selection.json
+++ b/.github/test-selection.json
@@ -1,29 +1,25 @@
 {
-  "reviewed_by": "Codex, harness skill and knowledge-boundary review",
-  "reason": "The change narrows the trusted Codex harness instruction so a disabled Nebula knowledge gateway cannot suppress an explicitly selected installed skill. Selected Python tests cover skill discovery and validation, the exact instruction boundary, disabled turn capability state through transport loss, and enabled knowledge privacy behavior. Selected Workbench browser entries cover skill autocomplete and the structured harness_skill request on desktop Chromium, mobile Chromium, and mobile WebKit.",
-  "exclusions": "No frontend or native source changed, so frontend and native unit selections are empty. The change does not alter source ingestion, gateway authorization, layout, browser-origin behavior, persistence, or reconnect mechanics. The production build and three focused mocked-browser projects were exercised locally. A live external Codex App Server response, non-loopback LAN run, packaged desktop run, and physical-device run are outside this focused merge gate and remain unverified.",
-  "baseline": "7dc0f8ff0d67b45ce47be93ca7b1b149c3aceddb",
+  "reviewed_by": "Codex, automatic knowledge availability review",
+  "reason": "The change removes the per-turn knowledge opt-out so loaded sources are automatically available whenever the selected runtime permits project data. Selected Workbench browser entries cover automatic knowledge status and request shaping on desktop Chromium, mobile Chromium, mobile WebKit, and production UI backed by real Core on a LAN origin.",
+  "exclusions": "No native source changed, so native tests are empty. No standalone frontend unit test exercises the SessionsPage integration; the focused Playwright regressions cover its visible state, outgoing request, and a durable source loaded from real Core. Source ingestion behavior, gateway authorization, reconnect behavior, and browser-origin security are unchanged. A live external Codex App Server response, packaged desktop run, and physical-device run remain outside this focused verification.",
+  "baseline": "f0126429a0df1253e2d695bd18bc1084718d7b4d",
   "python_versions": ["3.12"],
   "expected_tests": {
-    "python": 4,
+    "python": 0,
     "frontend": 0,
     "native": 0,
-    "playwright": 3
+    "playwright": 4
   },
-  "python": [
-    "tests/v3/test_harnesses.py::test_harness_skill_catalog_is_bounded_and_invocation_is_validated",
-    "tests/v3/test_harnesses.py::test_disabled_nebula_knowledge_does_not_suppress_installed_skills",
-    "tests/v3/test_harnesses.py::test_transport_loss_and_restart_interrupt_without_replay",
-    "tests/v3/test_harnesses.py::test_harness_chat_enables_direct_knowledge_with_privacy_confirmation"
-  ],
+  "python": [],
   "frontend": [],
   "native": [],
   "playwright": [
-    "entry:stabilization/desktop",
-    "entry:stabilization/mobile-chromium-small",
-    "entry:stabilization/mobile-webkit-small"
+    "entry:assistant/desktop",
+    "entry:assistant/mobile-chromium",
+    "entry:assistant/mobile-webkit",
+    "entry:assistant/assistant-real-desktop"
   ],
-  "change_digest": "865ef80d771cbdf72eb1bb7f01ebbc70793f9d5aa1a615ea3e729e1db60e85fb",
+  "change_digest": "45911467fefc1e93e6badc889efe4fd7151553f003386f9490e73dc03f13cb22",
   "python_browser": false,
   "python_node": false
 }

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -539,7 +539,6 @@ export function SessionsPage() {
   const [skillMenuIndex, setSkillMenuIndex] = useState(0);
   const [selectedMcpIds, setSelectedMcpIds] = useState<string[]>([]);
   const [model, setModel] = useState("");
-  const [includeKnowledge, setIncludeKnowledge] = useState(true);
   const [commandRuntimeReady, setCommandRuntimeReady] = useState(false);
   const [toolRuntimeReason, setToolRuntimeReason] = useState<string>();
   const [toolCards, setToolCards] = useState<ToolLifecycleCard[]>([]);
@@ -1085,11 +1084,6 @@ export function SessionsPage() {
   }, [coreState, providerId, refreshProvider, runtimeKind, sessionId]);
 
   useEffect(() => {
-    if (coreState !== "online" || (runtimeKind === "provider" ? !selectedProvider : !selectedHarness)) return;
-    setIncludeKnowledge(canUseKnowledge);
-  }, [canUseKnowledge, coreState, runtimeKind, selectedHarness, selectedProvider]);
-
-  useEffect(() => {
     sessionLoadAbortRef.current?.abort();
     historicalActivityAbortRef.current.forEach((controller) => controller.abort());
     historicalActivityAbortRef.current.clear();
@@ -1442,7 +1436,6 @@ export function SessionsPage() {
     const provider = enabledProviders.find((item) => item.id === id);
     setProviderId(id);
     setModel(provider?.models[0] ?? "");
-    setIncludeKnowledge(Boolean(knowledgeItemCount && (provider?.kind === "local" || provider?.privacy === "local_only" || provider?.permitsSensitiveData)));
   };
 
   const modelDiscoveryInProgress = discoveringProviderId === providerId;
@@ -2255,19 +2248,9 @@ export function SessionsPage() {
         : item));
     };
 
-    const wantsKnowledge = includeKnowledge && knowledgeItemCount > 0;
-    let allowCloudKnowledge = false;
+    const wantsKnowledge = canUseKnowledge;
     const knowledgeRuntimeIsLocal = runtimeKind === "harness" ? harnessIsLocal : providerIsLocal;
-    const knowledgeRuntimePermitsSensitive = runtimeKind === "harness" ? harnessRuntime?.permitsSensitiveData : providerRuntime?.permitsSensitiveData;
-    if (wantsKnowledge && !knowledgeRuntimeIsLocal) {
-      if (!knowledgeRuntimePermitsSensitive) {
-        const detail = "This runtime profile is text-only. Enable project/document data in Settings or turn off knowledge retrieval.";
-        setChatError(detail);
-        failQueuedFollowUp(detail);
-        return;
-      }
-      allowCloudKnowledge = true;
-    }
+    const allowCloudKnowledge = wantsKnowledge && !knowledgeRuntimeIsLocal;
 
     const wantsTools = browserControlEnabled || (runtimeKind === "harness"
       ? Boolean(harnessSessionId
@@ -3076,7 +3059,8 @@ export function SessionsPage() {
                 {runtimeKind === "harness" && selectedHarness?.capabilities?.skillInvocation && !selectedHarness.nativeCapabilities.skills && <div className="chat-knowledge-toggle" role="status"><ShieldCheck size={15} /><span>Skills unavailable<small>Enable installed skills for this harness in Settings.</small></span></div>}
                 {runtimeKind === "harness" && selectedHarness && !selectedHarness.capabilities?.skillInvocation && <div className="chat-knowledge-toggle" role="status"><ShieldCheck size={15} /><span>Skills unavailable<small>This harness did not advertise structured skill invocation.</small></span></div>}
                 {runtimeKind === "harness" && selectedHarness?.capabilities?.skillInvocation && selectedHarness.nativeCapabilities.skills && <div className="chat-knowledge-toggle" role="status"><span><strong>Skills</strong><small>{harnessSkillError ?? (harnessSkillsLoading ? "Discovering project and installed skills…" : harnessSkills.length ? "Type $ in the composer to invoke a skill for one turn." : "No project or installed skills were discovered.")}</small></span></div>}
-                {runtimeKind === "provider" ? <><label className="chat-knowledge-toggle"><input type="checkbox" checked={includeKnowledge && canUseKnowledge} disabled={!canUseKnowledge || sending} onChange={(event) => setIncludeKnowledge(event.target.checked)} /><span>Use knowledge<small>{knowledgeItemCount ? runtimePermitsKnowledge ? `${knowledgeItemCount} project + Library item${knowledgeItemCount === 1 ? "" : "s"}` : "Profile is text-only" : "No sources loaded"}</small></span></label><div className="chat-knowledge-toggle" role="status" title={commandRuntimeUnavailableReason}><ShieldCheck size={15} /><span>Command runtime<small>{canUseTools ? "run_command and process_io ready" : commandRuntimeUnavailableReason}</small></span></div><div className="chat-harness-mcp"><span>MCP servers</span>{mcpServers.length ? mcpServers.map((server) => <label className="chat-knowledge-toggle" key={server.id}><input type="checkbox" checked={selectedMcpIds.includes(server.id)} disabled={sending} onChange={(event) => setSelectedMcpIds((current) => event.target.checked ? [...current, server.id] : current.filter((id) => id !== server.id))} /><span>{server.name}<small>{server.tools.length} tools · Core-captured</small></span></label>) : <small>No enabled MCP profiles</small>}</div></> : <><label className="chat-knowledge-toggle"><input type="checkbox" checked={includeKnowledge && canUseKnowledge} disabled={!canUseKnowledge || sending} onChange={(event) => setIncludeKnowledge(event.target.checked)} /><span>Use knowledge<small>{knowledgeItemCount ? runtimePermitsKnowledge ? `${knowledgeItemCount} bounded item${knowledgeItemCount === 1 ? "" : "s"}` : "Harness is text-only" : "No sources loaded"}</small></span></label><div className="chat-harness-mcp"><span>MCP servers</span>{harnessSessionId ? <small>Frozen in selected session</small> : mcpServers.length ? mcpServers.map((server) => <label className="chat-knowledge-toggle" key={server.id}><input type="checkbox" checked={selectedMcpIds.includes(server.id)} disabled={sending || Boolean(sessionId)} onChange={(event) => setSelectedMcpIds((current) => event.target.checked ? [...current, server.id] : current.filter((id) => id !== server.id))} /><span>{server.name}<small>{server.tools.length} tools · {server.defaultApproval.replace("_", " ")}</small></span></label>) : <small>No enabled MCP profiles</small>}</div></>}
+                <div className="chat-knowledge-toggle" role="status"><ShieldCheck size={15} aria-hidden="true" /><span>Knowledge<small>{knowledgeItemCount ? runtimePermitsKnowledge ? `${knowledgeItemCount} source${knowledgeItemCount === 1 ? "" : "s"} available automatically` : `${runtimeKind === "provider" ? "Profile" : "Harness"} is text-only` : "No sources loaded"}</small></span></div>
+                {runtimeKind === "provider" ? <><div className="chat-knowledge-toggle" role="status" title={commandRuntimeUnavailableReason}><ShieldCheck size={15} /><span>Command runtime<small>{canUseTools ? "run_command and process_io ready" : commandRuntimeUnavailableReason}</small></span></div><div className="chat-harness-mcp"><span>MCP servers</span>{mcpServers.length ? mcpServers.map((server) => <label className="chat-knowledge-toggle" key={server.id}><input type="checkbox" checked={selectedMcpIds.includes(server.id)} disabled={sending} onChange={(event) => setSelectedMcpIds((current) => event.target.checked ? [...current, server.id] : current.filter((id) => id !== server.id))} /><span>{server.name}<small>{server.tools.length} tools · Core-captured</small></span></label>) : <small>No enabled MCP profiles</small>}</div></> : <div className="chat-harness-mcp"><span>MCP servers</span>{harnessSessionId ? <small>Frozen in selected session</small> : mcpServers.length ? mcpServers.map((server) => <label className="chat-knowledge-toggle" key={server.id}><input type="checkbox" checked={selectedMcpIds.includes(server.id)} disabled={sending || Boolean(sessionId)} onChange={(event) => setSelectedMcpIds((current) => event.target.checked ? [...current, server.id] : current.filter((id) => id !== server.id))} /><span>{server.name}<small>{server.tools.length} tools · {server.defaultApproval.replace("_", " ")}</small></span></label>) : <small>No enabled MCP profiles</small>}</div>}
                 </div>
                 </div>
               </section>, document.body)}
@@ -3432,7 +3416,7 @@ export function SessionsPage() {
               ["Corrections", activeContextStatus.snapshot.memory.corrections],
               ["Open questions", activeContextStatus.snapshot.memory.openQuestions],
             ] as const).map(([label, items]) => items.length ? <section key={label}><strong>{label}</strong><ul>{items.map((item, index) => <li key={`${label}-${index}`}>{item.text}</li>)}</ul></section> : null)}<small>{activeContextStatus.snapshot.sourceReferences.length} source reference{activeContextStatus.snapshot.sourceReferences.length === 1 ? "" : "s"} · private reasoning is not stored</small></div></details>}</> : <p>Context status has not been recorded yet.</p>}</section>
-          <section><h3>Knowledge boundary</h3><div className="scope-chip-list"><span>{knowledgeSources.length} project · {libraryItems.length} Library</span><span>{providerIsLocal ? "Local retrieval" : includeKnowledge && canUseKnowledge ? "Confirm each cloud request" : "Text only"}</span></div></section>
+          <section><h3>Knowledge boundary</h3><div className="scope-chip-list"><span>{knowledgeSources.length} project · {libraryItems.length} Library</span><span>{canUseKnowledge ? providerIsLocal ? "Local retrieval · automatic" : "Cloud retrieval · automatic" : "Text only"}</span></div></section>
           <section><h3>Execution boundary</h3><div className="empty-state mini"><Braces size={19} /><p>{canUseTools ? "Bash commands run in this session's isolated container; configured approvals pause this response." : commandRuntimeUnavailableReason ?? "Command runtime is unavailable for this session."}</p></div></section>
 
         <details><summary>Technical session details</summary>          <dl><div><dt>Active operator</dt><dd>{activeOperator?.displayName ?? "No active operator"}</dd></div><div><dt>Conversation</dt><dd>{conversationOpen ? sessionId ? sessions.find((session) => session.id === sessionId)?.title ?? "Saved chat" : "Unsaved chat" : "None selected"}</dd></div><div><dt>Runtime</dt><dd>{runtimeKind === "harness" ? selectedHarness?.name ?? "Harness" : selectedProvider?.name ?? "Not selected"}</dd></div>{runtimeKind === "harness" && <div><dt>Model configuration</dt><dd>{model || "Not selected"}{harnessReasoningEffort ? ` · ${harnessReasoningEffort} effort` : ""}{harnessServiceTier ? ` · ${harnessServiceTier} speed` : ""}</dd></div>}{runtimeKind === "harness" && harnessSessionId && <div><dt>Harness session</dt><dd><code title={harnessSessionId}>{harnessSessionId}</code></dd></div>}<div><dt>Code Run</dt><dd><span className={`status-dot ${executionCapabilities?.ready ? "healthy" : "unavailable"}`} /> {executionCapabilities?.ready ? "Review available" : "Unavailable"}</dd></div></dl></details></>}

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -5804,6 +5804,63 @@ test("assistant upgrade foundation keeps empty chat quiet and settings opaque", 
   await expect(page.getByRole("button", {name: "Assistant settings", exact: true})).toBeFocused();
 });
 
+test("assistant upgrade makes loaded knowledge sources available automatically", async ({ page }) => {
+  const provider = {
+    ...entity,
+    id: "automatic-knowledge-provider",
+    name: "Automatic knowledge provider",
+    provider_type: "vllm",
+    endpoint: "http://127.0.0.1:8000/v1",
+    enabled: true,
+    is_local: true,
+    secret_ref: null,
+    model_allowlist: ["knowledge-model"],
+    capabilities: { streaming: true },
+    privacy: { local_only: true, permits_sensitive_data: false },
+    metadata: { default_model: "knowledge-model" },
+  };
+  let sent: Record<string, unknown> | undefined;
+  await page.route("**/api/v1/**", async route => {
+    const path = new URL(route.request().url()).pathname;
+    if (path.endsWith("/providers") && route.request().method() === "GET") {
+      await route.fulfill({ json: [provider] });
+    } else if (path.endsWith("/knowledge") && route.request().method() === "GET") {
+      await route.fulfill({ json: [{
+        ...entity,
+        id: "automatic-source",
+        engagement_id: "scratch-project",
+        name: "operator-notes.md",
+        source_type: "text/markdown",
+        status: "ready",
+        citation: "Operator notes",
+        document_count: 1,
+        metadata: {},
+      }] });
+    } else if (path.endsWith("/chat/completions")) {
+      sent = route.request().postDataJSON();
+      const frames = [
+        { type: "started", provider_id: provider.id, model: "knowledge-model", session_id: "automatic-knowledge-chat", turn_id: "automatic-knowledge-turn" },
+        { type: "done", provider_id: provider.id, model: "knowledge-model", session_id: "automatic-knowledge-chat", turn_id: "automatic-knowledge-turn", message: { id: "automatic-answer", role: "assistant", content: "Knowledge was available." }, usage: { input_tokens: 4, output_tokens: 3, total_tokens: 7 }, finish_reason: "stop", citations: [] },
+      ];
+      await route.fulfill({ contentType: "text/event-stream", body: frames.map(frame => `data: ${JSON.stringify(frame)}\n\n`).join("") + "data: [DONE]\n\n" });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await openWorkspace(page, "/?view=chat", "Workbench");
+  await page.getByRole("button", { name: "New chat", exact: true }).click();
+  await page.getByRole("button", { name: "Assistant settings", exact: true }).click();
+  const settings = page.getByRole("dialog", { name: "Assistant settings" });
+  await expect(settings.getByRole("checkbox", { name: /Use knowledge/ })).toHaveCount(0);
+  await expect(settings.getByRole("status").filter({ hasText: "Knowledge1 source available automatically" })).toBeVisible();
+  await page.getByRole("button", { name: "Close assistant settings", exact: true }).click();
+  await page.getByPlaceholder("Ask about this project…").fill("Use the project notes.");
+  await page.getByRole("button", { name: "Send message", exact: true }).click();
+  await expect.poll(() => sent).toMatchObject({ include_knowledge: true, allow_cloud_knowledge: false });
+  await expect(page.getByText("Knowledge was available.", { exact: true }).first()).toBeVisible();
+});
+
 test("browser Assistant approves its requested upload after a device file is staged", async ({ page }) => {
   test.setTimeout(60000);
   const files: Array<{ reference: string; filename: string; size: number; media_type: string }> = [];

--- a/ui/tests/real-core.spec.ts
+++ b/ui/tests/real-core.spec.ts
@@ -2052,6 +2052,44 @@ for (const runtime of [
   });
 }
 
+test("assistant upgrade production LAN enables durable knowledge automatically", async ({ page }) => {
+  test.setTimeout(90_000);
+  const core = await startRealCore({bindHost: "0.0.0.0", browserHost: localNetworkIpv4()});
+  const stub = await startLocalModelStub({streamDelayMs: 50});
+  const api = await playwrightRequest.newContext({baseURL: `${core.origin}/api/v1/`, extraHTTPHeaders: {Authorization: `Bearer ${core.token}`}});
+  try {
+    const projects = await (await api.get("engagements")).json() as Array<{id: string}>;
+    const project = projects[0];
+    const providerResponse = await api.post("providers", {data: {name: "Automatic knowledge acceptance", provider_type: "vllm", endpoint: `${stub.origin}/v1`, enabled: true, is_local: true, model_allowlist: ["security-model"], privacy: {local_only: true, residency: [], permits_sensitive_data: false}, metadata: {default_model: "security-model"}}});
+    expect(providerResponse.ok(), await providerResponse.text()).toBe(true);
+    const sourceResponse = await api.post("knowledge/ingest", {data: {
+      engagement_id: project.id,
+      filename: "automatic-knowledge.md",
+      media_type: "text/markdown",
+      content_base64: Buffer.from("# Project marker\n\nThe automatic knowledge marker is NEBULA_AUTO_KNOWLEDGE.").toString("base64"),
+    }});
+    expect(sourceResponse.ok(), await sourceResponse.text()).toBe(true);
+
+    await page.goto(`${core.origin}/projects/${project.id}/workbench?view=chat#token=${encodeURIComponent(core.token)}`);
+    await expect(page.getByRole("button", {name: /Nebula Core (ready|degraded)/})).toBeVisible({timeout: 20_000});
+    await page.getByRole("button", {name: "Start new chat", exact: true}).click();
+    await page.getByRole("button", {name: "Assistant settings", exact: true}).click();
+    const settings = page.getByRole("dialog", {name: "Assistant settings"});
+    await expect(settings.getByRole("checkbox", {name: /Use knowledge/})).toHaveCount(0);
+    await expect(settings.getByRole("status").filter({hasText: "Knowledge1 source available automatically"})).toBeVisible();
+    await page.getByRole("button", {name: "Close assistant settings", exact: true}).click();
+    const completion = page.waitForRequest(request => request.url().endsWith("/api/v1/chat/completions") && request.method() === "POST");
+    await page.getByRole("textbox", {name: "Message the analyst assistant"}).fill("What is the project marker?");
+    await page.getByRole("button", {name: "Send message", exact: true}).click();
+    expect((await completion).postDataJSON()).toMatchObject({include_knowledge: true, allow_cloud_knowledge: false});
+    await expect(page.locator(".chat-message.assistant .assistant-markdown").last()).toContainText("Core is continuing in Project A", {timeout: 20_000});
+  } finally {
+    await api.dispose();
+    await stopLocalModelStub(stub);
+    await stopRealCore(core);
+  }
+});
+
 test("assistant upgrade deployed local service retains operator workflow", async ({page}, testInfo) => {
   const origin = process.env.NEBULA_ASSISTANT_LIVE_ORIGIN;
   const tokenFile = process.env.NEBULA_ASSISTANT_LIVE_TOKEN_FILE;


### PR DESCRIPTION
Loaded project and Library sources are now included automatically when the selected runtime permits project data. The assistant settings replace the per-turn checkbox with an availability status, while text-only runtimes continue without knowledge and existing provider privacy policy remains authoritative.

Validation:
- 3 focused mocked-browser checks passed: desktop Chromium, emulated mobile Chromium, and emulated mobile WebKit
- 1 production-bundle real-Core LAN check passed with a durably ingested source
- `npm --prefix ui run build`
- focused test-selection receipt validated against `origin/main`

Physical-device, packaged-desktop, and live external Codex App Server checks were not run.
