### PR TITLE
Discover native harness commands and preserve thinking in chat

### DIFF
--- a/.github/test-selection.json
+++ b/.github/test-selection.json
@@ -1,26 +1,44 @@
 {
-  "baseline": "f5c3b79be93708f76beafd3d9a9f32c2a0be97cb",
-  "change_digest": "911f6fcfd5da4dd889bc36fdfe64b1f58db78456a271cc3c634bcfa57c90dcfc",
-  "reviewed_by": "Codex focused header layout review",
-  "reason": "Focused compact header journey, including rightmost New chat placement, icon names, dimensions, keyboard/focus mode, selection and clipping across eight profiles.",
-  "exclusions": "No full suite. No backend/native/state changes; existing lifecycle handlers unchanged. Shared TabBar opt-in presentation reviewed. Component behavior exercised in focused browser test; physical devices unavailable.",
+  "reviewed_by": "Codex dynamic command discovery review",
+  "reason": "Grok/Codex native command routing, goal states and notification channels, preserved planning context, usage accounting, thinking disclosure, and catch-up geometry. Shared adapter, API types, SessionsPage and CSS changes reviewed. Focused unit and production desktop/mobile journeys cover discovery, use, invalid input/retry, durable replay and Core restart; no unrelated suites selected. Dynamic ACP catalogs are captured by the reader, scoped per session, replaced atomically, exposed through activity, and used by generic dispatch, help and picker. Reviewed shared protocol reader and activity equality impact; selected protocol, component and real-Core command journeys cover the new boundaries. Includes no-text native replies and bounded help for maximum-size catalogs. Rebased onto the compact Workbench header and browser welcome cleanup; preserved upstream entries and reviewed SessionsPage integration. Existing focused browser journeys exercise the updated header entry point. Type-check preparation makes existing adapter narrowing and validated usage summation explicit without changing command behavior.",
+  "exclusions": "No full suite approved. No native code or packaging changes. Unrelated adapters and UI journeys excluded. Real Core uses inert protocol peers and actual adapters; physical devices unavailable. Browser layer runtime bound ten minutes per focused matrix; unit layers two minutes; build five minutes.",
+  "baseline": "aab0054979a2cf7f5672b94223405294b44049c5",
   "expected_tests": {
-    "python": 0,
-    "frontend": 0,
+    "python": 34,
+    "frontend": 27,
     "native": 0,
-    "playwright": 8
+    "playwright": 24
   },
-  "python": [],
-  "frontend": [],
+  "python": [
+    "tests/v3/test_harness_commands.py",
+    "tests/v3/test_harness_adapters.py::test_grok_thinking_episodes_drain_completion_race",
+    "tests/v3/test_harness_adapters.py::test_codex_reasoning_summary_uses_streams_and_authoritative_completion",
+    "tests/v3/test_harness_adapters.py::test_codex_reasoning_summary_preserves_bounded_stream_without_snapshot",
+    "tests/v3/test_harness_adapters.py::test_codex_reasoning_summary_rejects_malformed_private_payloads"
+  ],
+  "frontend": [
+    "ui/src/components/HarnessThinking.test.tsx",
+    "ui/src/pages/harnessActivity.test.ts",
+    "ui/src/components/HarnessStatusRail.test.tsx"
+  ],
   "native": [],
   "playwright": [
-    "entry:compact-header/desktop",
-    "entry:compact-header/compact",
-    "entry:compact-header/mobile-chromium-small",
-    "entry:compact-header/mobile-chromium-ledger-390",
-    "entry:compact-header/mobile-chromium-wide",
-    "entry:compact-header/mobile-webkit-small",
-    "entry:compact-header/mobile-webkit",
-    "entry:compact-header/mobile-webkit-wide"
-  ]
+    "entry:harness-commands/desktop",
+    "entry:harness-commands/compact",
+    "entry:harness-commands/mobile-chromium-small",
+    "entry:harness-commands/mobile-chromium-ledger-390",
+    "entry:harness-commands/mobile-chromium-wide",
+    "entry:harness-commands/mobile-webkit-small",
+    "entry:harness-commands/mobile-webkit",
+    "entry:harness-commands/mobile-webkit-wide",
+    "entry:harness-commands-real/assistant-real-desktop",
+    "entry:harness-commands-real/assistant-real-compact",
+    "entry:harness-commands-real/assistant-real-chromium-320",
+    "entry:harness-commands-real/assistant-real-webkit-320",
+    "entry:harness-commands-real/assistant-real-chromium-390",
+    "entry:harness-commands-real/assistant-real-webkit-390",
+    "entry:harness-commands-real/assistant-real-chromium-430",
+    "entry:harness-commands-real/assistant-real-webkit-430"
+  ],
+  "change_digest": "d4fffc944664feda8ccadf68420495aeef1eb4f249f69ace03b69c5b9ae391a4"
 }

--- a/docs/design/harness-commands-thoughts.md
+++ b/docs/design/harness-commands-thoughts.md
@@ -1,0 +1,158 @@
+# Harness commands and thinking
+
+Entry: the chat composer with a Grok or Codex runtime selected. Commands must be
+discoverable, execute against the selected harness session, and return a durable
+visible result. Thinking supplied for display by either harness must have the same
+discoverable, expandable presentation during streaming and after reload.
+
+| Journey | Invariant | Authority | Planned evidence |
+| --- | --- | --- | --- |
+| Discover/select | Composer exposes supported command syntax for Grok/Codex | UI catalog, selected profile | component/browser |
+| Create/use | Goal and usage commands reach native protocol operations without prompt wrappers obscuring command dispatch | Core turn and harness session | adapter + real Core |
+| Stream/interrupt | Displayable thinking remains reachable; commands never become steering text | harness events, Core durable stream | component/browser + real Core |
+| Refresh/reconnect/background | Saved command replies and thinking return with the selected conversation | Core transcript/activity, URL | real Core/browser |
+| Failure/retry | Unsupported protocol operations fail visibly without silently invoking inference | adapter error, Core turn | adapter/browser |
+| Delete/fork | Existing conversation deletion/fork behavior applies; no new state store | Core | existing lifecycle, no change |
+
+Component state owns only disclosure and unsent composer input. No raw hidden
+reasoning is requested or displayed. Test only changed adapter, command and
+thinking journeys; use production desktop/mobile Chromium and mobile WebKit,
+real Core and LAN evidence where available. Physical devices must be reported
+separately. No full-suite run is authorized.
+
+Underlying product rule: native capabilities need an end-to-end operator entry
+point; event normalization must track the actual installed protocol, and retained
+thinking must remain discoverable without opening multiple diagnostic panels.
+
+The failure/retry/restart journey exposed catch-up notices consuming the remaining
+chat height on compact screens. Their height is now bounded by the chat container
+(`cqh`) so transcript controls remain reachable while notices can still scroll.
+
+## Operator behavior and limits
+
+Type `/` in the Grok/Codex composer to discover commands. Both integrations
+include `/goal`, `/goals` (an alias), `/usage`, and `/help`; Grok also adds commands
+advertised by the connected ACP session, including installed skills. Use `/help`
+to connect a new or restarted session and read its current catalog. Goals support
+an objective plus status, pause, resume and clear operations. Commands use the normal chat queue; to apply one
+before an active turn finishes, use the existing Stop and send action. They are
+not sent as live steering. Unknown or withdrawn commands fail visibly rather
+than becoming model prompts. Codex terminal-only commands remain outside this
+change because App Server has no generic slash-command dispatcher.
+
+Grok usage describes the current harness process's session totals. Codex usage
+is a native session estimate and explicitly reports unavailable estimates.
+Reading cumulative usage does not add those totals to Nebula's turn billing.
+Goal continuations retain the selected planning mode and Core context.
+
+## Acceptance evidence — September 11, 2026
+
+- Python: 27 passed. Exact selection: `tests/v3/test_harness_commands.py`, plus
+  `test_grok_thinking_episodes_drain_completion_race`,
+  `test_codex_reasoning_summary_uses_streams_and_authoritative_completion`,
+  `test_codex_reasoning_summary_preserves_bounded_stream_without_snapshot`, and
+  `test_codex_reasoning_summary_rejects_malformed_private_payloads` in
+  `tests/v3/test_harness_adapters.py`. Command: `PYTHONPATH=src .venv/bin/python -m pytest -q <selected nodes>`.
+- Frontend: 26 passed via `npm --prefix ui test -- src/components/HarnessThinking.test.tsx src/pages/harnessActivity.test.ts src/components/HarnessStatusRail.test.tsx`.
+- Build: `npm --prefix ui run build` passed. The tested servers served this worktree's
+  `ui/dist`; Vite reported its existing large-chunk advisory.
+- Mocked production browsers: 16 passed via `npm --prefix ui run test:e2e -- tests/interface.spec.ts --grep 'stabilization harness commands and thinking'`
+  with the eight `entry:harness-commands/*` projects recorded in `.github/test-selection.json`.
+  Origin: `http://192.168.1.155:19465`, using Vite preview of the production bundle.
+- Real Core: eight passed via `npm --prefix ui run test:e2e -- tests/real-core.spec.ts --grep 'assistant upgrade native commands retain thinking'`
+  with the eight `entry:harness-commands-real/*` projects in that selection.
+  Each case used a disposable Core on a non-loopback LAN origin, served the
+  production bundle, and exercised both Grok and Codex through the real adapters
+  with inert protocol peers: goal creation, thinking, invalid usage, correction
+  and retry, usage, Core restart, transcript/activity recovery, and goal status.
+- Desktop Chromium: 1440 and 1024 px. Emulated Android Chromium and iPhone WebKit:
+  320, 390 and 430 px. Keyboard disclosure, focus, accessible names, long thinking,
+  touch targets and no horizontal clipping were checked. Desktop and 320 px WebKit
+  screenshots were visually inspected; catch-up and thinking remain reachable together.
+- Read-only installed-peer checks: Codex CLI 0.153.2 and Grok 1.0.25 accepted their
+  session-usage RPCs. The Codex goal-read probe used an ephemeral thread and was
+  rejected because ephemeral threads do not support goals; it is not goal validation.
+- Ruff checks and `git diff --check` passed.
+
+Local logs: `/tmp/nebula-harness-build.log`,
+`/tmp/nebula-harness-browser-mock-final.log`, and
+`/tmp/nebula-harness-browser-real-final.log`. Screenshots are in
+`/tmp/nebula-harness-browser-real-final/`. The locally reviewed selection receipt
+is `/tmp/nebula-harness-selection-receipt.json`; no CI receipt has been uploaded.
+
+Limitations: live vendor model-driven goal execution, physical phones/software
+keyboards, and deployment to the installed application were not exercised.
+Native protocol peers are explicitly fixtures in real-Core acceptance, not live
+models. These limits prevent an unqualified production-completion claim.
+
+## Dynamic command catalog contract — September 12, 2026
+
+| Journey | Observable invariant | Authority | Test layers |
+| --- | --- | --- | --- |
+| Discover/select | Slash picker and help share names, descriptions and argument hints; vendor additions require no UI edit | ACP live session catalog, Core compatibility catalog | protocol, component, production browser |
+| Create/use | Advertised commands reach session/prompt unchanged ahead of Core context; unknown commands fail without inference | current connection catalog | adapter, real Core |
+| Idle/stream/update | Startup and idle advertisements survive turn replay draining; replacements remove old commands | protocol reader, scoped external session ID | protocol, real Core |
+| Refresh/reconnect | Browser reload reads current catalog; disconnected/Core-restarted sessions expose only compatibility commands until reconnection advertises again | live connection, Core activity API | component, real Core |
+| Failure/retry | Removed or unknown commands explain /help recovery; no silent model fallback | dispatch-time catalog | adapter, browser |
+| Fork/delete | Catalog never transfers between external sessions; connection teardown discards ephemeral discovery | existing connection lifecycle | protocol isolation |
+
+Catalogs are ephemeral capabilities, not durable transcript state. Replies retain
+existing durable chat handling. New sessions can use /help to connect and discover.
+Codex keeps explicit RPC bridges; its terminal command names are not advertised as
+executable. Existing permissions remain authoritative. Physical phone and installed
+application validation remain separate gates. Focused selection will extend the
+existing command/thinking entries, not unrelated journeys or full suites.
+
+## Dynamic discovery acceptance — September 12, 2026
+
+- Journey: slash picker reads Core's session catalog, shows native argument hints,
+  invokes an advertised command, removes a withdrawn command, rejects its retry,
+  and retains the reply after reload. Existing goal/usage/thinking journeys and
+  durable replay across Core restart remain covered for Grok and Codex.
+- Python: 34 passed in 1.55 seconds. Same files/node filters as the selection above;
+  the command file now covers catalog normalization, startup/idle capture, session
+  isolation, replacement, generic invocation, help, unknown/withdrawn commands,
+  no-text replies, and maximum-size catalogs.
+- Frontend: 27 passed in 1.44 seconds across the three selected files. Includes
+  live catalog equality, dynamic picker replacement, argument hints and selection.
+- Production build passed. Index SHA256:
+  `f08899b9619d689d0a94bf75ddab6de3e3ff2697ee425489cc009e39cf911cd1`.
+- Mocked production browser journey: 16 passed in 1 minute at
+  `http://192.168.1.155:19475`. Exact filter remains
+  `stabilization harness commands and thinking` in `ui/tests/interface.spec.ts`.
+  Projects: desktop, compact, mobile-chromium-small,
+  mobile-chromium-ledger-390, mobile-chromium-wide, mobile-webkit-small,
+  mobile-webkit, mobile-webkit-wide. Covered keyboard selection/focus, 44 px
+  targets, accessibility scans, long hints, reload and horizontal bounds.
+- Real-Core production journey: 8 passed in 2.3 minutes on disposable
+  `http://192.168.1.155:<allocated-port>` origins. Exact filter remains
+  `assistant upgrade native commands retain thinking` in `ui/tests/real-core.spec.ts`.
+  Projects: assistant-real-desktop, assistant-real-compact, and
+  assistant-real-{chromium,webkit}-{320,390,430}. These use inert native protocol
+  peers with the real adapters, Core, durable store, API mapping and UI.
+- Desktop Chromium 1440/1024 and emulated Android Chromium/iPhone WebKit
+  320/390/430 passed. Desktop and 320 px WebKit screenshots visually reviewed.
+- Installed Grok advertised 52 commands in an isolated temporary workspace.
+  The real ACP reader captured the catalog at startup; `/session-info` then ran
+  through generic dispatch and returned native session details with turn count 0.
+  This verifies discovery and one read-only native command, not every advertised
+  operation. No vendor model-driven goal was executed.
+- The small-screen mock initially exposed long picker hints crowding transcript
+  controls after draft restoration. The final bounded picker and one-line visible
+  hints passed the same matrix. One initial real-Core case collided with a build;
+  the complete final matrix ran after the build finished and passed.
+- Ruff (Python 3.12 target) and diff whitespace checks passed. Reviewed local
+  selection receipt: `/tmp/nebula-command-discovery-selection-receipt.json`.
+  No CI receipt was uploaded; no push or installed-app deployment was performed.
+
+Logs: `/tmp/nebula-command-discovery-{python,frontend,build,mock-final,real-final}.log`.
+Screenshots: `/tmp/nebula-command-discovery-{mock-final,real-final}/`.
+Live checks: `/tmp/nebula-command-discovery-live.log` and
+`/tmp/nebula-command-discovery-invoke.log`.
+
+Remaining limits: physical phones/software keyboards, installed-app deployment,
+and live vendor goal execution are unverified. Codex retains explicit RPC bridges;
+this change does not provide Codex terminal-command parity. Browser discovery is
+live-session state: after Core restart only compatibility commands are shown until
+reconnection supplies a fresh advertisement. Native catalogs are bounded to 256
+entries and are never copied across sessions.

--- a/src/nebula/v3/harness_commands.py
+++ b/src/nebula/v3/harness_commands.py
@@ -1,0 +1,113 @@
+"""Explicit operator commands, separate from model prompts and turn accounting."""
+
+import re
+from typing import Any
+
+
+COMMAND_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}\Z")
+
+
+def compatibility_commands() -> list[dict[str, str]]:
+    return [
+        {
+            "name": "goal",
+            "description": "Set or inspect a goal",
+            "hint": "<objective> | status | pause | resume | clear",
+            "source": "nebula",
+        },
+        {
+            "name": "goals",
+            "description": "Alias for /goal",
+            "hint": "<objective> | status | pause | resume | clear",
+            "source": "nebula",
+        },
+        {
+            "name": "usage",
+            "description": "Session usage",
+            "hint": "",
+            "source": "nebula",
+        },
+        {"name": "help", "description": "Command help", "hint": "", "source": "nebula"},
+    ]
+
+
+def normalize_commands(value: Any) -> list[dict[str, str]]:
+    """Bound untrusted display metadata; an advertisement replaces the catalog."""
+    commands: dict[str, dict[str, str]] = {}
+    if not isinstance(value, list):
+        return []
+    for item in value[:256]:
+        if not isinstance(item, dict):
+            continue
+        name, description = item.get("name"), item.get("description")
+        if (
+            not isinstance(name, str)
+            or not COMMAND_NAME.fullmatch(name)
+            or not isinstance(description, str)
+        ):
+            continue
+        argument = item.get("input")
+        hint = argument.get("hint") if isinstance(argument, dict) else ""
+        commands[name] = {
+            "name": name,
+            "description": description[:1000],
+            "hint": hint[:500] if isinstance(hint, str) else "",
+            "source": "native",
+        }
+    return list(commands.values())
+
+
+def parse_harness_command(text: str) -> tuple[str, str] | None:
+    parts = text.strip().split(maxsplit=1)
+    if (
+        not parts
+        or not parts[0].startswith("/")
+        or not COMMAND_NAME.fullmatch(parts[0][1:])
+    ):
+        return None
+    return parts[0], parts[1] if len(parts) > 1 else ""
+
+
+def usage_reply(value: Any, *, grok: bool) -> str:
+    if not isinstance(value, dict):
+        raise ValueError(
+            "The harness returned an invalid usage response. Retry /usage."
+        )
+    if grok:
+        usage = value.get("usage")
+        if not isinstance(usage, dict):
+            raise ValueError("Grok did not return session usage. Retry /usage.")
+        fields = [
+            ("Input tokens", usage.get("inputTokens")),
+            ("Output tokens", usage.get("outputTokens")),
+        ]
+        scope = "Grok session usage (since this harness process opened the session)"
+    else:
+        usage = value.get("threadUsage")
+        if not isinstance(usage, dict):
+            return "Codex has no usage estimate for this session yet. Retry /usage after a turn completes."
+        groups = usage.get("groups")
+        if not isinstance(groups, list):
+            raise ValueError("Codex returned invalid session usage. Retry /usage.")
+        fields = []
+        for label, key in [
+            ("Input tokens", "inputTokens"),
+            ("Output tokens", "outputTokens"),
+            ("Total tokens", "totalTokens"),
+        ]:
+            counts = [group.get(key) for group in groups if isinstance(group, dict)]
+            if counts and all(
+                isinstance(count, int) and not isinstance(count, bool) and count >= 0
+                for count in counts
+            ):
+                fields.append(
+                    (label, sum(count for count in counts if isinstance(count, int)))
+                )
+        scope = "Codex session usage (estimated)"
+    lines = [scope]
+    for label, count in fields:
+        if isinstance(count, int) and not isinstance(count, bool) and count >= 0:
+            lines.append(f"{label}: {count:,}")
+    if len(lines) == 1:
+        lines.append("Token counts are not available from the harness yet.")
+    return "\n\n".join(lines)

--- a/src/nebula/v3/harnesses.py
+++ b/src/nebula/v3/harnesses.py
@@ -23,6 +23,12 @@ from .diagnostics import (
     record_diagnostic,
 )
 from .diagnostic_guidance import guidance_for, reason_code_for
+from .harness_commands import (
+    compatibility_commands,
+    normalize_commands,
+    parse_harness_command,
+    usage_reply,
+)
 
 import asyncio
 import difflib
@@ -577,7 +583,16 @@ class HarnessPlanEntry(NebulaModel):
 
 class HarnessGoalSnapshot(NebulaModel):
     objective: str = Field(min_length=1, max_length=10_000)
-    status: Literal["pending", "running", "complete", "blocked", "failed"]
+    status: Literal[
+        "pending",
+        "running",
+        "complete",
+        "blocked",
+        "failed",
+        "paused",
+        "usage_limited",
+        "budget_limited",
+    ]
     progress: float | None = Field(default=None, ge=0, le=1)
     current_step: str | None = Field(default=None, max_length=2_000)
     elapsed_ms: int | None = Field(default=None, ge=0)
@@ -805,6 +820,8 @@ class HarnessSessionActivity(NebulaModel):
     mode: str | None = None
     plan: list[HarnessPlanEntry] = Field(default_factory=list)
     goal: HarnessGoalSnapshot | None = None
+    commands: list[dict[str, str]] = Field(default_factory=list)
+    commands_discovered: bool = False
 
 
 class HarnessCatalogItem(NebulaModel):
@@ -1463,11 +1480,16 @@ class _CodexRpc:
                 pending.set_result(message.get("result"))
             return
         if isinstance(message.get("method"), str):
+            if self._capture_notification(message):
+                return
             await self.events.put(message)
             return
         raise HarnessTransportError(
             f"{self.transport_name} returned an uncorrelatable message"
         )
+
+    def _capture_notification(self, message: dict[str, Any]) -> bool:
+        return False
 
     async def _drain_stderr(self) -> None:
         assert self.process is not None and self.process.stderr is not None
@@ -1901,7 +1923,12 @@ class CodexAppServerConnection(HarnessConnection):
                         payload=_bounded(params, limit=MAX_TOOL_RESULT_TEXT),
                     )
                 continue
-            if method in {"turn/goal/updated", "item/goal/updated", "goal/updated"}:
+            if method in {
+                "thread/goal/updated",
+                "turn/goal/updated",
+                "item/goal/updated",
+                "goal/updated",
+            }:
                 goal = _harness_goal_snapshot(
                     params.get("goal")
                     if isinstance(params.get("goal"), dict)
@@ -3819,6 +3846,38 @@ class _AcpRpc(_CodexRpc):
     transport_name = "Grok ACP"
     diagnostic_namespace = "grok_acp"
 
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.command_catalogs: dict[str, list[dict[str, str]]] = {}
+
+    def _capture_notification(self, message: dict[str, Any]) -> bool:
+        if "id" in message or message.get("method") not in {
+            "session/update",
+            "_x.ai/session/update",
+            "_x.ai/session_notification",
+        }:
+            return False
+        params = message.get("params")
+        if not isinstance(params, dict):
+            return False
+        update = params.get("update")
+        if (
+            not isinstance(update, dict)
+            or update.get("sessionUpdate") != "available_commands_update"
+        ):
+            return False
+        session_id = params.get("sessionId")
+        if (
+            isinstance(session_id, str)
+            and session_id
+            and isinstance(update.get("availableCommands"), list)
+        ):
+            if session_id in self.command_catalogs or len(self.command_catalogs) < 64:
+                self.command_catalogs[session_id] = normalize_commands(
+                    update["availableCommands"]
+                )
+        return True
+
     async def _write(self, value: dict[str, Any]) -> None:
         await super()._write({"jsonrpc": "2.0", **value})
 
@@ -3955,8 +4014,28 @@ def _harness_goal_snapshot(value: Any) -> HarnessGoalSnapshot | None:
         return None
     raw_status = str(value.get("status") or "pending").lower().replace("-", "_")
     status = cast(
-        Literal["pending", "running", "complete", "blocked", "failed"] | None,
+        Literal[
+            "pending",
+            "running",
+            "complete",
+            "blocked",
+            "failed",
+            "paused",
+            "usage_limited",
+            "budget_limited",
+        ]
+        | None,
         {
+            "active": "running",
+            "paused": "paused",
+            "user_paused": "paused",
+            "back_off_paused": "paused",
+            "no_progress_paused": "paused",
+            "infra_paused": "paused",
+            "usagelimited": "usage_limited",
+            "usage_limited": "usage_limited",
+            "budgetlimited": "budget_limited",
+            "budget_limited": "budget_limited",
             "running": "running",
             "in_progress": "running",
             "complete": "complete",
@@ -3975,7 +4054,9 @@ def _harness_goal_snapshot(value: Any) -> HarnessGoalSnapshot | None:
         )
     else:
         progress = None
-    elapsed_raw = value.get("elapsedMs") or value.get("elapsed_ms")
+    elapsed_raw = value.get("elapsedMs", value.get("elapsed_ms"))
+    if elapsed_raw is None and isinstance(value.get("timeUsedSeconds"), (int, float)):
+        elapsed_raw = value["timeUsedSeconds"] * 1_000
     token_budget_raw = value.get("tokenBudget") or value.get("token_budget")
     tokens_used_raw = value.get("tokensUsed") or value.get("tokens_used")
     return HarnessGoalSnapshot(
@@ -4011,9 +4092,140 @@ def _goal_item_status(goal: HarnessGoalSnapshot) -> HarnessItemStatus:
         return "queued"
     if goal.status == "running":
         return "running"
-    if goal.status == "complete":
+    if goal.status in {"complete", "paused"}:
         return "completed"
+    if goal.status in {"usage_limited", "budget_limited"}:
+        return "waiting_input"
     return "failed"
+
+
+def _connection_commands(connection: HarnessConnection) -> list[dict[str, str]]:
+    commands = {item["name"]: item for item in compatibility_commands()}
+    if isinstance(connection, GrokAcpConnection):
+        for item in getattr(connection.rpc, "command_catalogs", {}).get(
+            connection.external_session_id, []
+        ):
+            # Bridges retain stable Nebula semantics for help, goals and billing.
+            commands.setdefault(item["name"], item)
+    return list(commands.values())
+
+
+async def _run_harness_command(
+    connection: CodexAppServerConnection | GrokAcpConnection,
+    command: tuple[str, str],
+    *,
+    model: str,
+    context_prompt: str,
+    mode: str | None = None,
+) -> AsyncIterator[HarnessEvent]:
+    name, argument = command
+    catalog = _connection_commands(connection)
+    descriptor = next((item for item in catalog if "/" + item["name"] == name), None)
+    if descriptor is None:
+        raise HarnessConfigurationError(
+            f"{name} is not available in this harness session. Use /help to see available commands, then retry."
+        )
+    if descriptor["source"] == "native" and isinstance(connection, GrokAcpConnection):
+        async for event in connection.run_turn(
+            context_prompt,
+            model=model,
+            mode=mode,
+            command=f"{name} {argument}".rstrip(),
+        ):
+            if event.type == "completed" and not event.message:
+                reply = f"The harness returned no text for {name}. Check the session state before retrying."
+                yield HarnessEvent(
+                    type="message_delta", vendor=HarnessKind.GROK_ACP, delta=reply
+                )
+                event = event.model_copy(update={"message": reply})
+            yield event
+        return
+    if name == "/goals":
+        name = "/goal"
+    grok = isinstance(connection, GrokAcpConnection)
+    vendor = HarnessKind.GROK_ACP if grok else HarnessKind.CODEX_APP_SERVER
+    if name == "/goal" and isinstance(connection, GrokAcpConnection):
+        async for event in connection.run_turn(
+            context_prompt, model=model, mode=mode, command=f"/goal {argument}".rstrip()
+        ):
+            yield event
+        return
+    yield HarnessEvent(
+        type="started",
+        vendor=vendor,
+        external_session_id=connection.external_session_id,
+    )
+    if name == "/help":
+        reply = "Commands for this harness session:\n\n" + "\n\n".join(
+            f"/{item['name']} {item['hint'][:200]} — {item['description'][:240]}".replace(
+                "  —", " —"
+            )
+            for item in catalog
+        )
+    elif name == "/usage":
+        if argument:
+            raise HarnessConfigurationError(
+                "Use /usage without arguments to read this session's usage."
+            )
+        result = await connection.rpc.request(
+            "_x.ai/session/usage" if grok else "account/usage/read",
+            {"sessionId" if grok else "threadId": connection.external_session_id},
+        )
+        reply = usage_reply(result, grok=grok)
+    else:
+        params: dict[str, Any] = {"threadId": connection.external_session_id}
+        action = argument.lower()
+        if action in {"", "status"}:
+            method = "thread/goal/get"
+        elif action == "clear":
+            method = "thread/goal/clear"
+        else:
+            method = "thread/goal/set"
+            if action in {"pause", "resume"}:
+                params["status"] = "paused" if action == "pause" else "active"
+            else:
+                params.update(objective=argument, status="active")
+        result = await connection.rpc.request(method, params)
+        if not isinstance(result, dict):
+            raise HarnessTransportError(
+                "Codex returned an invalid goal response. Retry the command."
+            )
+        raw_goal = result.get("goal")
+        goal = _harness_goal_snapshot(raw_goal)
+        if action == "clear":
+            reply = "Goal cleared."
+        elif raw_goal is None and method == "thread/goal/get":
+            reply = "No goal is set. Use /goal <objective> to start one."
+        elif goal is None:
+            raise HarnessTransportError(
+                "Codex returned an unsupported goal state. Update the harness and retry."
+            )
+        else:
+            yield HarnessEvent(
+                type="item_upsert",
+                vendor=vendor,
+                item_id="turn-goal",
+                item_kind="goal",
+                item_status=_goal_item_status(goal),
+                title="Goal",
+                summary=goal.objective,
+                goal=goal,
+                payload={"goal": goal.model_dump(mode="json")},
+            )
+            assert isinstance(raw_goal, dict)
+            reply = f"Goal: {goal.objective}\n\nStatus: {raw_goal.get('status')}"
+            if method == "thread/goal/set" and action != "pause":
+                # Establish the vendor-owned goal before starting its first turn.
+                # Keep Core's context and the original operator request intact.
+                async for event in connection.run_turn(
+                    context_prompt, model=model, mode=mode
+                ):
+                    yield event
+                return
+    # A usage query is a transcript reply, never billable turn usage: otherwise
+    # repeated queries would add cumulative session totals to the run ledger.
+    yield HarnessEvent(type="message_delta", vendor=vendor, delta=reply)
+    yield HarnessEvent(type="completed", vendor=vendor, message=reply)
 
 
 class GrokAcpConnection(HarnessConnection):
@@ -4045,6 +4257,7 @@ class GrokAcpConnection(HarnessConnection):
         mode: str | None = None,
         skill: HarnessSkillInvocation | None = None,
         images: list[dict[str, Any]] | None = None,
+        command: str | None = None,
     ) -> AsyncIterator[HarnessEvent]:
         if images:
             raise HarnessConfigurationError(
@@ -4070,7 +4283,8 @@ class GrokAcpConnection(HarnessConnection):
                 "session/prompt",
                 {
                     "sessionId": self.external_session_id,
-                    "prompt": [{"type": "text", "text": prompt}],
+                    "prompt": ([{"type": "text", "text": command}] if command else [])
+                    + [{"type": "text", "text": prompt}],
                 },
             )
         )
@@ -4115,7 +4329,11 @@ class GrokAcpConnection(HarnessConnection):
                     async for event in self._permission(raw, params):
                         yield event
                     continue
-                if method != "session/update":
+                if method not in {
+                    "session/update",
+                    "_x.ai/session/update",
+                    "_x.ai/session_notification",
+                }:
                     yield HarnessEvent(
                         type="notice",
                         vendor=HarnessKind.GROK_ACP,
@@ -6891,13 +7109,39 @@ class HarnessRuntimeService:
                     turn_options["images"] = [
                         part for part in resolved_content if part["type"] == "image"
                     ]
-                async for event in _coalesce_activity_deltas(
-                    connection.run_turn(
+                command = (
+                    parse_harness_command(turn.prompt)
+                    if turn.origin == HarnessTurnOrigin.CHAT
+                    and isinstance(
+                        connection, (CodexAppServerConnection, GrokAcpConnection)
+                    )
+                    else None
+                )
+                if command and (
+                    turn_options.get("images") or turn_options.get("skill")
+                ):
+                    raise HarnessConfigurationError(
+                        "Send harness commands without images or a selected skill."
+                    )
+                turn_events = (
+                    _run_harness_command(
+                        connection,
+                        command,
+                        model=session.model,
+                        context_prompt=_harness_turn_prompt(turn),
+                        mode=turn_options.get("mode"),
+                    )
+                    if command
+                    and isinstance(
+                        connection, (CodexAppServerConnection, GrokAcpConnection)
+                    )
+                    else connection.run_turn(
                         _harness_turn_prompt(turn),
                         model=session.model,
                         **turn_options,
                     )
-                ):
+                )
+                async for event in _coalesce_activity_deltas(turn_events):
                     event = event.model_copy(
                         update={
                             "origin": turn.origin,
@@ -8525,6 +8769,7 @@ class HarnessRuntimeService:
                 if event.item_kind == "goal" and event.goal is not None:
                     goal = event.goal
 
+        connection = self._connections.get(session.id)
         return HarnessSessionActivity(
             session_id=session.id,
             session_status=session.status,
@@ -8539,6 +8784,21 @@ class HarnessRuntimeService:
             mode=mode,
             plan=plan,
             goal=goal,
+            commands=(
+                _connection_commands(connection)
+                if isinstance(connection, (GrokAcpConnection, CodexAppServerConnection))
+                and self.connection_state(session.id) != "disconnected"
+                else compatibility_commands()
+                if self.store.get(HarnessProfile, session.harness_profile_id).kind
+                in {HarnessKind.GROK_ACP, HarnessKind.CODEX_APP_SERVER}
+                else []
+            ),
+            commands_discovered=(
+                isinstance(connection, GrokAcpConnection)
+                and self.connection_state(session.id) != "disconnected"
+                and session.external_session_id
+                in getattr(connection.rpc, "command_catalogs", {})
+            ),
         )
 
     def _gateway_catalog(

--- a/tests/v3/test_harness_commands.py
+++ b/tests/v3/test_harness_commands.py
@@ -1,0 +1,498 @@
+import asyncio
+
+import pytest
+
+from nebula.v3.harness_commands import parse_harness_command, usage_reply
+from nebula.v3.harnesses import (
+    CodexAppServerConnection,
+    GrokAcpConnection,
+    HarnessEvent,
+    _harness_goal_snapshot,
+    _run_harness_command,
+)
+
+
+class Rpc:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+        self.events = asyncio.Queue()
+
+    async def request(self, method, params):
+        self.calls.append((method, params))
+        if method == "session/prompt":
+            await self.events.put(
+                {
+                    "method": "session/update",
+                    "params": {
+                        "update": {
+                            "sessionUpdate": "agent_message_chunk",
+                            "content": {"type": "text", "text": "Goal status: active"},
+                        }
+                    },
+                }
+            )
+            return {"stopReason": "end_turn"}
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        (" /goal build a clock ", ("/goal", "build a clock")),
+        ("/goals", ("/goals", "")),
+        ("/usage", ("/usage", "")),
+        ("Explain /goal", None),
+        ("/goalkeeper", ("/goalkeeper", "")),
+        ("/yolo", ("/yolo", "")),
+    ],
+)
+def test_command_parser_preserves_slash_syntax_for_catalog_validation(text, expected):
+    assert parse_harness_command(text) == expected
+
+
+@pytest.mark.parametrize("grok", [True, False])
+def test_usage_calls_selected_session_without_inference_or_double_accounting(grok):
+    async def scenario():
+        rpc = Rpc(
+            {"usage": {"inputTokens": 12, "outputTokens": 3}}
+            if grok
+            else {
+                "threadUsage": {
+                    "groups": [
+                        {"inputTokens": 12, "outputTokens": 3, "totalTokens": 15}
+                    ]
+                }
+            }
+        )
+        cls = GrokAcpConnection if grok else CodexAppServerConnection
+        connection = cls(
+            rpc, external_session_id="selected-session", permission_handler=None
+        )
+        events = [
+            event
+            async for event in _run_harness_command(
+                connection,
+                ("/usage", ""),
+                model="model",
+                context_prompt="wrapped /usage",
+            )
+        ]
+        assert rpc.calls == [
+            (
+                "_x.ai/session/usage" if grok else "account/usage/read",
+                {"sessionId" if grok else "threadId": "selected-session"},
+            )
+        ]
+        assert "Input tokens: 12" in events[-1].message
+        assert all(event.type != "usage" for event in events)
+
+    asyncio.run(scenario())
+
+
+def test_grok_goal_prefix_precedes_but_preserves_core_context():
+    async def scenario():
+        rpc = Rpc({})
+        connection = GrokAcpConnection(
+            rpc,
+            external_session_id="grok",
+            permission_handler=None,
+            developer_instructions="trusted capabilities",
+        )
+        events = [
+            event
+            async for event in _run_harness_command(
+                connection,
+                ("/goal", "status"),
+                model="model",
+                context_prompt="Core capability state and operator request",
+            )
+        ]
+        blocks = rpc.calls[0][1]["prompt"]
+        assert blocks[0] == {"type": "text", "text": "/goal status"}
+        assert "trusted capabilities" in blocks[1]["text"]
+        assert "Core capability state" in blocks[1]["text"]
+        assert events[-1].message == "Goal status: active"
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "argument,method,extra",
+    [
+        ("status", "thread/goal/get", {}),
+        ("pause", "thread/goal/set", {"status": "paused"}),
+        ("clear", "thread/goal/clear", {}),
+        (
+            "build a clock",
+            "thread/goal/set",
+            {"objective": "build a clock", "status": "active"},
+        ),
+        ("resume", "thread/goal/set", {"status": "active"}),
+    ],
+)
+def test_codex_goal_dispatch_and_continuation(argument, method, extra):
+    async def scenario():
+        rpc = Rpc(
+            {
+                "goal": {
+                    "objective": "build a clock",
+                    "status": "paused" if argument == "pause" else "active",
+                }
+            }
+        )
+        connection = CodexAppServerConnection(
+            rpc, external_session_id="codex", permission_handler=None
+        )
+        prompts = []
+
+        async def run_turn(prompt, **kwargs):
+            assert kwargs["mode"] == "plan"
+            prompts.append(prompt)
+            yield HarnessEvent(type="completed", message="Working on goal")
+
+        connection.run_turn = run_turn
+        events = [
+            event
+            async for event in _run_harness_command(
+                connection,
+                ("/goal", argument),
+                model="model",
+                context_prompt="trusted context",
+                mode="plan",
+            )
+        ]
+        assert rpc.calls == [(method, {"threadId": "codex", **extra})]
+        assert prompts == (
+            ["trusted context"] if argument in {"build a clock", "resume"} else []
+        )
+        assert events[-1].type == "completed"
+
+    asyncio.run(scenario())
+
+
+def test_unsupported_native_command_fails_without_model_fallback():
+    async def scenario():
+        rpc = Rpc(RuntimeError("Method not found"))
+        connection = CodexAppServerConnection(
+            rpc, external_session_id="codex", permission_handler=None
+        )
+        with pytest.raises(RuntimeError, match="Method not found"):
+            _ = [
+                event
+                async for event in _run_harness_command(
+                    connection, ("/usage", ""), model="model", context_prompt="context"
+                )
+            ]
+        assert len(rpc.calls) == 1
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "status,normalized",
+    [
+        ("active", "running"),
+        ("paused", "paused"),
+        ("usageLimited", "usage_limited"),
+        ("budgetLimited", "budget_limited"),
+    ],
+)
+def test_current_codex_goal_states_and_elapsed_time(status, normalized):
+    goal = _harness_goal_snapshot(
+        {"objective": "clock", "status": status, "timeUsedSeconds": 4}
+    )
+    assert goal.status == normalized
+    assert goal.elapsed_ms == 4_000
+
+
+def test_missing_usage_is_not_presented_as_zero_spend():
+    assert "no usage estimate" in usage_reply({"threadUsage": None}, grok=False)
+    with pytest.raises(ValueError):
+        usage_reply({}, grok=True)
+
+
+@pytest.mark.parametrize(
+    "method", ["_x.ai/session_notification", "_x.ai/session/update"]
+)
+def test_grok_native_goal_notifications_are_not_lost(method):
+    class GoalRpc(Rpc):
+        async def request(self, request_method, params):
+            if request_method == "session/prompt":
+                await self.events.put(
+                    {
+                        "method": method,
+                        "params": {
+                            "update": {
+                                "sessionUpdate": "goal_updated",
+                                "objective": "Clock",
+                                "status": "user_paused",
+                                "elapsedMs": 1200,
+                            }
+                        },
+                    }
+                )
+            return await super().request(request_method, params)
+
+    async def scenario():
+        connection = GrokAcpConnection(
+            GoalRpc({}), external_session_id="grok", permission_handler=None
+        )
+        events = [
+            event async for event in connection.run_turn("status", model="fixture")
+        ]
+        goal = next(event.goal for event in events if event.item_kind == "goal")
+        assert goal.status == "paused"
+        assert goal.elapsed_ms == 1200
+
+    asyncio.run(scenario())
+
+
+def test_acp_catalog_survives_idle_replay_drain_and_replaces_per_session():
+    import json
+    from nebula.v3.harnesses import (
+        _AcpRpc,
+        _discard_queued_session_replay,
+        _connection_commands,
+    )
+
+    async def scenario():
+        rpc = _AcpRpc()
+
+        async def advertise(session, commands):
+            await rpc._dispatch(
+                json.dumps(
+                    {
+                        "method": "session/update",
+                        "params": {
+                            "sessionId": session,
+                            "update": {
+                                "sessionUpdate": "available_commands_update",
+                                "availableCommands": commands,
+                            },
+                        },
+                    }
+                )
+            )
+
+        await advertise(
+            "a",
+            [
+                {
+                    "name": "vendor-check",
+                    "description": "Check project",
+                    "input": {"hint": "target"},
+                }
+            ],
+        )
+        await advertise("b", [{"name": "other", "description": "Other session"}])
+        await rpc.events.put({"method": "session/update", "params": {}})
+        _discard_queued_session_replay(rpc.events)
+        connection = GrokAcpConnection(
+            rpc, external_session_id="a", permission_handler=None
+        )
+        catalog = _connection_commands(connection)
+        assert catalog[-1] == {
+            "name": "vendor-check",
+            "description": "Check project",
+            "hint": "target",
+            "source": "native",
+        }
+        assert not any(item["name"] == "other" for item in catalog)
+        await advertise("a", [{"name": "replacement", "description": "New"}])
+        assert [item["name"] for item in _connection_commands(connection)][
+            -1
+        ] == "replacement"
+        assert not any(
+            item["name"] == "vendor-check" for item in _connection_commands(connection)
+        )
+        await advertise("a", [])
+        assert len(_connection_commands(connection)) == 4
+        assert rpc.events.empty()
+
+    asyncio.run(scenario())
+
+
+def test_catalog_validation_bounds_metadata_and_preserves_bridge_semantics():
+    from nebula.v3.harness_commands import normalize_commands
+    from nebula.v3.harnesses import _connection_commands
+
+    catalog = normalize_commands(
+        [
+            {"name": "../bad", "description": "bad"},
+            {"name": "two words", "description": "bad"},
+            {"name": "valid", "description": "x" * 2000, "input": {"hint": "y" * 900}},
+            {"name": "usage", "description": "Vendor usage"},
+            {"name": "bad", "description": None},
+        ]
+    )
+    assert len(catalog) == 2
+    assert len(catalog[0]["description"]) == 1000
+    assert len(catalog[0]["hint"]) == 500
+    rpc = Rpc({})
+    rpc.command_catalogs = {"a": catalog}
+    connection = GrokAcpConnection(
+        rpc, external_session_id="a", permission_handler=None
+    )
+    assert (
+        next(
+            item for item in _connection_commands(connection) if item["name"] == "usage"
+        )["source"]
+        == "nebula"
+    )
+
+
+def test_discovered_command_dispatch_and_help_share_catalog_without_new_handler():
+    async def scenario():
+        rpc = Rpc({})
+        rpc.command_catalogs = {
+            "a": [
+                {
+                    "name": "vendor-check",
+                    "description": "Check project",
+                    "hint": "target",
+                    "source": "native",
+                }
+            ]
+        }
+        connection = GrokAcpConnection(
+            rpc, external_session_id="a", permission_handler=None
+        )
+        events = [
+            event
+            async for event in _run_harness_command(
+                connection, ("/help", ""), model="fixture", context_prompt="context"
+            )
+        ]
+        assert "/vendor-check target" in events[-1].message
+        assert not rpc.calls
+        events = [
+            event
+            async for event in _run_harness_command(
+                connection,
+                ("/vendor-check", "a  b"),
+                model="fixture",
+                context_prompt="trusted context",
+            )
+        ]
+        assert rpc.calls[0] == (
+            "session/prompt",
+            {
+                "sessionId": "a",
+                "prompt": [
+                    {"type": "text", "text": "/vendor-check a  b"},
+                    {"type": "text", "text": "trusted context"},
+                ],
+            },
+        )
+        rpc.command_catalogs["a"] = []
+        with pytest.raises(Exception, match="not available.*Use /help"):
+            _ = [
+                event
+                async for event in _run_harness_command(
+                    connection,
+                    ("/vendor-check", ""),
+                    model="fixture",
+                    context_prompt="context",
+                )
+            ]
+        assert len(rpc.calls) == 1
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("grok", [True, False])
+def test_unknown_command_is_rejected_without_inference(grok):
+    from nebula.v3.harness_commands import parse_harness_command
+    from nebula.v3.harnesses import HarnessConfigurationError
+
+    async def scenario():
+        rpc = Rpc({})
+        connection = (GrokAcpConnection if grok else CodexAppServerConnection)(
+            rpc, external_session_id="a", permission_handler=None
+        )
+        with pytest.raises(HarnessConfigurationError, match="Use /help"):
+            _ = [
+                event
+                async for event in _run_harness_command(
+                    connection,
+                    parse_harness_command("/unknown argument"),
+                    model="fixture",
+                    context_prompt="context",
+                )
+            ]
+        assert rpc.calls == []
+        assert parse_harness_command("/home/operator/project") is None
+        assert parse_harness_command("Explain /unknown") is None
+
+    asyncio.run(scenario())
+
+
+def test_discovered_command_without_text_has_an_explicit_durable_reply():
+    async def scenario():
+        rpc = Rpc({})
+        rpc.command_catalogs = {
+            "a": [
+                {
+                    "name": "quiet",
+                    "description": "Quiet command",
+                    "hint": "",
+                    "source": "native",
+                }
+            ]
+        }
+        connection = GrokAcpConnection(
+            rpc, external_session_id="a", permission_handler=None
+        )
+
+        async def run_turn(*args, **kwargs):
+            yield HarnessEvent(type="completed", message="")
+
+        connection.run_turn = run_turn
+        events = [
+            event
+            async for event in _run_harness_command(
+                connection, ("/quiet", ""), model="fixture", context_prompt="context"
+            )
+        ]
+        assert events[-2].type == "message_delta"
+        assert "returned no text for /quiet" in events[-1].message
+        assert not rpc.calls
+
+    asyncio.run(scenario())
+
+
+def test_help_keeps_all_names_within_durable_message_limit():
+    from nebula.v3.harness_commands import normalize_commands
+
+    async def scenario():
+        rpc = Rpc({})
+        rpc.command_catalogs = {
+            "a": normalize_commands(
+                [
+                    {
+                        "name": "x" * 120 + str(i),
+                        "description": "d" * 1000,
+                        "input": {"hint": "h" * 500},
+                    }
+                    for i in range(256)
+                ]
+            )
+        }
+        connection = GrokAcpConnection(
+            rpc, external_session_id="a", permission_handler=None
+        )
+        events = [
+            event
+            async for event in _run_harness_command(
+                connection, ("/help", ""), model="fixture", context_prompt="context"
+            )
+        ]
+        assert all(
+            "/" + item["name"] in events[-1].message
+            for item in rpc.command_catalogs["a"]
+        )
+
+    asyncio.run(scenario())

--- a/ui/playwright-impact.json
+++ b/ui/playwright-impact.json
@@ -85,6 +85,138 @@
         "shard": "1/1"
       }
     ],
+    "harness-commands-real": [
+  {
+    "area": "harness-commands-real",
+    "project": "assistant-real-desktop",
+    "test_match": "tests/real-core.spec.ts",
+    "grep": "assistant upgrade native commands retain thinking",
+    "runtime": "real-core",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands-real",
+    "project": "assistant-real-compact",
+    "test_match": "tests/real-core.spec.ts",
+    "grep": "assistant upgrade native commands retain thinking",
+    "runtime": "real-core",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands-real",
+    "project": "assistant-real-chromium-320",
+    "test_match": "tests/real-core.spec.ts",
+    "grep": "assistant upgrade native commands retain thinking",
+    "runtime": "real-core",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands-real",
+    "project": "assistant-real-webkit-320",
+    "test_match": "tests/real-core.spec.ts",
+    "grep": "assistant upgrade native commands retain thinking",
+    "runtime": "real-core",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands-real",
+    "project": "assistant-real-chromium-390",
+    "test_match": "tests/real-core.spec.ts",
+    "grep": "assistant upgrade native commands retain thinking",
+    "runtime": "real-core",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands-real",
+    "project": "assistant-real-webkit-390",
+    "test_match": "tests/real-core.spec.ts",
+    "grep": "assistant upgrade native commands retain thinking",
+    "runtime": "real-core",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands-real",
+    "project": "assistant-real-chromium-430",
+    "test_match": "tests/real-core.spec.ts",
+    "grep": "assistant upgrade native commands retain thinking",
+    "runtime": "real-core",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands-real",
+    "project": "assistant-real-webkit-430",
+    "test_match": "tests/real-core.spec.ts",
+    "grep": "assistant upgrade native commands retain thinking",
+    "runtime": "real-core",
+    "shard": "1/1"
+  }
+],
+    "harness-commands": [
+  {
+    "area": "harness-commands",
+    "project": "desktop",
+    "test_match": "tests/interface.spec.ts",
+    "grep": "stabilization harness commands and thinking",
+    "runtime": "mock",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands",
+    "project": "compact",
+    "test_match": "tests/interface.spec.ts",
+    "grep": "stabilization harness commands and thinking",
+    "runtime": "mock",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands",
+    "project": "mobile-chromium-small",
+    "test_match": "tests/interface.spec.ts",
+    "grep": "stabilization harness commands and thinking",
+    "runtime": "mock",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands",
+    "project": "mobile-chromium-ledger-390",
+    "test_match": "tests/interface.spec.ts",
+    "grep": "stabilization harness commands and thinking",
+    "runtime": "mock",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands",
+    "project": "mobile-chromium-wide",
+    "test_match": "tests/interface.spec.ts",
+    "grep": "stabilization harness commands and thinking",
+    "runtime": "mock",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands",
+    "project": "mobile-webkit-small",
+    "test_match": "tests/interface.spec.ts",
+    "grep": "stabilization harness commands and thinking",
+    "runtime": "mock",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands",
+    "project": "mobile-webkit",
+    "test_match": "tests/interface.spec.ts",
+    "grep": "stabilization harness commands and thinking",
+    "runtime": "mock",
+    "shard": "1/1"
+  },
+  {
+    "area": "harness-commands",
+    "project": "mobile-webkit-wide",
+    "test_match": "tests/interface.spec.ts",
+    "grep": "stabilization harness commands and thinking",
+    "runtime": "mock",
+    "shard": "1/1"
+  }
+],
     "harness-accounts": [
   {
     "area": "harness-accounts",

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -1294,7 +1294,7 @@ interface WireChatStreamEvent extends JsonObject {
   plan?: Array<{ id: string; title: string; status: "pending" | "in_progress" | "completed" | "blocked" }>;
   goal?: {
     objective: string;
-    status: "pending" | "running" | "complete" | "blocked" | "failed";
+    status: "pending" | "running" | "complete" | "blocked" | "failed" | "paused" | "usage_limited" | "budget_limited";
     progress?: number | null;
     current_step?: string | null;
     elapsed_ms?: number | null;
@@ -1468,6 +1468,8 @@ interface WireHarnessSession extends WireEntity {
 }
 
 interface WireHarnessSessionActivity extends JsonObject {
+  commands?: HarnessSessionActivity["commands"];
+  commands_discovered?: boolean;
   session_id: string;
   session_status: HarnessSessionSummary["status"];
   busy: boolean;
@@ -1486,7 +1488,7 @@ interface WireHarnessSessionActivity extends JsonObject {
   }>;
   goal?: {
     objective: string;
-    status: "pending" | "running" | "complete" | "blocked" | "failed";
+    status: "pending" | "running" | "complete" | "blocked" | "failed" | "paused" | "usage_limited" | "budget_limited";
     progress?: number | null;
     current_step?: string | null;
     elapsed_ms?: number | null;
@@ -3265,6 +3267,8 @@ function mapHarnessSessionActivity(
   return {
     sessionId: value.session_id,
     sessionStatus: value.session_status,
+    commands: value.commands,
+    commandsDiscovered: value.commands_discovered ?? false,
     busy: value.busy,
     live: value.live,
     turnId: value.turn_id ?? undefined,

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -1515,7 +1515,7 @@ export interface HarnessPlanEntry {
 
 export interface HarnessGoalSnapshot {
   objective: string;
-  status: "pending" | "running" | "complete" | "blocked" | "failed";
+  status: "pending" | "running" | "complete" | "blocked" | "failed" | "paused" | "usage_limited" | "budget_limited";
   progress?: number;
   currentStep?: string;
   elapsedMs?: number;
@@ -1928,7 +1928,16 @@ export interface HarnessSessionSummary {
   lastActivityAt: string;
 }
 
+export interface HarnessCommand {
+  name: string;
+  description: string;
+  hint: string;
+  source: "native" | "nebula";
+}
+
 export interface HarnessSessionActivity {
+  commands?: HarnessCommand[];
+  commandsDiscovered?: boolean;
   sessionId: Identifier;
   sessionStatus: HarnessSessionSummary["status"];
   busy: boolean;

--- a/ui/src/components/HarnessCommandHints.tsx
+++ b/ui/src/components/HarnessCommandHints.tsx
@@ -1,0 +1,28 @@
+import type { HarnessCommand } from "../api/types";
+
+// New sessions have no peer yet. Core supplies the authoritative catalog once connected.
+export const harnessCommands: HarnessCommand[] = [
+  { name: "goal", description: "Set or inspect a goal", hint: "<objective> | status | pause | resume | clear", source: "nebula" },
+  { name: "goals", description: "Alias for /goal", hint: "", source: "nebula" },
+  { name: "usage", description: "Session usage", hint: "", source: "nebula" },
+  { name: "help", description: "Command help", hint: "", source: "nebula" },
+];
+
+export function isHarnessCommand(text: string): boolean {
+  return /^\/[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}(?:\s|$)/.test(text.trim());
+}
+
+export function HarnessCommandHints({ draft, onSelect, commands = harnessCommands, discoveryPending = false }: {
+  draft: string;
+  onSelect: (text: string) => void;
+  commands?: HarnessCommand[];
+  discoveryPending?: boolean;
+}) {
+  if (!draft.startsWith("/") || /\s/.test(draft)) return null;
+  const matches = commands.filter(({ name }) => `/${name}`.startsWith(draft));
+  return <div className="harness-command-hints" aria-label="Harness commands">
+    {matches.map(({ name, description, hint }) => <button className="button quiet" type="button" key={name} title={hint || description} aria-label={`/${name} ${description}`} onClick={() => onSelect(`/${name} `)}><strong>/{name}</strong><span>{description}{hint && <small>{hint}</small>}</span></button>)}
+    {!matches.length && <span role="status">Command unavailable. Use /help to see available commands.</span>}
+    {discoveryPending && <small>Use /help to connect and discover session commands.</small>}
+  </div>;
+}

--- a/ui/src/components/HarnessStatusRail.tsx
+++ b/ui/src/components/HarnessStatusRail.tsx
@@ -41,7 +41,7 @@ export function HarnessStatusRail({ activity, pendingRequests, authoritativeStat
     <strong>{status}</strong>
     {elapsed !== undefined && activity.busy && <span>{Math.floor(elapsed / 60)}m {elapsed % 60}s</span>}
     {currentStep && !expanded && <span title={currentStep}>{currentStep}</span>}
-    {activity.goal && <span title={activity.goal.objective}>Goal: {activity.goal.status}{typeof activity.goal.progress === "number" ? ` · ${Math.round(activity.goal.progress * 100)}%` : ""}</span>}
+    {activity.goal && <span title={activity.goal.objective}>Goal: {activity.goal.status.replaceAll("_", " ")}{typeof activity.goal.progress === "number" ? ` · ${Math.round(activity.goal.progress * 100)}%` : ""}</span>}
     {plan.length > 0 && <span>{completed}/{plan.length} plan steps</span>}
     {pendingRequests > 0 && <span>{pendingRequests} request{pendingRequests === 1 ? "" : "s"}</span>}
   </>;

--- a/ui/src/components/HarnessThinking.test.tsx
+++ b/ui/src/components/HarnessThinking.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { HarnessThinking } from "./HarnessThinking";
+import { HarnessCommandHints, isHarnessCommand } from "./HarnessCommandHints";
+import { reduceHarnessActivity } from "../pages/harnessActivity";
+
+describe("Harness thinking and commands", () => {
+  for (const vendor of ["grok_acp", "codex_app_server"] as const) {
+    it(`keeps ${vendor} thinking accessible through streaming, completion and replay`, async () => {
+      const user = userEvent.setup();
+      const event = { schemaVersion: "nebula.harness-activity/v2" as const, type: "output_delta" as const, vendor, itemId: "thinking-1", itemKind: "reasoning" as const, itemStatus: "streaming" as const, title: "Reasoning", stream: "reasoning_summary" as const, delta: "First line\nSecond line", sequence: 1, payload: {}, artifactIds: [] };
+      const live = reduceHarnessActivity([], event, "assistant");
+      const { rerender } = render(<HarnessThinking items={live} />);
+      const summary = screen.getByText("Thinking…");
+      expect(summary.closest("details")).not.toHaveAttribute("open");
+      await user.click(summary);
+      expect(screen.getByText(/First line/)).toBeVisible();
+      const completed = reduceHarnessActivity(live, { ...event, sequence: 2, type: "item_upsert", delta: undefined, itemStatus: "completed", title: "Thinking" }, "assistant");
+      rerender(<HarnessThinking items={completed} />);
+      expect(screen.getByText("Thinking")).toBeVisible();
+      expect(screen.getByText(/Second line/)).toBeVisible();
+      rerender(<HarnessThinking items={JSON.parse(JSON.stringify(completed))} />);
+      expect(screen.getByText(/First line/)).toBeVisible();
+    });
+  }
+
+  it("does not render hidden reasoning or empty content", () => {
+    render(<HarnessThinking items={[]} />);
+    expect(screen.queryByLabelText("Harness thinking")).toBeNull();
+  });
+
+  it("discovers commands and inserts syntax without executing", async () => {
+    expect(isHarnessCommand(" /usage ")).toBe(true);
+    expect(isHarnessCommand("/goals status")).toBe(true);
+    expect(isHarnessCommand("/home/operator/project")).toBe(false);
+    expect(isHarnessCommand("Explain /goal")).toBe(false);
+    const selected: string[] = [];
+    const user = userEvent.setup();
+    const { rerender } = render(<HarnessCommandHints draft="/" onSelect={(text) => selected.push(text)} />);
+    await user.click(screen.getByRole("button", { name: "/goal Set or inspect a goal" }));
+    expect(selected).toEqual(["/goal "]);
+    rerender(<HarnessCommandHints draft="/u" onSelect={() => {}} />);
+    expect(screen.getByRole("button", { name: "/usage Session usage" })).toBeVisible();
+    expect(screen.queryByText("/goal")).toBeNull();
+    rerender(<HarnessCommandHints draft="/goal do the work" onSelect={() => {}} />);
+    expect(screen.queryByLabelText("Harness commands")).toBeNull();
+  });
+});
+
+
+it("uses updated session command metadata and removes withdrawn commands", async () => {
+  const selected: string[] = [];
+  const commands = [{ name: "vendor-check", description: "Check project", hint: "target", source: "native" as const }];
+  const { rerender } = render(<HarnessCommandHints draft="/" commands={commands} onSelect={text => selected.push(text)} />);
+  const button = screen.getByRole("button", { name: "/vendor-check Check project" });
+  expect(button).toHaveAttribute("title", "target");
+  await userEvent.setup().click(button);
+  expect(selected).toEqual(["/vendor-check "]);
+  expect(isHarnessCommand("/vendor-check target")).toBe(true);
+  expect(isHarnessCommand("/unknown")).toBe(true);
+  rerender(<HarnessCommandHints draft="/vendor" commands={[]} onSelect={() => {}} />);
+  expect(screen.queryByRole("button")).toBeNull();
+  expect(screen.getByRole("status")).toHaveTextContent("Command unavailable");
+});

--- a/ui/src/components/HarnessThinking.tsx
+++ b/ui/src/components/HarnessThinking.tsx
@@ -1,0 +1,11 @@
+import { reasoningSummaryState, reasoningSummaryText, type HarnessActivityItem } from "../pages/harnessActivity";
+
+export function HarnessThinking({ items }: { items: HarnessActivityItem[] }) {
+  const thoughts = items.filter((item) => reasoningSummaryText(item) || reasoningSummaryState(item) === "pending");
+  if (!thoughts.length) return null;
+  const active = thoughts.some((item) => ["running", "streaming", "pending"].includes(item.status ?? ""));
+  return <details className="harness-thinking" aria-label="Harness thinking">
+    <summary>{active ? "Thinking…" : "Thinking"}<span>{thoughts.length > 1 ? `${thoughts.length} sections` : ""}</span></summary>
+    {thoughts.map((item) => <p className="harness-reasoning-summary" key={item.key}>{reasoningSummaryText(item) || "Waiting for a summary from the harness…"}</p>)}
+  </details>;
+}

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -107,6 +107,8 @@ import { ModalSurface, useConfirmation } from "../components/DialogSystem";
 import { copySelectionText, createHashedSelectionAttachment } from "../components/selection";
 import { WorkspacePanel } from "../components/WorkspacePanel";
 import { HarnessSkillAutocomplete, findHarnessSkillToken, type HarnessSkillTokenRange } from "../components/HarnessSkillAutocomplete";
+import { HarnessThinking } from "../components/HarnessThinking";
+import { HarnessCommandHints, isHarnessCommand } from "../components/HarnessCommandHints";
 import { HarnessStatusRail } from "../components/HarnessStatusRail";
 import { WorkbenchBrowser } from "../components/WorkbenchBrowser";
 import { TabBar, Toolbar } from "../components/SurfacePrimitives";
@@ -301,7 +303,7 @@ function AssistantLedgerEntryDetails({ entry }: { entry: ActivityLedgerEntry }) 
   if (!item) return null;
   const summaryText = reasoningSummaryText(item);
   return <div className="activity-ledger-entry-body">
-    {item.summary && <p>{item.summary}</p>}
+    {(item.streams.commentary || item.summary) && <p>{item.streams.commentary || item.summary}</p>}
     {summaryText && <p className="harness-reasoning-summary">{summaryText}</p>}
     {reasoningSummaryState(item) === "pending" && !summaryText && <p>Thinking is in progress. Text will appear if the harness provides it.</p>}
     {reasoningSummaryState(item) === "not_provided" && <p>No thinking summary was provided by the harness.</p>}
@@ -2228,6 +2230,7 @@ export function SessionsPage() {
     if (activeTurn && !queuedFollowUp && !queueOptions) {
       const text = draft.trim();
       const canSteer = sending
+        && !isHarnessCommand(text)
         && runtimeKind === "harness"
         && Boolean(selectedHarness?.capabilities?.steering)
         && Boolean(harnessProgress?.turnId || harnessActivity?.turnId)
@@ -2952,7 +2955,8 @@ export function SessionsPage() {
   const composerBusy = sending || Boolean(authoritativeState?.busy) || pendingResponseActive;
   const canSend = Boolean(api && coreState === "online" && engagement && runtimeReady && model.trim() && (draft.trim() || pendingImages.length) && !composerBusy && !uploadingImage);
   const canSteerCurrentHarness = Boolean(
-    sending
+    !isHarnessCommand(draft)
+    && sending
     && runtimeKind === "harness"
     && selectedHarness?.capabilities?.steering
     && (harnessProgress?.turnId || harnessActivity?.turnId)
@@ -3132,6 +3136,7 @@ export function SessionsPage() {
                       {commentaryItems.length > 0 && <div className={`assistant-commentary${message.state === "streaming" ? " live" : ""}`} aria-label="Assistant commentary" aria-live="polite">
                         {commentaryItems.map((item) => <p key={item.key}>{item.text}</p>)}
                       </div>}
+                      {message.role === "assistant" && <HarnessThinking items={messageActivityItems} />}
                       {message.content && (message.role === "assistant"
                         ? <AssistantMarkdown content={message.content} messageId={message.id} durable={message.durable && message.state === "complete"} streaming={message.state === "streaming"} runnableLanguages={assistantRunnableLanguages} onRun={setRunCandidate} onRunInTerminal={runInTerminal} />
                         : <p>{message.content}</p>)}
@@ -3222,6 +3227,7 @@ export function SessionsPage() {
                 <label className="sr-only" htmlFor="analyst-message">Message the analyst assistant</label>
                 <div className="chat-composer-input" role="combobox" aria-label="Skill suggestions" aria-autocomplete="list" aria-expanded={Boolean(skillToken)} aria-controls={skillToken ? "harness-skill-menu" : undefined} aria-activedescendant={skillToken && matchingHarnessSkills.length ? `harness-skill-option-${skillMenuIndex}` : undefined}>
                   <textarea ref={composerRef} id="analyst-message" data-selection-actions-disabled="true" value={draft} disabled={!engagement || !runtimeReady || loadingHistory} placeholder={!engagement ? "Create or select a project to chat…" : canSteerCurrentHarness ? "Add guidance while the harness works…" : canStopAndSend ? "Queue a follow-up or send it now…" : queueMode ? "Queue the next message while this response finishes…" : runtimeReady ? "Ask about this project…" : "Add a model or harness in Settings…"} rows={1} onFocus={() => setAssistantSettingsOpen(false)} onPaste={pasteComposerImages} onKeyDown={onComposerKeyDown} onChange={(event) => updateComposerDraft(event.target.value, event.target.selectionStart ?? event.target.value.length)} />
+                  {runtimeKind === "harness" && ["grok_acp", "codex_app_server"].includes(selectedHarness?.kind ?? "") && <HarnessCommandHints draft={draft} commands={harnessActivity?.sessionId === harnessSessionId && !harnessActivityError ? harnessActivity.commands : undefined} discoveryPending={selectedHarness?.kind === "grok_acp" && (harnessActivity?.sessionId !== harnessSessionId || !harnessActivity?.commandsDiscovered || Boolean(harnessActivityError))} onSelect={(text) => { updateComposerDraft(text); composerRef.current?.focus(); }} />}
                   {skillToken && <HarnessSkillAutocomplete skills={harnessSkills} token={skillToken} activeIndex={skillMenuIndex} onActiveIndexChange={setSkillMenuIndex} onSelect={selectHarnessSkill} onClose={() => setSkillToken(undefined)} />}
                 </div>
                 <footer><button ref={assistantSettingsButtonRef} className={`button quiet chat-runtime-summary chat-settings-trigger${runtimeReady ? "" : " needs-attention"}`} type="button" aria-label="Assistant settings" aria-expanded={assistantSettingsOpen} aria-controls="assistant-settings-popover" title={runtimeReady ? `${assistantSource}${runtimeConfiguration ? ` · ${runtimeConfiguration}` : ""}` : "Choose an assistant runtime"} onClick={() => setAssistantSettingsOpen((open) => !open)}><Settings2 size={15} aria-hidden="true" /><span><strong>{assistantSource}</strong><small> · {runtimeConfiguration || "Choose a model"}</small></span></button>{sessionId && <button className={`button quiet chat-context-meter status-${activeContextStatus?.status ?? "loading"}`} type="button" aria-label={contextPercent === undefined ? "Open context details" : `Open context details, ${contextPercent} percent of target input used`} title={activeContextStatus?.status === "runtime_managed" ? "Context is managed by the harness runtime" : contextPercent === undefined ? "Read authoritative context status" : `${activeContextStatus?.estimatedInputTokens.toLocaleString()} of ${activeContextStatus?.targetInputTokens.toLocaleString()} target input tokens`} onClick={() => { localStorage.setItem("nebula.session-inspector.open", "true"); setSessionInspectorOpen(true); }}><span aria-hidden="true" style={contextPercent === undefined ? undefined : { "--context-percent": `${contextPercent}%` } as CSSProperties}>{contextPercent === undefined ? <Gauge size={16} aria-hidden="true" /> : contextPercent}</span></button>}<button className="button quiet chat-composer-icon" type="button" aria-label="Results" title="Results" disabled={!sessionId} onClick={() => setSearchParams(current => {const next = new URLSearchParams(current); next.set("drawer", "results"); return next;})}><FileClock size={18} aria-hidden="true" /></button><input ref={imageInputRef} className="sr-only" type="file" aria-label="Choose image attachments" accept="image/png,image/jpeg,image/webp" multiple onChange={(event) => void attachImages(event)} />{api && engagement && <ChatAttachments key={engagement.id} api={api} projectId={engagement.id} onAttach={request => requestNebulaDraft(request, view === "browser" ? "browser" : "chat")} onImages={() => imageInputRef.current?.click()} imagesEnabled={imageInputEnabled && !composerBusy} />}{canSteerCurrentHarness && draft.trim() && <button className="button primary square chat-composer-submit" type="submit" disabled={harnessControlBusy} aria-label="Guide current turn" title="Guide the current turn"><Send size={16} /></button>}{canStopAndSend && draft.trim() && <><button className="button quiet square chat-composer-submit" type="button" onClick={() => void submit(undefined, undefined, {})} aria-label="Queue follow-up message" title="Send next after the active response"><ListTodo size={16} /></button><button className="button primary chat-composer-send-now" type="button" aria-label="Stop and send" title="Stop the current turn and send this message next" onClick={() => void stopAndSend()}><Send size={15} /><span className="chat-composer-send-now-label">Stop and send</span></button></>}{(queueMode || canSteerCurrentHarness) && !canStopAndSend && draft.trim() && <button className="button primary square chat-composer-submit" type="button" onClick={() => void submit(undefined, undefined, {})} aria-label="Queue follow-up message" title="Send next after the active response"><ListTodo size={16} /></button>}{sending && <button className="button secondary square chat-composer-submit" type="button" aria-label="Stop response" disabled={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false} title={runtimeKind === "harness" && selectedHarness?.capabilities?.interruption === false ? "This harness does not advertise turn interruption" : undefined} onClick={() => void stopCurrentResponse()}><Square size={15} /></button>}{sessionId && draft.trim() && !composerBusy && <button type="button" className="button quiet square chat-composer-submit" aria-label="Queue for later" title="Queue for later" disabled={coreQueue.busy} onClick={() => void submit(undefined, undefined, {paused: true})}><ListTodo size={18} aria-hidden="true" /></button>}{!composerBusy && <button className="button primary square chat-composer-submit" type="submit" onPointerDown={(event) => { if (view === "browser") event.preventDefault(); }} disabled={!canSend} aria-label="Send message"><Send size={16} /></button>}</footer>

--- a/ui/src/pages/harnessActivity.test.ts
+++ b/ui/src/pages/harnessActivity.test.ts
@@ -46,6 +46,7 @@ describe("harness activity presentation", () => {
     expect(isSameHarnessSessionActivity(activityState, { ...activityState })).toBe(true);
     expect(isSameHarnessSessionActivity(activityState, { ...activityState, busy: true })).toBe(false);
     expect(isSameHarnessSessionActivity(undefined, activityState)).toBe(false);
+    expect(isSameHarnessSessionActivity(activityState, { ...activityState, commands: [{ name: "new", description: "New command", hint: "", source: "native" }] })).toBe(false);
   });
 
   it("keeps routine turn status out of the assistant timeline", () => {

--- a/ui/src/pages/harnessActivity.ts
+++ b/ui/src/pages/harnessActivity.ts
@@ -23,6 +23,8 @@ export function isSameHarnessSessionActivity(
     && current.startedAt === next.startedAt
     && current.lastActivityAt === next.lastActivityAt
     && current.detail === next.detail
+    && current.commandsDiscovered === next.commandsDiscovered
+    && JSON.stringify(current.commands) === JSON.stringify(next.commands)
     && current.mode === next.mode
     && JSON.stringify(current.plan) === JSON.stringify(next.plan)
     && JSON.stringify(current.goal) === JSON.stringify(next.goal);

--- a/ui/src/ui.css
+++ b/ui/src/ui.css
@@ -72,7 +72,7 @@
 
 /* Assistant controls share a bounded column; transcript and composer stay reachable. */
 .chat-panel > .chat-thread { flex: 1 1 0; min-height: 0; overflow: hidden; }
-.chat-operator-updates { flex: 0 0 auto; min-height: 0; max-height: min(240px, 30dvh); overflow: auto; overscroll-behavior: contain; width: min(var(--chat-reading-track), calc(100% - 24px)); margin-inline: auto; }
+.chat-operator-updates { flex: 0 0 auto; min-height: 0; max-height: min(240px, 30cqh); overflow: auto; overscroll-behavior: contain; width: min(var(--chat-reading-track), calc(100% - 24px)); margin-inline: auto; }
 .chat-operator-updates:empty { display: none; }
 .chat-operator-updates > * { margin: 6px 0; }
 .chat-operator-updates .chat-follow-up-queue, .chat-operator-updates .chat-catch-up { max-height: none; overflow: visible; }
@@ -102,7 +102,7 @@
   .chat-message-actions > button { min-width: 44px; min-height: 44px; }
   .chat-composer footer .chat-runtime-summary { max-width: 120px; }
   .chat-composer footer .chat-context-meter { min-width: 44px; }
-  .chat-operator-updates { max-height: min(200px, 30dvh); width: calc(100% - 12px); }
+  .chat-operator-updates { max-height: min(200px, 30cqh); width: calc(100% - 12px); }
   .assistant-search summary { min-height: 44px; display: flex; align-items: center; }
 }
 
@@ -163,3 +163,14 @@
 .activity-ledger-failure[open] > summary > svg { transform: rotate(180deg); }
 .activity-ledger-failure > summary:focus-visible { outline: 2px solid var(--focus); outline-offset: -2px; border-radius: inherit; }
 .activity-ledger-failure > .activity-ledger-entry-body { padding: 0 12px 10px; }
+
+.harness-thinking { margin-block: 8px; min-width: 0; }
+.harness-thinking > summary { cursor: pointer; min-height: 44px; padding: 10px 4px; }
+.harness-thinking > summary span { margin-inline-start: 12px; font-size: 0.85em; }
+.harness-thinking > summary:focus-visible { outline: 2px solid currentColor; outline-offset: 2px; }
+.harness-thinking .harness-reasoning-summary { white-space: pre-wrap; overflow-wrap: anywhere; }
+.harness-command-hints { display: flex; flex-wrap: wrap; gap: 4px; max-height: min(8rem, 18cqh); overflow-y: auto; }
+.harness-command-hints button { min-height: 44px; gap: 8px; flex-wrap: wrap; }
+
+.harness-command-hints button > span { min-width: 0; overflow-wrap: anywhere; }
+.harness-command-hints small { display: -webkit-box; -webkit-line-clamp: 1; -webkit-box-orient: vertical; overflow: hidden; font-size: .75rem; color: var(--muted); }

--- a/ui/tests/fixtures/approval_core.py
+++ b/ui/tests/fixtures/approval_core.py
@@ -25,6 +25,8 @@ from nebula.v3.domain import (
     ToolCall,
 )
 from nebula.v3.harnesses import (
+    CodexAppServerConnection,
+    GrokAcpConnection,
     HarnessAdapter,
     HarnessConnection,
     HarnessRuntimeService,
@@ -173,6 +175,19 @@ class InertAdapter(HarnessAdapter):
         )
 
     async def open(self, request):
+        if self.runtime.scenario == "commands":
+            from command_peer import CommandPeer
+
+            cls = (
+                CodexAppServerConnection
+                if request.profile.kind == HarnessKind.CODEX_APP_SERVER
+                else GrokAcpConnection
+            )
+            return cls(
+                CommandPeer(self.runtime.fixture_root, request.session.id),
+                external_session_id=request.session.id,
+                permission_handler=None,
+            )
         return InertConnection(request, self.runtime)
 
 
@@ -198,6 +213,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--scenario",
         choices=[
+            "commands",
             "settings",
             "single",
             "two_requests",

--- a/ui/tests/fixtures/command_peer.py
+++ b/ui/tests/fixtures/command_peer.py
@@ -1,0 +1,164 @@
+"""Inert protocol peer; Core and the production harness adapters remain real."""
+
+import asyncio
+import json
+
+from nebula.v3.harnesses import HarnessTransportError, _AcpRpc
+
+
+class CommandPeer(_AcpRpc):
+    connection_state = "connected"
+
+    def __init__(self, root, session_id):
+        self.events = asyncio.Queue()
+        self.command_catalogs = {}
+        self._capture_notification(
+            {
+                "method": "session/update",
+                "params": {
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "available_commands_update",
+                        "availableCommands": [
+                            {
+                                "name": "vendor-check",
+                                "description": "Check project",
+                                "input": {"hint": "target"},
+                            }
+                        ],
+                    },
+                },
+            }
+        )
+        self.root, self.session_id = root, session_id
+        self.state = root / f"command-goal-{session_id}.json"
+
+    async def request(self, method, params):
+        with (self.root / "command-requests.jsonl").open("a") as file:
+            file.write(json.dumps({"method": method, "params": params}) + "\n")
+        goal = json.loads(self.state.read_text()) if self.state.exists() else None
+        if method == "account/usage/read":
+            return {
+                "threadUsage": {
+                    "groups": [
+                        {"inputTokens": 12, "outputTokens": 3, "totalTokens": 15}
+                    ]
+                }
+            }
+        if method == "_x.ai/session/usage":
+            return {"usage": {"inputTokens": 12, "outputTokens": 3}}
+        if method == "thread/goal/get":
+            return {"goal": goal}
+        if method == "thread/goal/set":
+            goal = {
+                "objective": params.get(
+                    "objective", (goal or {}).get("objective", "Clock")
+                ),
+                "status": params.get("status", "active"),
+            }
+            self.state.write_text(json.dumps(goal))
+            return {"goal": goal}
+        if method == "thread/goal/clear":
+            self.state.unlink(missing_ok=True)
+            return {}
+        if method == "session/prompt":
+            first = params["prompt"][0]["text"]
+            if first.startswith("/vendor-check"):
+                answer = "Vendor command received: " + first
+                self._capture_notification(
+                    {
+                        "method": "session/update",
+                        "params": {
+                            "sessionId": self.session_id,
+                            "update": {
+                                "sessionUpdate": "available_commands_update",
+                                "availableCommands": [],
+                            },
+                        },
+                    }
+                )
+            elif first == "/goal status":
+                answer = "Goal: Clock" if goal else "No goal is set."
+            else:
+                if first.startswith("/goal "):
+                    self.state.write_text(
+                        json.dumps({"objective": first[6:], "status": "active"})
+                    )
+                answer = "Goal work completed."
+                await self.events.put(
+                    {
+                        "method": "session/update",
+                        "params": {
+                            "update": {
+                                "sessionUpdate": "agent_thought_chunk",
+                                "content": {
+                                    "type": "text",
+                                    "text": "Retained thinking from the native peer.",
+                                },
+                            }
+                        },
+                    }
+                )
+            await self.events.put(
+                {
+                    "method": "session/update",
+                    "params": {
+                        "update": {
+                            "sessionUpdate": "agent_message_chunk",
+                            "content": {"type": "text", "text": answer},
+                        }
+                    },
+                }
+            )
+            return {"stopReason": "end_turn"}
+        if method == "turn/start":
+            turn = "native-command-turn"
+            updates = [
+                (
+                    "item/reasoning/summaryTextDelta",
+                    {
+                        "itemId": "thought",
+                        "summaryIndex": 0,
+                        "delta": "Retained thinking from the native peer.",
+                    },
+                ),
+                (
+                    "item/completed",
+                    {
+                        "item": {
+                            "id": "thought",
+                            "type": "reasoning",
+                            "summary": [
+                                {
+                                    "type": "summary_text",
+                                    "text": "Retained thinking from the native peer.",
+                                }
+                            ],
+                        }
+                    },
+                ),
+                (
+                    "item/agentMessage/delta",
+                    {"itemId": "answer", "delta": "Goal work completed."},
+                ),
+                ("turn/completed", {"turn": {"id": turn, "status": "completed"}}),
+            ]
+            for event, payload in updates:
+                await self.events.put(
+                    {
+                        "method": event,
+                        "params": {
+                            "threadId": self.session_id,
+                            "turnId": turn,
+                            **payload,
+                        },
+                    }
+                )
+            return {"turn": {"id": turn}}
+        raise HarnessTransportError(f"Unsupported inert peer method: {method}")
+
+    async def notify(self, method, params=None):
+        pass
+
+    async def close(self):
+        self.connection_state = "disconnected"

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -6178,3 +6178,59 @@ test("stabilization compact Workbench header icons", async ({ page }, testInfo) 
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
   await page.screenshot({path: `/tmp/nebula-compact-header-${testInfo.project.name}.png`});
 });
+for (const vendor of ["grok_acp", "codex_app_server"]) {
+  reloadTest(`stabilization harness commands and thinking ${vendor}`, async ({ page }, info) => {
+    const chat = "chat-command-thinking", session = "session-command-thinking", turn = "turn-command-thinking";
+    const text = "Check the selected session.\n" + "Long retained thinking text. ".repeat(40);
+    await page.route("**/api/v1/**", async route => {
+      const path = new URL(route.request().url()).pathname;
+      const json = (value: unknown) => route.fulfill({ json: value });
+      if (path.endsWith("/harnesses")) return json([{ ...entity, id: "harness-command-thinking", name: "Harness", kind: vendor, connection_mode: "spawn", transport: "stdio", executable: vendor === "grok_acp" ? "grok" : "codex", auth_mode: "existing_session", default_model: "security-model", enabled: true, privacy: { local_only: true, permits_sensitive_data: true }, capabilities: { models: ["security-model"], checked_at: entity.updated_at } }]);
+      if (path.endsWith("/chat-sessions")) return json([{ ...entity, id: chat, engagement_id: "scratch-project", title: "Command thinking", backend: "harness", harness_profile_id: "harness-command-thinking", harness_session_id: session, model: "security-model", metadata: {} }]);
+      if (path.endsWith(`/chat/sessions/${chat}/messages`)) return json([{ ...entity, id: "answer-command-thinking", engagement_id: "scratch-project", session_id: chat, sequence: 1, role: "assistant", content: "Saved response", citations: [], metadata: { harness_turn_id: turn } }]);
+      if (path.endsWith(`/harness-turns/${turn}/events`)) return json({ events: [{ id: "thought", type: "item_upsert", schema_version: "nebula.harness-activity/v2", sequence: 1, vendor, harness_session_id: session, harness_turn_id: turn, item_id: "thinking-1", item_kind: "reasoning", item_status: "completed", title: "Reasoning", payload: { reasoning_summary_state: "available", reasoning_summary_text: text }, artifact_ids: [] }], next_sequence: 1 });
+      if (path.endsWith(`/harness-turns/${turn}/interactions`)) return json([]);
+      if (path.endsWith(`/chat/sessions/${chat}/pending-turn`)) return json(null);
+      if (path.endsWith(`/harness-sessions/${session}/activity`)) return json({ session_id: session, session_status: "idle", busy: false, live: true, turn_id: turn, turn_status: "completed", turn_origin: "chat", detail: "Ready", commands_discovered: vendor === "grok_acp", commands: [{name: "usage", description: "Session usage", hint: "", source: "nebula"}, ...(vendor === "grok_acp" ? [{name: "vendor-check", description: "Check project", hint: "A long target argument hint ".repeat(8), source: "native"}] : [])] });
+      await route.fallback();
+    });
+    await openWorkspace(page, `/?view=chat&session=${chat}`, "Workbench");
+    const thinking = page.getByLabel("Harness thinking");
+    await expect(thinking).toBeVisible();
+    await expect(thinking).not.toHaveAttribute("open", "");
+    await thinking.locator("summary").focus();
+    await page.keyboard.press("Enter");
+    await expect(thinking.getByText(/Check the selected session/)).toBeVisible();
+    const geometry = await thinking.evaluate(element => ({ right: element.getBoundingClientRect().right, width: innerWidth, scroll: element.scrollWidth, client: element.clientWidth, target: element.querySelector("summary")!.getBoundingClientRect().height }));
+    expect(geometry.right).toBeLessThanOrEqual(geometry.width + 1);
+    expect(geometry.scroll).toBeLessThanOrEqual(geometry.client + 1);
+    expect(geometry.target).toBeGreaterThanOrEqual(44);
+    const composer = page.getByRole("textbox", { name: "Message the analyst assistant" });
+    await composer.fill("/");
+    await page.getByRole("button", { name: "/usage Session usage" }).click();
+    await expect(composer).toHaveValue("/usage ");
+    await expect(composer).toBeFocused();
+    await composer.fill("/vendor");
+    if (vendor === "grok_acp") {
+      const command = page.getByRole("button", {name: "/vendor-check Check project"});
+      await expect(command).toBeVisible();
+      const box = await command.boundingBox();
+      expect(box!.height).toBeGreaterThanOrEqual(44);
+      expect(box!.x + box!.width).toBeLessThanOrEqual(page.viewportSize()!.width + 1);
+      await command.focus();
+      await page.keyboard.press("Enter");
+      await expect(composer).toHaveValue("/vendor-check ");
+      await expect(composer).toBeFocused();
+    } else {
+      await expect(page.getByRole("status").filter({hasText: "Command unavailable"})).toBeVisible();
+    }
+    await composer.fill("/");
+    expect((await new AxeBuilder({ page }).include(".harness-command-hints").include(".harness-thinking").analyze()).violations).toEqual([]);
+    await page.screenshot({path: info.outputPath("command-picker.png")});
+
+    await page.reload();
+    await expect(thinking).toBeVisible();
+    await thinking.locator("summary").click();
+    await expect(thinking.getByText(/Check the selected session/)).toBeVisible();
+  });
+}

--- a/ui/tests/real-core.spec.ts
+++ b/ui/tests/real-core.spec.ts
@@ -2985,3 +2985,71 @@ reliabilityTest("assistant upgrade account homes persist and switch without losi
     await info.attach("account-home-screen", {body: await page.screenshot(), contentType: "image/png"});
   } finally {await core.stop();}
 });
+
+reliabilityTest("assistant upgrade native commands retain thinking and replies across Core restart", async ({page}, info) => {
+  test.setTimeout(120_000);
+  const core = await startApprovalCore(localNetworkIpv4(), "commands");
+  try {
+    const profile = await core.api.post("harnesses", {data: {name: "Codex command fixture", kind: "codex_app_server", executable: "/bin/true", default_model: "fixture", enabled: true, privacy: {local_only: true, permits_sensitive_data: true}}});
+    expect(profile.ok(), await profile.text()).toBe(true);
+    const codex = await profile.json();
+    for (const id of ["inert-fixture", codex.id]) expect((await core.api.post(`harnesses/${id}/health`)).ok()).toBe(true);
+    const pairing = await (await core.api.post(`http://127.0.0.1:${core.port}/api/v1/auth/pairings`, {data: {name: "Command acceptance"}})).json();
+    await page.goto(`${core.origin}/?view=chat#pair=${encodeURIComponent(pairing.secret)}&code=${encodeURIComponent(pairing.confirmation_code)}`);
+    await page.getByLabel("Device name").fill("Command acceptance");
+    await page.getByRole("button", {name: "Pair device", exact: true}).click();
+    await expect(page.getByRole("button", {name: /Nebula Core (ready|degraded)/})).toBeVisible({timeout: 20_000});
+    for (const id of ["inert-fixture", codex.id]) {
+      await page.goto(`${core.origin}/?view=chat`);
+      await page.getByRole("button", {name: "New chat", exact: true}).click();
+      await page.getByRole("button", {name: "Assistant settings", exact: true}).click();
+      await page.getByLabel("Chat harness", {exact: true}).selectOption(id);
+      await page.getByRole("button", {name: "Close assistant settings"}).click();
+      const composer = page.getByRole("textbox", {name: "Message the analyst assistant", exact: true});
+      await composer.fill("/goal Clock");
+      await page.getByRole("button", {name: "Send message", exact: true}).click();
+      await expect(page.locator(".chat-message.assistant .assistant-markdown").last()).toContainText("Goal work completed.", {timeout: 20_000});
+      const thinking = page.getByLabel("Harness thinking").first();
+      await expect(thinking).toBeVisible();
+      await thinking.locator("summary").click();
+      await expect(thinking).toContainText("Retained thinking from the native peer.");
+      if (id === "inert-fixture") {
+        await composer.fill("/vendor");
+        await expect(page.getByRole("button", {name: "/vendor-check Check project"})).toBeVisible();
+        await page.screenshot({path: info.outputPath("discovered-command.png")});
+        await page.getByRole("button", {name: "/vendor-check Check project"}).click();
+        await expect(composer).toHaveValue("/vendor-check ");
+        await page.getByRole("button", {name: "Send message", exact: true}).click();
+        await expect(page.locator(".chat-message.assistant .assistant-markdown").last()).toContainText("Vendor command received: /vendor-check", {timeout: 20_000});
+        await composer.fill("/vendor");
+        await expect(page.getByRole("button", {name: "/vendor-check Check project"})).toHaveCount(0, {timeout: 10_000});
+        await page.reload();
+        await expect(page.locator(".chat-message.assistant .assistant-markdown").last()).toContainText("Vendor command received: /vendor-check");
+        await composer.fill("/vendor-check");
+        await page.getByRole("button", {name: "Send message", exact: true}).click();
+        await expect(page.getByText("/vendor-check is not available in this harness session.", {exact: false}).first()).toBeVisible({timeout: 20_000});
+      }
+      await composer.fill("/usage extra");
+      await page.getByRole("button", {name: "Send message", exact: true}).click();
+      await expect(page.getByText("Use /usage without arguments to read this session\'s usage.", {exact: false}).first()).toBeVisible({timeout: 20_000});
+      await composer.fill("/u");
+      await page.getByRole("button", {name: "/usage Session usage"}).click();
+      await page.getByRole("button", {name: "Send message", exact: true}).click();
+      await expect(page.locator(".chat-message.assistant .assistant-markdown").last()).toContainText("Input tokens: 12", {timeout: 20_000});
+      await core.restart();
+      await page.reload();
+      await expect(page.locator(".chat-message.assistant .assistant-markdown").last()).toContainText("Input tokens: 12", {timeout: 20_000});
+      await expect(thinking).toBeVisible();
+      await thinking.locator("summary").click();
+      await expect(thinking).toContainText("Retained thinking from the native peer.");
+      await composer.fill("/goal status");
+      await page.getByRole("button", {name: "Send message", exact: true}).click();
+      await expect(page.locator(".chat-message.assistant .assistant-markdown").last()).toContainText("Goal: Clock", {timeout: 20_000});
+      const entries = (await readFile(path.join(core.dataDir, "command-requests.jsonl"), "utf8")).trim().split("\n").map(line => JSON.parse(line));
+      expect(entries.some(row => row.method === (id === codex.id ? "account/usage/read" : "_x.ai/session/usage"))).toBe(true);
+      await thinking.scrollIntoViewIfNeeded();
+      await info.attach(`native-command-${id}`, {body: await page.screenshot({path: info.outputPath(`native-command-${id}.png`)}), contentType: "image/png"});
+    }
+    await info.attach("native-command-evidence", {body: JSON.stringify({origin: core.origin, project: info.project.name, viewport: page.viewportSize(), peer: "inert native protocol peer; real Core, production adapters, persistence and UI"}), contentType: "application/json"});
+  } finally {await core.stop();}
+});


### PR DESCRIPTION
The chat composer now discovers commands advertised by a Grok ACP session and invokes them through a generic dispatcher. Autocomplete and `/help` share the current catalog, withdrawn or unknown commands fail explicitly, and commands are queued instead of being sent as live steering. Codex retains explicit goal and usage RPC mappings.

The change also exposes displayable harness thinking consistently during streaming and after reload, normalizes current goal states, preserves Core context for goal continuations, and keeps cumulative usage queries out of turn billing.

Validation recorded in `docs/design/harness-commands-thoughts.md`: 34 focused Python tests, 27 frontend tests, 16 mocked production-browser cases, and 8 real-Core cases passed on LAN across desktop Chromium and emulated mobile Chromium/WebKit. Live Grok advertised 52 commands and `/session-info` returned a native response. The diff-bound CI selection repeats only these focused journeys.

Limitations: real-Core tests use inert protocol peers; live model-driven goal execution, physical phones/software keyboards, and installed-app deployment remain unverified. This does not provide Codex terminal-command parity.

After rebasing onto current `main`, local production build, all 34 selected Python tests, and type-checking passed. GitHub CI and the complete selected production-browser matrix passed on commit `892db9702c022fe7996902abf7e0ec47fd63a53a`. The uploaded test-selection and Playwright impact receipts were reviewed and match the committed scope; no full suite ran.

[CI results and selection receipt](https://github.com/berylliumsec/nebula/actions/runs/34689979311) · [Focused browser results and impact receipt](https://github.com/berylliumsec/nebula/actions/runs/34689979297)
