### PR TITLE
Compact Workbench tools into header icons

### DIFF
--- a/.github/test-selection.json
+++ b/.github/test-selection.json
@@ -1,17 +1,26 @@
 {
-  "reviewed_by": "Codex banner-removal review",
-  "reason": "Remove only the redundant Security Browser empty-state welcome banner and its unused CSS selectors. Reviewed the two-file diff; tool dock and selected assessment controls remain unchanged. This reversible presentation-only deletion receives source diff checks, with runtime verification outstanding.",
-  "exclusions": "No suites selected for this small static presentation removal. No backend, native, API, state ownership, or interaction changes. Shared CSS edit only removes selectors for deleted markup. Browser/mobile, production build and real workflow verification remain outstanding; no full suite authorized.",
-  "baseline": "ac2edefcd75351d2976e467476c4c4dbc2888995",
+  "baseline": "6f341bc45ad15ec5cef8a8f074b3c833283204ad",
+  "change_digest": "1d6c1ec6b0fd58e25c0d44ade24d4dd044bafdab754c87da793ec219233816d1",
+  "reviewed_by": "Codex focused header layout review",
+  "reason": "Relocate existing tool controls; verify icon names, dimensions, selection, new chat entry and clipping across eight browser profiles.",
+  "exclusions": "No full suite. No backend/native/state changes; existing lifecycle handlers unchanged. Shared TabBar opt-in presentation reviewed. Component behavior exercised in focused browser test; physical devices unavailable.",
   "expected_tests": {
     "python": 0,
     "frontend": 0,
     "native": 0,
-    "playwright": 0
+    "playwright": 8
   },
   "python": [],
   "frontend": [],
   "native": [],
-  "playwright": [],
-  "change_digest": "f0093c9446cc07db19d62bbda0d3b7d2b196fe9667e17668ff8ec78acff267d1"
+  "playwright": [
+    "entry:compact-header/desktop",
+    "entry:compact-header/compact",
+    "entry:compact-header/mobile-chromium-small",
+    "entry:compact-header/mobile-chromium-ledger-390",
+    "entry:compact-header/mobile-chromium-wide",
+    "entry:compact-header/mobile-webkit-small",
+    "entry:compact-header/mobile-webkit",
+    "entry:compact-header/mobile-webkit-wide"
+  ]
 }

--- a/.github/test-selection.json
+++ b/.github/test-selection.json
@@ -1,6 +1,6 @@
 {
-  "baseline": "6f341bc45ad15ec5cef8a8f074b3c833283204ad",
-  "change_digest": "c33db2d6b09be6ff12d3ab87eb5054b87dadf29d43981eb12d58948dcc60019e",
+  "baseline": "f5c3b79be93708f76beafd3d9a9f32c2a0be97cb",
+  "change_digest": "911f6fcfd5da4dd889bc36fdfe64b1f58db78456a271cc3c634bcfa57c90dcfc",
   "reviewed_by": "Codex focused header layout review",
   "reason": "Focused compact header journey, including rightmost New chat placement, icon names, dimensions, keyboard/focus mode, selection and clipping across eight profiles.",
   "exclusions": "No full suite. No backend/native/state changes; existing lifecycle handlers unchanged. Shared TabBar opt-in presentation reviewed. Component behavior exercised in focused browser test; physical devices unavailable.",

--- a/.github/test-selection.json
+++ b/.github/test-selection.json
@@ -1,8 +1,8 @@
 {
   "baseline": "6f341bc45ad15ec5cef8a8f074b3c833283204ad",
-  "change_digest": "1d6c1ec6b0fd58e25c0d44ade24d4dd044bafdab754c87da793ec219233816d1",
+  "change_digest": "c33db2d6b09be6ff12d3ab87eb5054b87dadf29d43981eb12d58948dcc60019e",
   "reviewed_by": "Codex focused header layout review",
-  "reason": "Relocate existing tool controls; verify icon names, dimensions, selection, new chat entry and clipping across eight browser profiles.",
+  "reason": "Focused compact header journey, including rightmost New chat placement, icon names, dimensions, keyboard/focus mode, selection and clipping across eight profiles.",
   "exclusions": "No full suite. No backend/native/state changes; existing lifecycle handlers unchanged. Shared TabBar opt-in presentation reviewed. Component behavior exercised in focused browser test; physical devices unavailable.",
   "expected_tests": {
     "python": 0,

--- a/docs/design/compact-workbench-header.md
+++ b/docs/design/compact-workbench-header.md
@@ -1,0 +1,17 @@
+# Compact Workbench header contract
+
+Journey: open Workbench, discover tools by named icons/tooltips, select a tool,
+return to Assistant and start a new chat. Desktop tools share the shell header;
+phones retain the existing bottom navigation and compact New chat action.
+
+Invariants: one tool switcher, visible selection, keyboard arrow navigation,
+44 px controls, no horizontal page clipping, focus mode retains its controls.
+URL owns tool selection; existing Core/session handlers own conversations;
+React owns transient menus. No persistence or API behavior is changed.
+
+Coverage: entry/select/use and reload navigation are applicable. Chat creation
+uses its existing handler. Streaming, interruption, reconnect, retry, deletion
+and revocation have no changed behavior; backend lifecycle testing is excluded.
+Planned layers: focused production browser regression across desktop/compact,
+Android and WebKit boundary profiles; production compile. Physical devices are
+unavailable. No origin-sensitive behavior is introduced.

--- a/ui/playwright-impact.json
+++ b/ui/playwright-impact.json
@@ -19,6 +19,72 @@
     {"name": "remaining-core", "fallback": true, "patterns": ["src/nebula/v3/**"], "areas": ["core-api"]}
   ],
   "areas": {
+    "compact-header": [
+      {
+        "area": "compact-header",
+        "project": "desktop",
+        "test_match": "tests/interface.spec.ts",
+        "grep": "stabilization compact Workbench header icons",
+        "runtime": "mocked",
+        "shard": "1/1"
+      },
+      {
+        "area": "compact-header",
+        "project": "compact",
+        "test_match": "tests/interface.spec.ts",
+        "grep": "stabilization compact Workbench header icons",
+        "runtime": "mocked",
+        "shard": "1/1"
+      },
+      {
+        "area": "compact-header",
+        "project": "mobile-chromium-small",
+        "test_match": "tests/interface.spec.ts",
+        "grep": "stabilization compact Workbench header icons",
+        "runtime": "mocked",
+        "shard": "1/1"
+      },
+      {
+        "area": "compact-header",
+        "project": "mobile-chromium-ledger-390",
+        "test_match": "tests/interface.spec.ts",
+        "grep": "stabilization compact Workbench header icons",
+        "runtime": "mocked",
+        "shard": "1/1"
+      },
+      {
+        "area": "compact-header",
+        "project": "mobile-chromium-wide",
+        "test_match": "tests/interface.spec.ts",
+        "grep": "stabilization compact Workbench header icons",
+        "runtime": "mocked",
+        "shard": "1/1"
+      },
+      {
+        "area": "compact-header",
+        "project": "mobile-webkit-small",
+        "test_match": "tests/interface.spec.ts",
+        "grep": "stabilization compact Workbench header icons",
+        "runtime": "mocked",
+        "shard": "1/1"
+      },
+      {
+        "area": "compact-header",
+        "project": "mobile-webkit",
+        "test_match": "tests/interface.spec.ts",
+        "grep": "stabilization compact Workbench header icons",
+        "runtime": "mocked",
+        "shard": "1/1"
+      },
+      {
+        "area": "compact-header",
+        "project": "mobile-webkit-wide",
+        "test_match": "tests/interface.spec.ts",
+        "grep": "stabilization compact Workbench header icons",
+        "runtime": "mocked",
+        "shard": "1/1"
+      }
+    ],
     "harness-accounts": [
   {
     "area": "harness-accounts",

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -2507,3 +2507,19 @@ button.harness-status-summary:focus-visible { outline: 2px solid var(--focus); o
   .chat-resolved-approval { width: calc(100% - 12px); flex-wrap: wrap; }
   .chat-resolved-actions { margin-left: auto; }
 }
+
+/* Workbench tools share the shell action row with New chat. */
+.top-bar-page-actions:has(.compact-workbench-toolbar) { overflow: visible; }
+.compact-workbench-toolbar.in-shell-header { border: 0; background: transparent; padding: 0; min-height: 44px; gap: 8px; }
+.compact-workbench-toolbar .session-tabs > button,
+.compact-workbench-toolbar .session-toolbar-actions > button,
+.compact-workbench-toolbar .workbench-actions > button { width: 44px; height: 44px; min-width: 44px; padding: 0; justify-content: center; }
+.compact-workbench-toolbar .session-tabs > button > span { display: inline-flex; }
+.compact-workbench-toolbar .compact-new-chat .page-header-action-label { display: none; }
+.compact-workbench-toolbar .session-toolbar-actions { padding-left: 0; }
+@media (max-width: 760px) {
+  .compact-workbench-toolbar.in-shell-header { display: flex; }
+  .compact-workbench-toolbar.in-shell-header .session-tabs,
+  .compact-workbench-toolbar.in-shell-header .session-conversations-toggle,
+  .compact-workbench-toolbar.in-shell-header .workbench-actions { display: none; }
+}

--- a/ui/src/components/SurfacePrimitives.tsx
+++ b/ui/src/components/SurfacePrimitives.tsx
@@ -81,6 +81,7 @@ export interface TabItem<T extends string> {
 
 interface TabBarProps<T extends string> {
   items: readonly TabItem<T>[];
+  iconOnly?: boolean;
   value: T;
   onChange: (value: T) => void;
   label: string;
@@ -88,7 +89,7 @@ interface TabBarProps<T extends string> {
 }
 
 /** Quiet, keyboard-navigable tab anatomy shared by every tool switcher. */
-export function TabBar<T extends string>({ items, value, onChange, label, className = "" }: TabBarProps<T>) {
+export function TabBar<T extends string>({ items, value, onChange, label, className = "", iconOnly = false }: TabBarProps<T>) {
   const tabListRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const selected = tabListRef.current?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]');
@@ -103,7 +104,7 @@ export function TabBar<T extends string>({ items, value, onChange, label, classN
     tabs[next]?.focus();
     tabs[next]?.click();
   };
-  return <div ref={tabListRef} className={`tab-bar ${className}`.trim()} role="tablist" aria-label={label}>{items.map((item) => <button key={item.id} type="button" role="tab" aria-label={item.ariaLabel} aria-selected={value === item.id} tabIndex={value === item.id ? 0 : -1} disabled={item.disabled} onKeyDown={moveFocus} onClick={() => onChange(item.id)}>{item.icon}{item.label}</button>)}</div>;
+  return <div ref={tabListRef} className={`tab-bar ${className}`.trim()} role="tablist" aria-label={label}>{items.map((item) => <button key={item.id} type="button" role="tab" title={iconOnly ? String(item.label) : undefined} aria-label={item.ariaLabel ?? (iconOnly ? String(item.label) : undefined)} aria-selected={value === item.id} tabIndex={value === item.id ? 0 : -1} disabled={item.disabled} onKeyDown={moveFocus} onClick={() => onChange(item.id)}>{iconOnly ? <span aria-hidden="true">{item.icon}</span> : item.icon}{!iconOnly && item.label}</button>)}</div>;
 }
 
 interface ListRowProps extends Omit<HTMLAttributes<HTMLElement>, "title"> {

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -3243,7 +3243,6 @@ export function SessionsPage() {
           { id: "activity", label: "Activity", ariaLabel: "Activity history", icon: <FileClock size={16} /> },
         ] as const} />
         <div className="session-toolbar-actions">
-          {view === "chat" && <PageHeaderAction className="button primary compact-new-chat" label="New chat" icon={<Plus size={18} />} disabled={!engagement} title={!engagement ? "Create or select a project before starting chat" : "New chat"} onClick={newConversation} />}
           {view === "missions" && <NewMissionButton showSetupGuidance={false} />}
           {view === "chat" && <button
             className="button quiet session-conversations-toggle"
@@ -3273,6 +3272,7 @@ export function SessionsPage() {
               </button>
             </div>}
           </div>
+          {view === "chat" && <PageHeaderAction className="button primary compact-new-chat" label="New chat" icon={<Plus size={18} />} disabled={!engagement} title={!engagement ? "Create or select a project before starting chat" : "New chat"} onClick={newConversation} />}
         </div>
       </Toolbar>
   );

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -3230,17 +3230,9 @@ export function SessionsPage() {
             </div>
   );
 
-  return (
-    <div className={`page sessions-page${view === "chat" ? " chat-active" : ""}${screenFitViews.has(view) ? " screen-fit" : ""}${fullScreen ? " full-screen" : ""}`}>
-      <PageHeader
-        title="Workbench"
-        description="Start in Terminal, edit shared code, browse a target, ask the assistant, or open your project files."
-        showIntroduction={false}
-        actions={view === "chat" ? <PageHeaderAction label="New chat" icon={<Plus size={16} />} disabled={!engagement} title={!engagement ? "Create or select a project before starting chat" : undefined} onClick={newConversation} /> : view === "missions" ? <NewMissionButton showSetupGuidance={false} /> : undefined}
-      />
-
-      <Toolbar className="session-toolbar" label="Workbench controls">
-        <TabBar className="session-tabs" label="Workbench views" value={view} onChange={setView} items={[
+  const workbenchToolbar = (
+      <Toolbar className={`session-toolbar compact-workbench-toolbar${fullScreen ? "" : " in-shell-header"}`} label="Workbench controls">
+        <TabBar iconOnly className="session-tabs" label="Workbench views" value={view} onChange={setView} items={[
           { id: "terminal", label: "Terminal", icon: <SquareTerminal size={16} /> },
           { id: "code", label: "Code", ariaLabel: "Workspace code editor", icon: <Braces size={16} /> },
           { id: "browser", label: "Browser", ariaLabel: "Project browser", icon: <Globe2 size={16} /> },
@@ -3251,19 +3243,22 @@ export function SessionsPage() {
           { id: "activity", label: "Activity", ariaLabel: "Activity history", icon: <FileClock size={16} /> },
         ] as const} />
         <div className="session-toolbar-actions">
+          {view === "chat" && <PageHeaderAction className="button primary compact-new-chat" label="New chat" icon={<Plus size={18} />} disabled={!engagement} title={!engagement ? "Create or select a project before starting chat" : "New chat"} onClick={newConversation} />}
+          {view === "missions" && <NewMissionButton showSetupGuidance={false} />}
           {view === "chat" && <button
             className="button quiet session-conversations-toggle"
             type="button"
             aria-label={conversationPanelOpen ? "Hide conversations" : "Show conversations"}
             aria-expanded={conversationPanelOpen}
+            title={conversationPanelOpen ? "Hide conversations" : "Show conversations"}
             aria-controls="workbench-conversations"
             onClick={toggleConversationPanel}
           >
-            <MessageSquare size={15} aria-hidden="true" /> Conversations{sessions.length ? <span>{sessions.length}</span> : null}
+            <MessageSquare size={18} aria-hidden="true" />
           </button>}
           {fullScreen && <button className="icon-button subtle workbench-full-screen-toggle" type="button" aria-label="Exit full screen workbench" title="Exit focus mode" onClick={() => setFullScreen(false)}><Minimize2 size={17} aria-hidden="true" /></button>}
           <div className="workbench-actions">
-            <button ref={workbenchActionsButtonRef} className="icon-button subtle" type="button" aria-label="More Workbench actions" aria-haspopup="menu" aria-expanded={workbenchActionsOpen} aria-controls={workbenchActionsOpen ? "workbench-actions-menu" : undefined} onClick={() => setWorkbenchActionsOpen((open) => !open)}><MoreHorizontal size={18} aria-hidden="true" /></button>
+            <button ref={workbenchActionsButtonRef} className="icon-button subtle" type="button" title="More Workbench actions" aria-label="More Workbench actions" aria-haspopup="menu" aria-expanded={workbenchActionsOpen} aria-controls={workbenchActionsOpen ? "workbench-actions-menu" : undefined} onClick={() => setWorkbenchActionsOpen((open) => !open)}><MoreHorizontal size={18} aria-hidden="true" /></button>
             {workbenchActionsOpen && <div ref={workbenchActionsMenuRef} className="workbench-actions-menu" id="workbench-actions-menu" role="menu" aria-label="Workbench actions">
               {api && engagement && <PostToolAssistant api={api} engagementId={engagement.id} providers={providers} harnesses={harnesses} onRun={setRunCandidate} triggerVariant="menu" />}
               {view === "chat" && <button className="workbench-menu-item" type="button" role="menuitem" onClick={() => {
@@ -3280,6 +3275,17 @@ export function SessionsPage() {
           </div>
         </div>
       </Toolbar>
+  );
+
+  return (
+    <div className={`page sessions-page${view === "chat" ? " chat-active" : ""}${screenFitViews.has(view) ? " screen-fit" : ""}${fullScreen ? " full-screen" : ""}`}>
+      <PageHeader
+        title="Workbench"
+        description="Start in Terminal, edit shared code, browse a target, ask the assistant, or open your project files."
+        showIntroduction={false}
+        actions={fullScreen ? undefined : workbenchToolbar}
+      />
+      {fullScreen && workbenchToolbar}
 
       <div className={`session-layout ${view}${mobileListOpen ? " mobile-list-open" : ""}${view === "chat" && conversationPanelOpen ? " conversation-panel-open" : ""}${view === "chat" && sessionInspectorOpen ? " inspector-open" : ""}`}>
         {view === "chat" && (conversationPanelOpen || mobileListOpen) && <aside className="session-list" id="workbench-conversations" aria-label="Conversations">

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -6147,6 +6147,9 @@ test("stabilization compact Workbench header icons", async ({ page }, testInfo) 
   expect(await newChat.innerText()).toBe('');
   const mobile = (page.viewportSize()?.width ?? 1440) <= 760;
   if (!mobile) {
+    const plusBox = await newChat.boundingBox();
+    const moreBox = await header.getByRole('button', {name: 'More Workbench actions'}).boundingBox();
+    expect(plusBox!.x).toBeGreaterThanOrEqual(moreBox!.x + moreBox!.width);
     const tabs = header.getByRole('tablist', {name: 'Workbench views'});
     await expect(tabs.getByRole('tab')).toHaveCount(8);
     for (const tab of await tabs.getByRole('tab').all()) {

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -6137,3 +6137,41 @@ for (const scenario of ["stale catalog", "request failure", "reconnected approva
     await expect(page.getByRole("button", { name: "Review pending actions", exact: true })).toHaveCount(0);
   });
 }
+
+test("stabilization compact Workbench header icons", async ({ page }, testInfo) => {
+  await openWorkspace(page, "/?view=chat", "Workbench");
+  const header = page.locator('.top-bar-page-actions');
+  const newChat = header.getByRole('button', {name: 'New chat', exact: true});
+  await expect(newChat).toBeVisible();
+  await expect(newChat).toHaveAttribute('title', 'New chat');
+  expect(await newChat.innerText()).toBe('');
+  const mobile = (page.viewportSize()?.width ?? 1440) <= 760;
+  if (!mobile) {
+    const tabs = header.getByRole('tablist', {name: 'Workbench views'});
+    await expect(tabs.getByRole('tab')).toHaveCount(8);
+    for (const tab of await tabs.getByRole('tab').all()) {
+      expect(await tab.innerText()).toBe('');
+      await expect(tab).toHaveAttribute('title', /.+/);
+      const box = await tab.boundingBox();
+      expect(box!.width).toBeGreaterThanOrEqual(44);
+      expect(box!.height).toBeGreaterThanOrEqual(44);
+    }
+    await tabs.getByRole('tab', {name: 'Workspace code editor'}).click();
+    await expect(page).toHaveURL(/view=code/);
+    await tabs.getByRole('tab', {name: 'Analyst chat'}).click();
+    await expect(tabs.getByRole('tab', {name: 'Analyst chat'})).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('.sessions-page > .session-toolbar')).toHaveCount(0);
+    await tabs.getByRole('tab', {name: 'Analyst chat'}).focus();
+    await page.keyboard.press('ArrowRight');
+    await expect(tabs.getByRole('tab', {name: 'Workspace files'})).toBeFocused();
+    await tabs.getByRole('tab', {name: 'Analyst chat'}).click();
+    await header.getByRole('button', {name: 'More Workbench actions'}).click();
+    await page.getByRole('menuitem', {name: 'Enter focus mode'}).click();
+    await expect(page.locator('.sessions-page > .session-toolbar')).toBeVisible();
+    await page.getByRole('button', {name: 'Exit full screen workbench'}).click();
+  }
+  await newChat.click();
+  await expect(page.locator('#analyst-message')).toBeVisible();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+  await page.screenshot({path: `/tmp/nebula-compact-header-${testInfo.project.name}.png`});
+});


### PR DESCRIPTION
Move Workbench tools into the shell header as named icons with hover tooltips, removing the second toolbar row. New chat is an icon at the right end of the Workbench controls, after Conversations and the overflow menu. Preserve phone navigation and focus-mode controls.

Validation: production build passed; focused header regression passed in 8 desktop Chromium and emulated Android/WebKit profiles (1440/1024 desktop, 320/390/430 mobile). Covers placement, 44 px targets, selection, keyboard navigation, focus mode, New chat entry and page clipping. Diff-bound test selection limits CI to this journey. Core data is mocked; live Core and physical devices were not tested. Existing backend handlers are unchanged.
