### PR TITLE
Remove oversized Security Browser welcome banner

### DIFF
--- a/.github/test-selection.json
+++ b/.github/test-selection.json
@@ -1,44 +1,17 @@
 {
-  "reviewed_by": "Codex account home and queue icon review",
-  "reason": "Profile-owned account homes across adapters, catalogs and skills; API create/update isolation and used-session identity guards; account settings host folder selection and persistence; Assistant switching and accessible queue icon. Shared files reviewed; only this workflow is selected.",
-  "exclusions": "No full suites authorized. Unrelated browser research edits excluded in isolated worktree. No native changes. No live vendor logins or physical devices; adapter fixtures and emulated mobile browsers explicitly qualify evidence.",
-  "baseline": "6f341bc45ad15ec5cef8a8f074b3c833283204ad",
-  "python_versions": [
-    "3.12"
-  ],
+  "reviewed_by": "Codex banner-removal review",
+  "reason": "Remove only the redundant Security Browser empty-state welcome banner and its unused CSS selectors. Reviewed the two-file diff; tool dock and selected assessment controls remain unchanged. This reversible presentation-only deletion receives source diff checks, with runtime verification outstanding.",
+  "exclusions": "No suites selected for this small static presentation removal. No backend, native, API, state ownership, or interaction changes. Shared CSS edit only removes selectors for deleted markup. Browser/mobile, production build and real workflow verification remain outstanding; no full suite authorized.",
+  "baseline": "ac2edefcd75351d2976e467476c4c4dbc2888995",
   "expected_tests": {
-    "python": 19,
-    "frontend": 10,
+    "python": 0,
+    "frontend": 0,
     "native": 0,
-    "playwright": 8
+    "playwright": 0
   },
-  "python": [
-    "tests/v3/test_harness_adapters.py::test_account_homes_isolate_spawn_without_changing_workspace",
-    "tests/v3/test_harness_adapters.py::test_missing_account_home_fails_before_launch",
-    "tests/v3/test_harness_adapters.py::test_grok_catalog_uses_selected_account_for_command_and_cache",
-    "tests/v3/test_harness_adapters.py::test_grok_process_removes_host_command_and_workspace_tools",
-    "tests/v3/test_harnesses.py::test_account_home_skill_discovery_does_not_cross_accounts",
-    "tests/v3/test_harnesses.py::test_account_home_api_persists_invalidates_health_and_preserves_used_identity",
-    "tests/v3/test_harnesses.py::test_account_home_requires_unambiguous_absolute_path",
-    "tests/v3/test_harnesses.py::test_remote_endpoint_rejects_local_account_home",
-    "tests/v3/test_harnesses.py::test_assistant_settings_keep_chat_history_and_replace_frozen_runtime"
-  ],
-  "frontend": [
-    "ui/src/components/HarnessSettings.test.tsx",
-    "ui/src/components/HostFolderPicker.test.tsx"
-  ],
+  "python": [],
+  "frontend": [],
   "native": [],
-  "playwright": [
-    "entry:harness-accounts/assistant-real-desktop",
-    "entry:harness-accounts/assistant-real-compact",
-    "entry:harness-accounts/assistant-real-chromium-320",
-    "entry:harness-accounts/assistant-real-webkit-320",
-    "entry:harness-accounts/assistant-real-chromium-390",
-    "entry:harness-accounts/assistant-real-webkit-390",
-    "entry:harness-accounts/assistant-real-chromium-430",
-    "entry:harness-accounts/assistant-real-webkit-430"
-  ],
-  "python_browser": false,
-  "python_node": false,
-  "change_digest": "b078f1acaaeea2f78bb12f3dc8349cea02fdf843476007d85e8a4368ddfb23ff"
+  "playwright": [],
+  "change_digest": "f0093c9446cc07db19d62bbda0d3b7d2b196fe9667e17668ff8ec78acff267d1"
 }

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -690,9 +690,9 @@ kbd { font-size: 11px; }
 .security-browser-assessment-list > button strong, .security-browser-assessment-list > button small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .security-browser-assessment-list > button small, .security-browser-assessment-list > button > span:last-child { color: var(--muted); font-size: 11px; }
 .security-browser-loading { display: flex; align-items: center; gap: 6px; padding: 12px 4px; color: var(--muted); font-size: 11px; }
-.security-browser-empty, .security-browser-welcome { display: grid; justify-items: center; gap: 7px; padding: 24px 12px; color: var(--muted); text-align: center; }
-.security-browser-empty strong, .security-browser-welcome h2 { margin: 0; color: var(--text); }
-.security-browser-empty span, .security-browser-welcome p { margin: 0; font-size: 11px; line-height: 1.5; }
+.security-browser-empty { display: grid; justify-items: center; gap: 7px; padding: 24px 12px; color: var(--muted); text-align: center; }
+.security-browser-empty strong { margin: 0; color: var(--text); }
+.security-browser-empty span { margin: 0; font-size: 11px; line-height: 1.5; }
 .security-browser-main { display: flex; min-width: 0; min-height: 0; flex-direction: column; overflow: hidden; }
 .security-browser-run-summary { display: grid; max-height: 46%; flex: 0 1 auto; gap: 9px; padding: 12px; overflow: auto; border-bottom: 1px solid var(--border); background: var(--surface); }
 .security-browser-run-summary > header { display: flex; min-width: 0; align-items: flex-start; justify-content: space-between; gap: 10px; }

--- a/ui/src/components/SecurityBrowserWorkspacePanel.tsx
+++ b/ui/src/components/SecurityBrowserWorkspacePanel.tsx
@@ -410,7 +410,7 @@ export function SecurityBrowserWorkspacePanel({
         </div>
       </aside>
       <section className="security-browser-main">
-        {selected ? <div className="security-browser-run-summary">
+        {selected && <div className="security-browser-run-summary">
           <header><div><span className={`security-browser-status status-${selected.status}`}>{stateLabel(selected.status)}</span><h2>{selected.name}</h2><p>{selected.objective}</p></div><div className="security-browser-run-controls">
             {selected.status === "ready" && <button className="button primary" type="button" disabled={!desktop || busy} onClick={() => void transition("start")}><CirclePlay size={15} /> Start</button>}
             {selected.status === "running" && <><button className="button secondary" type="button" disabled={busy} onClick={() => void transition("takeover", { reason: "Operator requested control of the live browser." })}><Hand size={15} /> Take over</button><button className="button secondary" type="button" disabled={busy} onClick={() => void transition("pause", { reason: "Paused by operator." })}><CirclePause size={15} /> Pause</button><button className="button danger" type="button" disabled={busy} onClick={() => void transition("stop")}><Square size={14} /> Stop</button></>}
@@ -441,7 +441,7 @@ export function SecurityBrowserWorkspacePanel({
             </div>
           </section>}
           {selected.status !== "running" && <button className="security-browser-delete" type="button" disabled={busy} onClick={() => void deleteSelected()}><Trash2 size={13} /> Delete assessment metadata</button>}
-        </div> : <div className="security-browser-welcome"><ShieldCheck size={28} /><h2>One workspace for manual and autonomous testing</h2><p>Select an assessment or start a guided test. Browser identity, traffic, frozen scope, evidence, and candidate review remain connected.</p></div>}
+        </div>}
         <div className="security-browser-tool-dock">
           {toolNavigation}
           <div className="security-browser-tool-content">{children}</div>


### PR DESCRIPTION
The Security Browser empty-state welcome banner consumes vertical space above the tool tabs. Remove it and its unused CSS selectors so Traffic, Intercept, and Repeater content starts higher when no assessment is selected.

Validation: source diff reviewed and `git diff --check` passed. Diff-bound test-selection receipt validates; no suites selected for this static removal. Browser/mobile, production build, and live workflow verification remain outstanding.
