### PR TITLE
Add manual browser testing and resizable side panels

### DIFF
--- a/.github/test-selection.json
+++ b/.github/test-selection.json
@@ -1,24 +1,37 @@
 {
-  "reviewed_by": "Codex, alpha.16 AppImage integrity repair",
-  "reason": "The release-only change prevents linuxdeploy from stripping the bundled Chromium executable so the staged SHA-256 manifest remains valid inside the AppImage, synchronizes alpha.16 version sources, and adds release notes. The packaging tests cover the workflow command, package tree integrity, version synchronization, and release contracts.",
-  "exclusions": "No application, backend, UI, state, API, or Rust behavior changes. The terminal Assistant product matrix and sandbox integration passed on the identical application commit in alpha.15 preparation run 34619152649. Frontend, native, Playwright, and unrelated Python suites are excluded. Three updater-manifest tests, production UI build, and locked Rust checks run separately. This is not full-suite approval.",
-  "baseline": "19ae74eaeb91089080f9b6ce8168cb6118cf3a98",
+  "reviewed_by": "Codex Security Browser and resizable side-panel review",
+  "reason": "Verifies the requested manual Security Browser lifecycle (pause, Repeater handoff/send, response review, and resume), registers the lazily started managed-browser adapter with guided assessments, preserves the live native browser beside adjustable manual controls, and adds one shared persisted, pointer- and keyboard-adjustable width contract to Browser Assistant, Terminal Assistant, and the Security Browser workspace. Focused component tests cover assessment/Repeater state and sizing bounds; selected browser and terminal-assistant journeys cover desktop resizing and full-width mobile behavior.",
+  "exclusions": "Providers, missions, reports, settings, release/packaging, native Rust commands, and unrelated Workbench journeys are excluded. Native child bounds continue through the existing bridge contract and are exercised by the focused desktop browser journey, so no broad native suite is selected. This is not approval for a full suite. Physical-device testing is unavailable; mobile checks use the repository's permanent emulated Chromium and WebKit profiles. Traffic-to-Repeater capture cannot be exercised in this Linux build because browser event capture reports unavailable; direct editable Repeater send is covered instead.",
+  "baseline": "3e793bb245ab03486cb3e5355428ebd6fc6fe570",
   "python_versions": [
     "3.12"
   ],
   "expected_tests": {
-    "python": 33,
-    "frontend": 0,
+    "python": 9,
+    "frontend": 11,
     "native": 0,
-    "playwright": 0
+    "playwright": 7
   },
   "python": [
-    "tests/v3/test_packaging.py"
+    "tests/v3/test_browser_assessments.py",
+    "tests/v3/test_browser_host.py"
   ],
-  "frontend": [],
+  "frontend": [
+    "ui/src/components/SecurityBrowserWorkspacePanel.test.tsx",
+    "ui/src/components/BrowserResearchSuite.test.tsx",
+    "ui/src/components/useResizableSidePanel.test.tsx"
+  ],
   "native": [],
-  "playwright": [],
-  "change_digest": "b72995606441cb6e2edd585834ceca1d7ab904352d6a63996b18867a9177bfe7",
+  "playwright": [
+    "entry:browser/desktop",
+    "entry:browser/browser-chromium-landscape",
+    "entry:browser/browser-webkit-landscape",
+    "entry:terminal-assistant/desktop",
+    "entry:terminal-assistant/mobile-chromium-small",
+    "entry:terminal-assistant/mobile-webkit-small",
+    "entry:core-api/real-core"
+  ],
+  "change_digest": "7412aa4b7c1ae1f536ce6821442db2fdf941c60e6a9595485ff6b5c59f81e7e1",
   "python_browser": false,
   "python_node": false
 }

--- a/src/nebula/v3/browser_companion.py
+++ b/src/nebula/v3/browser_companion.py
@@ -372,6 +372,10 @@ class BrowserCompanion:
             host = host_ref()
             if host is not None:
                 adapter = await host.adapter()
+                # Assessments and the companion share this registry. Once the
+                # lazy desktop host is ready, publish that authoritative adapter
+                # so guided preflight and pause/resume see the same capability.
+                self.engines.register(adapter)
         if not isinstance(adapter, LocalBrowserdAdapter):
             raise ValueError(
                 "Managed Chromium is unavailable. Prepare the browser runtime on the Nebula host, then retry. Your saved conversations remain available."

--- a/tests/v3/test_browser_host.py
+++ b/tests/v3/test_browser_host.py
@@ -88,3 +88,39 @@ def test_partial_external_configuration_does_not_switch_browser_profiles(
     )
     with pytest.raises(ValueError, match="Managed Chromium is unavailable"):
         asyncio.run(service.adapter())
+
+
+def test_lazy_host_adapter_becomes_available_to_guided_assessments(tmp_path):
+    from nebula.v3.browser_companion import BrowserCompanion
+    from nebula.v3.browser_engine import LocalBrowserdAdapter, BrowserEngineRegistry
+    from nebula.v3.domain import BrowserEngineCapability, BrowserEngineState
+
+    class ReadyAdapter(LocalBrowserdAdapter):
+        def __init__(self):
+            super().__init__("http://127.0.0.1:4711", "fixture-token")
+
+        async def readiness(self):
+            return BrowserEngineCapability(
+                adapter="managed-chromium",
+                display_name="Managed Chromium",
+                state=BrowserEngineState.READY,
+                installed_version="fixture",
+                digest=f"sha256:{'a' * 64}",
+                actions=["navigate", "takeover"],
+                protocols=["http", "https"],
+            )
+
+    adapter = ReadyAdapter()
+
+    class Host:
+        async def adapter(self):
+            return adapter
+
+    host = Host()
+    registry = BrowserEngineRegistry([])
+    companion = BrowserCompanion(
+        NebulaStore(tmp_path / "core.db"), registry, managed_host=host
+    )
+
+    assert asyncio.run(companion.adapter()) is adapter
+    assert asyncio.run(registry.adapter("managed-chromium")) is adapter

--- a/ui/src/browser-assistant.css
+++ b/ui/src/browser-assistant.css
@@ -7,7 +7,7 @@
 .integrated-browser-page > .workbench-browser { flex: 1; min-height: 0; }
 .terminal-companion-page > .container-terminal-shell { flex: 1; min-height: 0; }
 .terminal-companion-page > .browser-workspace-toolbar > span { display: flex; align-items: center; gap: 8px; color: var(--muted); font-size: 12px; }
-.integrated-browser-assistant { flex: 1 1 45%; min-width: 0; min-height: 0; display: flex; flex-direction: column; overflow: hidden; }
+.integrated-browser-assistant { position: relative; flex: 1 1 45%; min-width: 0; min-height: 0; display: flex; flex-direction: column; overflow: hidden; }
 .integrated-browser-assistant > header { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .integrated-browser-assistant > header > strong { margin-right: auto; }
 .integrated-browser-assistant .chat-panel { flex: 1; min-height: 0; }

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -660,8 +660,12 @@ kbd { font-size: 11px; }
 .browser-selection-error { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--red); font-size: 11px; line-height: 1.45; }
 .browser-selection-assistant > footer { justify-content: space-between; gap: 10px; color: var(--muted); font-size: 11px; }
 .browser-unavailable { min-height: 590px; }
-.workbench-browser.research-open > .browser-surface { margin-right: min(920px, 68vw); }
+.workbench-browser.research-open > .browser-surface { margin-right: min(var(--security-browser-panel-width, 920px), calc(100% - 320px)); }
 .browser-research-panel { position: absolute; z-index: 6; top: 86px; right: 0; bottom: 0; display: flex; width: min(920px, 68vw); min-width: 640px; max-width: calc(100% - 320px); flex-direction: column; overflow: hidden; border-left: 1px solid var(--border); color: var(--text); background: var(--surface-raised); box-shadow: var(--shadow-lg); }
+.side-panel-resize-handle { position: absolute; z-index: 8; inset: 0 auto 0 -11px; width: 22px; cursor: col-resize; touch-action: none; }
+.side-panel-resize-handle::after { content: ""; position: absolute; inset: 0 auto 0 10px; width: 2px; background: transparent; transition: background-color 120ms ease; }
+.side-panel-resize-handle:hover::after, .side-panel-resize-handle:focus-visible::after { background: var(--blue); }
+.side-panel-resize-handle:focus-visible { outline: 2px solid var(--blue); outline-offset: -4px; }
 .browser-research-panel > header { display: flex; min-height: 58px; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 10px 10px 14px; border-bottom: 1px solid var(--border-soft); }
 .browser-research-panel > header > div { display: grid; min-width: 0; gap: 3px; }
 .browser-research-panel > header strong { font-size: 13px; }
@@ -690,7 +694,7 @@ kbd { font-size: 11px; }
 .security-browser-empty strong, .security-browser-welcome h2 { margin: 0; color: var(--text); }
 .security-browser-empty span, .security-browser-welcome p { margin: 0; font-size: 11px; line-height: 1.5; }
 .security-browser-main { display: flex; min-width: 0; min-height: 0; flex-direction: column; overflow: hidden; }
-.security-browser-run-summary { display: grid; gap: 9px; padding: 12px; border-bottom: 1px solid var(--border); background: var(--surface); }
+.security-browser-run-summary { display: grid; max-height: 46%; flex: 0 1 auto; gap: 9px; padding: 12px; overflow: auto; border-bottom: 1px solid var(--border); background: var(--surface); }
 .security-browser-run-summary > header { display: flex; min-width: 0; align-items: flex-start; justify-content: space-between; gap: 10px; }
 .security-browser-run-summary > header > div:first-child { display: grid; min-width: 0; gap: 4px; }
 .security-browser-run-summary h2 { margin: 0; font-size: 15px; }
@@ -911,7 +915,7 @@ kbd { font-size: 11px; }
 .web-browser-fallback .browser-start { overflow: auto; justify-content: safe center; }
 .web-browser-fallback .browser-start input:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
 .web-browser-fallback .browser-research-panel { top: 55px; width: min(920px, 100%); }
-.web-browser-fallback.research-open > .browser-surface { margin-right: min(920px, 68vw); }
+.web-browser-fallback.research-open > .browser-surface { margin-right: min(var(--security-browser-panel-width, 920px), calc(100% - 320px)); }
 @media (max-width: 1100px) {
   .workbench-browser.research-open > .browser-surface, .web-browser-fallback.research-open > .browser-surface { margin-right: 0; visibility: hidden; }
   .browser-research-panel { width: 100%; min-width: 0; max-width: none; border-left: 0; }
@@ -929,6 +933,7 @@ kbd { font-size: 11px; }
   .security-browser-layout { display: flex; flex-direction: column; overflow: auto; }
   .security-browser-assessment-rail { min-height: 210px; max-height: 42%; border-right: 0; border-bottom: 1px solid var(--border); }
   .security-browser-main { min-height: 520px; overflow: visible; }
+  .security-browser-run-summary { max-height: none; overflow: visible; }
   .security-browser-run-summary > header { flex-direction: column; }
   .security-browser-run-controls { width: 100%; justify-content: stretch; }
   .security-browser-run-controls .button { min-height: 44px; flex: 1; justify-content: center; }

--- a/ui/src/components/BrowserAssistantPanel.tsx
+++ b/ui/src/components/BrowserAssistantPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
+import { useResizableSidePanel } from "./useResizableSidePanel";
 
 export const BROWSER_ASSISTANT_SHEET_QUERY = "(max-width: 760px), (pointer: coarse) and (max-height: 500px)";
 
@@ -20,6 +21,15 @@ export function BrowserAssistantPanel({ header, children, onActionContainer, pan
       height: Math.min(560, height - reserve - 12, Math.max(240, height * .68)) };
   };
   const [viewport, setViewport] = useState(measure);
+  const size = useResizableSidePanel({
+    defaultWidth: 560,
+    enabled: !viewport.mobile,
+    label: `Resize ${label}`,
+    maxWidth: 900,
+    minPrimaryWidth: 360,
+    minWidth: 360,
+    storageKey: `nebula.${panelId}.width`,
+  });
   useEffect(() => {
     const update = () => setViewport(measure());
     window.addEventListener("resize", update);
@@ -31,8 +41,9 @@ export function BrowserAssistantPanel({ header, children, onActionContainer, pan
       window.visualViewport?.removeEventListener("scroll", update);
     };
   }, []);
-  const panel = <aside id={panelId} className={`integrated-browser-assistant${viewport.mobile ? " browser-assistant-sheet" : ""}`} aria-label={label}
-    style={viewport.mobile ? { bottom: `calc(${viewport.bottom}px + env(safe-area-inset-bottom, 0px))`, height: `calc(${viewport.height}px - env(safe-area-inset-bottom, 0px))` } : undefined}>
+  const panel = <aside ref={size.panelRef} id={panelId} className={`integrated-browser-assistant${viewport.mobile ? " browser-assistant-sheet" : ""}`} aria-label={label}
+    style={viewport.mobile ? { bottom: `calc(${viewport.bottom}px + env(safe-area-inset-bottom, 0px))`, height: `calc(${viewport.height}px - env(safe-area-inset-bottom, 0px))` } : size.panelStyle}>
+    {size.resizeHandle}
     <header>{header}</header>
     {viewport.mobile && <div ref={onActionContainer} className="browser-assistant-required-actions" />}
     {children}

--- a/ui/src/components/SecurityBrowserWorkspacePanel.tsx
+++ b/ui/src/components/SecurityBrowserWorkspacePanel.tsx
@@ -26,6 +26,7 @@ import type {
 } from "../api/types";
 import type { StreamState } from "../api/events";
 import { logCaughtDiagnostic } from "../diagnostics";
+import { useResizableSidePanel } from "./useResizableSidePanel";
 
 interface SecurityBrowserWorkspacePanelProps {
   api: ApiClient;
@@ -37,6 +38,7 @@ interface SecurityBrowserWorkspacePanelProps {
   toolNavigation: ReactNode;
   children: ReactNode;
   onClose: () => void;
+  onWidthChange?: (width: number | undefined) => void;
 }
 
 const PROFILE_ORDER: SecurityBrowserAssessmentProfile[] = [
@@ -69,6 +71,7 @@ export function SecurityBrowserWorkspacePanel({
   toolNavigation,
   children,
   onClose,
+  onWidthChange,
 }: SecurityBrowserWorkspacePanelProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const [workspace, setWorkspace] = useState<SecurityBrowserAssessmentWorkspace>();
@@ -84,6 +87,25 @@ export function SecurityBrowserWorkspacePanel({
   const [validationTechnique, setValidationTechnique] = useState("");
   const [validationMaxRequests, setValidationMaxRequests] = useState(10);
   const [validationDurationSeconds, setValidationDurationSeconds] = useState(600);
+  const [compact, setCompact] = useState(() => globalThis.matchMedia?.("(max-width: 1100px)").matches ?? false);
+  const size = useResizableSidePanel({
+    defaultWidth: 920,
+    enabled: !compact,
+    label: "Resize Security Browser workspace",
+    maxWidth: 1280,
+    minPrimaryWidth: 320,
+    minWidth: 640,
+    onWidthChange,
+    storageKey: "nebula.security-browser-workspace.width",
+  });
+
+  useEffect(() => {
+    const media = globalThis.matchMedia?.("(max-width: 1100px)");
+    if (!media) return;
+    const update = () => setCompact(media.matches);
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
 
   const selectedId = searchParams.get("assessment") ?? undefined;
   const selected = workspace?.assessments.find((assessment) => assessment.id === selectedId);
@@ -372,7 +394,8 @@ export function SecurityBrowserWorkspacePanel({
     </section>,
   ];
 
-  return <aside className="browser-research-panel security-browser-workspace" aria-label="Security Browser workspace">
+  return <aside ref={size.panelRef} style={size.panelStyle} className="browser-research-panel security-browser-workspace" aria-label="Security Browser workspace">
+    {size.resizeHandle}
     <header>
       <div><strong>Security Browser</strong><small>Guided assessments, live browser, evidence, and expert tools</small></div>
       <div className="security-browser-header-actions"><span className={`security-browser-stream stream-${streamState}`}>{stateLabel(streamState)}</span><button type="button" aria-label="Close Security Browser" onClick={onClose}><X size={17} /></button></div>

--- a/ui/src/components/WorkbenchBrowser.tsx
+++ b/ui/src/components/WorkbenchBrowser.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type FormEvent } from "react";
 import { ArrowLeft, ArrowRight, BookOpenCheck, BookPlus, Bug, Check, Download, ExternalLink, GitCompareArrows, Globe2, History, LoaderCircle, MessageSquareText, Network, Plus, RefreshCw, Search, Send, ShieldCheck, Sparkles, Square, Trash2, UserRound, X } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { Link, useSearchParams } from "react-router-dom";
@@ -168,6 +168,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   const [workspaceError, setWorkspaceError] = useState<string>();
   const [sessionId, setSessionId] = useState<string | undefined>(() => searchParams.get("browserSession") ?? undefined);
   const [researchOpen, setResearchOpen] = useState(false);
+  const [researchPanelWidth, setResearchPanelWidth] = useState<number>();
   const [researchView, setResearchView] = useState<ResearchView>(() => normalizedResearchView(searchParams.get("tool") ?? searchParams.get("browserTool")));
   const [selectedExchangeIds, setSelectedExchangeIds] = useState<string[]>(() => searchParams.get("browserExchange") ? [searchParams.get("browserExchange")!] : []);
   const [identityName, setIdentityName] = useState("");
@@ -255,7 +256,8 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   const scopeDecision = scopeLoading
     ? { state: "unknown" as const, label: "Checking scope", detail: "Loading the durable Project scope." }
     : evaluateBrowserScope(desktop ? activeTab?.url : deviceAddress?.url, scope);
-  const browserVisible = desktop && active && !activityOpen && !paletteOpen && !settingLensOpen && !dialogOpen
+  const researchCoversBrowser = researchOpen && window.matchMedia("(max-width: 1100px)").matches;
+  const browserVisible = desktop && active && !researchCoversBrowser && !activityOpen && !paletteOpen && !settingLensOpen && !dialogOpen
     && (sidebarCollapsed || !window.matchMedia("(max-width: 760px)").matches);
 
   const bounds = useCallback((): BrowserBounds | undefined => {
@@ -1624,6 +1626,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
     session={activeSession}
     targetOptions={automationTargetOptions}
     onClose={() => setResearchOpen(false)}
+    onWidthChange={setResearchPanelWidth}
     toolNavigation={<nav aria-label="Security Browser tools">
       <button type="button" className={researchView === "target" ? "active" : ""} onClick={() => setResearchView("target")}>Target</button>
       <button type="button" className={researchView === "traffic" ? "active" : ""} onClick={() => setResearchView("traffic")}><Network size={14} /> Traffic <span>{sessionTraffic.length}</span></button>
@@ -1701,7 +1704,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
     </div>}
   </SecurityBrowserWorkspacePanel> : null;
 
-  if (!desktop) return <div className={`workbench-browser web-browser-fallback${researchOpen ? " research-open" : ""}`}>
+  if (!desktop) return <div className={`workbench-browser web-browser-fallback${researchOpen ? " research-open" : ""}`} style={researchPanelWidth ? { "--security-browser-panel-width": `${researchPanelWidth}px` } as CSSProperties : undefined}>
     <div className="browser-web-research-bar"><button className="button secondary" type="button" aria-expanded={researchOpen} onClick={() => setResearchOpen((value) => !value)}><Network size={14} /> Research workbench</button><span>Durable history and desktop handoff are available on paired devices.</span></div>
     {error && <div className="browser-notice error" role="alert"><span>{error}</span><button type="button" aria-label="Dismiss browser error" onClick={() => setError(undefined)}><X size={14} /></button></div>}
     {notice && <div className="browser-notice" role="status">
@@ -1728,7 +1731,7 @@ export function WorkbenchBrowser({ active, api, operatorId = "operator", project
   </div>;
 
   return (
-    <div className={`workbench-browser${researchOpen ? " research-open" : ""}`}>
+    <div className={`workbench-browser${researchOpen ? " research-open" : ""}`} style={researchPanelWidth ? { "--security-browser-panel-width": `${researchPanelWidth}px` } as CSSProperties : undefined}>
       <div className="browser-tab-strip" role="tablist" aria-label="Browser tabs">
         {tabs.map((tab) => <div className={tab.id === activeId ? "browser-tab active" : "browser-tab"} key={tab.id}><button type="button" role="tab" aria-selected={tab.id === activeId} title={tab.title} onClick={() => setActiveId(tab.id)}>{tab.loading ? <LoaderCircle className="spin" size={13} /> : <Globe2 size={13} />}<span>{tab.title}</span></button><button type="button" aria-label={`Close ${tab.title}`} onClick={() => void closeTab(tab.id)}><X size={13} /></button></div>)}
         <button className="browser-new-tab" type="button" aria-label="New browser tab" disabled={tabs.length >= MAX_TABS} onClick={() => addTab()}><Plus size={15} /></button>

--- a/ui/src/components/useResizableSidePanel.test.tsx
+++ b/ui/src/components/useResizableSidePanel.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useResizableSidePanel } from "./useResizableSidePanel";
+
+function Harness({ enabled = true }: { enabled?: boolean }) {
+  const size = useResizableSidePanel({
+    defaultWidth: 560,
+    enabled,
+    label: "Resize test panel",
+    maxWidth: 900,
+    minPrimaryWidth: 320,
+    minWidth: 360,
+    storageKey: "nebula.test-panel.width",
+  });
+  return <main><aside ref={size.panelRef} style={size.panelStyle}>{size.resizeHandle}<span>Panel</span></aside></main>;
+}
+
+describe("useResizableSidePanel", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("resizes from the keyboard, clamps to safe bounds, and persists the width", () => {
+    render(<Harness />);
+    const handle = screen.getByRole("separator", { name: "Resize test panel" });
+    expect(handle).toHaveAttribute("aria-valuenow", "560");
+
+    fireEvent.keyDown(handle, { key: "ArrowLeft" });
+    expect(handle).toHaveAttribute("aria-valuenow", "584");
+    expect(localStorage.getItem("nebula.test-panel.width")).toBe("584");
+
+    fireEvent.keyDown(handle, { key: "End" });
+    expect(handle).toHaveAttribute("aria-valuenow", "704");
+    fireEvent.keyDown(handle, { key: "Home" });
+    expect(handle).toHaveAttribute("aria-valuenow", "360");
+  });
+
+  it("restores a saved width and omits desktop sizing when disabled", () => {
+    localStorage.setItem("nebula.test-panel.width", "640");
+    const view = render(<Harness />);
+    expect(screen.getByRole("separator")).toHaveAttribute("aria-valuenow", "640");
+    view.rerender(<Harness enabled={false} />);
+    expect(screen.queryByRole("separator")).not.toBeInTheDocument();
+    expect((screen.getByText("Panel").parentElement as HTMLElement).style.width).toBe("");
+  });
+});

--- a/ui/src/components/useResizableSidePanel.tsx
+++ b/ui/src/components/useResizableSidePanel.tsx
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
+
+interface ResizableSidePanelOptions {
+  defaultWidth: number;
+  enabled?: boolean;
+  label: string;
+  maxWidth: number;
+  minPrimaryWidth: number;
+  minWidth: number;
+  onWidthChange?: (width: number | undefined) => void;
+  storageKey: string;
+}
+
+function storedWidth(key: string, fallback: number): number {
+  try {
+    const value = Number(globalThis.localStorage?.getItem(key));
+    return Number.isFinite(value) && value > 0 ? value : fallback;
+  } catch {
+    // diagnostic-expected: device-local preferences may be blocked or unavailable.
+    return fallback;
+  }
+}
+
+/** Shared, keyboard-accessible sizing behavior for right-hand operator panels. */
+export function useResizableSidePanel({
+  defaultWidth,
+  enabled = true,
+  label,
+  maxWidth,
+  minPrimaryWidth,
+  minWidth,
+  onWidthChange,
+  storageKey,
+}: ResizableSidePanelOptions) {
+  const panelRef = useRef<HTMLElement | null>(null);
+  const drag = useRef<{ pointerId: number; startWidth: number; startX: number } | undefined>(undefined);
+  const [width, setWidth] = useState(() => storedWidth(storageKey, defaultWidth));
+  const [, setViewportRevision] = useState(0);
+
+  const bounds = useCallback(() => {
+    const available = panelRef.current?.parentElement?.clientWidth || globalThis.innerWidth || maxWidth + minPrimaryWidth;
+    return {
+      min: minWidth,
+      max: Math.max(minWidth, Math.min(maxWidth, available - minPrimaryWidth)),
+    };
+  }, [maxWidth, minPrimaryWidth, minWidth]);
+
+  const resizeTo = useCallback((next: number) => {
+    const { min, max } = bounds();
+    setWidth(Math.round(Math.max(min, Math.min(max, next))));
+  }, [bounds]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    resizeTo(width);
+    const update = () => {
+      resizeTo(width);
+      setViewportRevision((value) => value + 1);
+    };
+    globalThis.addEventListener("resize", update);
+    return () => globalThis.removeEventListener("resize", update);
+  }, [enabled, resizeTo, width]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    try { globalThis.localStorage?.setItem(storageKey, String(width)); } catch { /* diagnostic-expected: device-local preferences may be unavailable. */ }
+  }, [enabled, storageKey, width]);
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!enabled) return;
+    drag.current = { pointerId: event.pointerId, startWidth: width, startX: event.clientX };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    event.preventDefault();
+  };
+
+  const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!drag.current || drag.current.pointerId !== event.pointerId) return;
+    resizeTo(drag.current.startWidth + drag.current.startX - event.clientX);
+  };
+
+  const endPointer = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (drag.current?.pointerId !== event.pointerId) return;
+    drag.current = undefined;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId);
+  };
+
+  const { min, max } = bounds();
+  const effectiveWidth = Math.max(min, Math.min(max, width));
+  useEffect(() => {
+    onWidthChange?.(enabled ? effectiveWidth : undefined);
+  }, [effectiveWidth, enabled, onWidthChange]);
+  const panelStyle: CSSProperties | undefined = enabled ? { flex: `0 0 ${effectiveWidth}px`, width: effectiveWidth } : undefined;
+  const resizeHandle = enabled ? <div
+    aria-label={label}
+    aria-orientation="vertical"
+    aria-valuemax={max}
+    aria-valuemin={min}
+    aria-valuenow={effectiveWidth}
+    className="side-panel-resize-handle"
+    onDoubleClick={() => resizeTo(defaultWidth)}
+    onKeyDown={(event) => {
+      const step = event.shiftKey ? 80 : 24;
+      if (event.key === "ArrowLeft") resizeTo(effectiveWidth + step);
+      else if (event.key === "ArrowRight") resizeTo(effectiveWidth - step);
+      else if (event.key === "Home") resizeTo(min);
+      else if (event.key === "End") resizeTo(max);
+      else return;
+      event.preventDefault();
+    }}
+    onPointerCancel={endPointer}
+    onPointerDown={onPointerDown}
+    onPointerMove={onPointerMove}
+    onPointerUp={endPointer}
+    role="separator"
+    tabIndex={0}
+    title="Drag to resize. Use Left and Right arrow keys when focused; double-click to reset."
+  /> : null;
+
+  return { panelRef, panelStyle, resizeHandle };
+}

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -904,7 +904,7 @@ test("browser keeps native bounds and opens scoped live context as a reviewed AI
       address: { top: addressRect.top, bottom: addressRect.bottom, height: addressRect.height },
       surfaceTop: surfaceRect.top,
       panelBottom: panelRect.bottom,
-      bounds: create?.args.bounds as { y: number; height: number },
+      bounds: create?.args.bounds as { x: number; y: number; width: number; height: number },
       devicePixelRatio: window.devicePixelRatio,
     };
   });
@@ -919,8 +919,51 @@ test("browser keeps native bounds and opens scoped live context as a reviewed AI
   expect(geometry.bounds.y + geometry.bounds.height).toBeLessThanOrEqual(geometry.panelBottom + 1);
   expect(geometry.devicePixelRatio).toBe(2);
   await expect(page.getByText("In scope")).toBeVisible();
+
+  const callsBeforeResearch = await page.evaluate(() => (
+    (window as Window & { __NEBULA_BROWSER_CALLS__?: Array<unknown> }).__NEBULA_BROWSER_CALLS__ ?? []
+  ).length);
+  await page.getByRole("button", { name: "Security research workbench" }).click();
+  const securityWorkspace = page.getByRole("complementary", { name: "Security Browser workspace", exact: true });
+  await expect(securityWorkspace).toBeVisible();
+  const securityResize = securityWorkspace.getByRole("separator", { name: "Resize Security Browser workspace" });
+  await expect(securityResize).toBeVisible();
+  await expect.poll(() => page.evaluate(() => {
+    const calls = (window as Window & { __NEBULA_BROWSER_CALLS__?: Array<{ command: string; args: Record<string, unknown> }> }).__NEBULA_BROWSER_CALLS__ ?? [];
+    const boundsCalls = calls.filter((call) => call.command === "browser_set_bounds");
+    const bounds = boundsCalls.at(-1)?.args.bounds as { width?: number } | undefined;
+    return bounds?.width ?? 0;
+  })).toBeLessThan(geometry.bounds.width);
+  const narrowedBrowserWidth = await page.evaluate(() => {
+    const calls = (window as Window & { __NEBULA_BROWSER_CALLS__?: Array<{ command: string; args: Record<string, unknown> }> }).__NEBULA_BROWSER_CALLS__ ?? [];
+    const boundsCalls = calls.filter((call) => call.command === "browser_set_bounds");
+    const bounds = boundsCalls.at(-1)?.args.bounds as { width?: number } | undefined;
+    return bounds?.width ?? 0;
+  });
+  const initialSecurityWidth = (await securityWorkspace.boundingBox())!.width;
+  await securityResize.focus();
+  await page.keyboard.press("ArrowRight");
+  await expect.poll(async () => (await securityWorkspace.boundingBox())!.width).toBeLessThan(initialSecurityWidth);
+  await expect.poll(() => page.evaluate(() => localStorage.getItem("nebula.security-browser-workspace.width"))).not.toBeNull();
+  await expect.poll(() => page.evaluate(() => {
+    const calls = (window as Window & { __NEBULA_BROWSER_CALLS__?: Array<{ command: string; args: Record<string, unknown> }> }).__NEBULA_BROWSER_CALLS__ ?? [];
+    const boundsCalls = calls.filter((call) => call.command === "browser_set_bounds");
+    const bounds = boundsCalls.at(-1)?.args.bounds as { width?: number } | undefined;
+    return bounds?.width ?? 0;
+  })).toBeGreaterThan(narrowedBrowserWidth);
+  expect(await page.evaluate((start) => {
+    const calls = (window as Window & { __NEBULA_BROWSER_CALLS__?: Array<{ command: string; args: Record<string, unknown> }> }).__NEBULA_BROWSER_CALLS__ ?? [];
+    return calls.slice(start).some((call) => call.command === "browser_set_visible" && call.args.visible === false);
+  }, callsBeforeResearch)).toBe(false);
   await page.screenshot({ path: testInfo.outputPath("browser-address-bar-2x.png") });
 
+  await page.getByRole("button", { name: "Security research workbench" }).click();
+  await expect.poll(() => page.evaluate(() => {
+    const calls = (window as Window & { __NEBULA_BROWSER_CALLS__?: Array<{ command: string; args: Record<string, unknown> }> }).__NEBULA_BROWSER_CALLS__ ?? [];
+    const boundsCalls = calls.filter((call) => call.command === "browser_set_bounds");
+    const bounds = boundsCalls.at(-1)?.args.bounds as { width?: number } | undefined;
+    return bounds?.width ?? 0;
+  })).toBeGreaterThan(narrowedBrowserWidth);
   await page.getByRole("button", { name: "Ask Nebula about the live page" }).click();
   await expect(page).toHaveURL(/view=browser/);
   const attachment = page.getByRole("region", { name: "Selected context pack" });
@@ -4665,6 +4708,17 @@ test("Terminal opens Assistant beside the live shell", async ({ page }) => {
   expect(bounds.right).toBeLessThanOrEqual(viewport.width + 1);
   expect(bounds.top).toBeGreaterThanOrEqual(0);
   expect(bounds.bottom).toBeLessThanOrEqual(viewport.height + 1);
+  const resizeHandle = assistant.getByRole("separator", { name: "Resize Terminal Assistant" });
+  if (viewport.width > 760) {
+    await expect(resizeHandle).toBeVisible();
+    const initialWidth = (await assistant.boundingBox())!.width;
+    await resizeHandle.focus();
+    await page.keyboard.press("ArrowLeft");
+    await expect.poll(async () => (await assistant.boundingBox())!.width).toBeGreaterThan(initialWidth);
+    await expect.poll(() => page.evaluate(() => localStorage.getItem("nebula.terminal-assistant-panel.width"))).not.toBeNull();
+  } else {
+    await expect(resizeHandle).toHaveCount(0);
+  }
   await assistant.getByRole("button", { name: "Collapse terminal Assistant" }).click();
   await expect(assistant).toBeHidden();
 });
@@ -5642,6 +5696,18 @@ test(`browser Assistant stays beside the page through an answer and follow-up${d
   await expect(page.getByRole("complementary", { name: "Browser Assistant", exact: true })).toHaveCount(0);
   await toggleAssistant.click();
   await expect(toggleAssistant).toHaveAttribute("aria-expanded", "true");
+  const openedAssistant = page.getByRole("complementary", { name: "Browser Assistant", exact: true });
+  const assistantResize = openedAssistant.getByRole("separator", { name: "Resize Browser Assistant" });
+  if (await openedAssistant.locator(".browser-assistant-sheet").count() === 0 && await openedAssistant.evaluate((element) => !element.classList.contains("browser-assistant-sheet"))) {
+    await expect(assistantResize).toBeVisible();
+    const initialWidth = (await openedAssistant.boundingBox())!.width;
+    await assistantResize.focus();
+    await page.keyboard.press("ArrowLeft");
+    await expect.poll(async () => (await openedAssistant.boundingBox())!.width).toBeGreaterThan(initialWidth);
+    await expect.poll(() => page.evaluate(() => localStorage.getItem("nebula.browser-assistant-panel.width"))).not.toBeNull();
+  } else {
+    await expect(assistantResize).toHaveCount(0);
+  }
   await page.getByRole("button", { name: "Collapse browser Assistant" }).click();
   await expect(toggleAssistant).toBeFocused();
   await expect(toggleAssistant).toHaveAttribute("aria-expanded", "false");
@@ -5663,7 +5729,7 @@ test(`browser Assistant stays beside the page through an answer and follow-up${d
   }
   const pageSurface = page.locator(".managed-browser-screen");
   const expandedPage = await pageSurface.boundingBox();
-  const browserBounds = await page.locator(".integrated-browser-page").boundingBox();
+  const browserBounds = await page.locator(".persistent-browser > .integrated-browser-page").boundingBox();
   expect(expandedPage!.height).toBeGreaterThanOrEqual(160);
   expect(expandedPage!.y - browserBounds!.y).toBeLessThan(205);
   await expect(page.getByLabel("Browser address")).toHaveAttribute("readonly", "");


### PR DESCRIPTION
## Summary
- keep guided assessments connected to the lazily started managed browser so operators can pause, use manual tools, and resume
- add persisted pointer and keyboard resizing for browser/terminal Assistant panels and the Security Browser workspace
- keep the native browser visible and correctly bounded beside adjustable manual-testing controls

## Verification
- 9 focused Python tests passed
- 11 focused UI component tests passed
- focused desktop, mobile Chromium, and mobile WebKit Playwright journeys passed
- production UI and packaged Core builds passed
- packaged workflow manually exercised through Running → Paused → editable Repeater HTTP 200 → Resumed

## Limitations
- Linux reported browser event capture unavailable, so direct Repeater was manually verified while Traffic → Repeater remains component-tested
- mobile coverage used emulated permanent profiles; no physical device was available