### PR TITLE
Expose Workbench actions directly in the top bar

### DIFF
--- a/.github/test-selection.json
+++ b/.github/test-selection.json
@@ -1,40 +1,25 @@
 {
-  "reviewed_by": "Codex assistant reliability review",
-  "reason": "Focused adapter transport/auth/startup coverage, durable next-turn runtime settings and history, validated workspace retrieval errors, independent settings catalogs and opt-in assistant failure details. One real-Core production LAN journey across eight permanent desktop/mobile profiles validates settings, persistence, disclosure and catalog recovery.",
-  "exclusions": "No full suite authorized. Unrelated missions, security browser, releases, native shell and other UI journeys excluded. Shared harness/chat files reviewed: adapter contract tests and exact runtime/history regressions cover touched paths. No native code changes. Real vendor authentication and physical devices are unavailable; vendor protocols use inert fixtures and mobile browsers are emulated.",
-  "baseline": "8491ca4702e3a46384ccd3b489bfe7f8718a5a39",
-  "python_versions": [
-    "3.12"
-  ],
+  "baseline": "6f341bc45ad15ec5cef8a8f074b3c833283204ad",
+  "change_digest": "4873f0e69eb1544881ebe3acb102e2c9e0dad7408ad8a890f6b3075d6889efc5",
+  "reviewed_by": "Codex toolbar review",
+  "reason": "Direct Workbench toolbar discovery, details toggle and focus entry/exit. Selected component files and four browser cases cover toolbar presentation; existing transcript stability failure is documented.",
+  "exclusions": "No backend or native changes. Unrelated browser work remains uncommitted. No full suite. No origin-sensitive behavior changed; physical devices and full mobile boundary coverage unavailable.",
   "expected_tests": {
-    "python": 61,
-    "frontend": 14,
+    "python": 0,
+    "frontend": 38,
     "native": 0,
-    "playwright": 8
+    "playwright": 4
   },
-  "python": [
-    "tests/v3/test_harness_adapters.py",
-    "tests/v3/test_harnesses.py::test_harness_model_controls_are_validated_and_frozen_per_session",
-    "tests/v3/test_harnesses.py::test_workspace_retrieval_reports_actionable_argument_errors",
-    "tests/v3/test_harnesses.py::test_assistant_settings_keep_chat_history_and_replace_frozen_runtime",
-    "tests/v3/test_chat.py::test_provider_settings_change_preserves_chat_and_history"
-  ],
+  "python": [],
   "frontend": [
-    "ui/src/components/HarnessSettings.test.tsx",
-    "ui/src/components/ActivityLedger.test.tsx"
+    "ui/src/App.test.tsx",
+    "ui/src/components/PostToolAssistant.test.tsx"
   ],
   "native": [],
   "playwright": [
-    "entry:assistant-reliability/assistant-real-desktop",
-    "entry:assistant-reliability/assistant-real-compact",
-    "entry:assistant-reliability/assistant-real-chromium-320",
-    "entry:assistant-reliability/assistant-real-webkit-320",
-    "entry:assistant-reliability/assistant-real-chromium-390",
-    "entry:assistant-reliability/assistant-real-webkit-390",
-    "entry:assistant-reliability/assistant-real-chromium-430",
-    "entry:assistant-reliability/assistant-real-webkit-430"
-  ],
-  "change_digest": "829bae289cb54c6c37e7da094d27c21013e382671c45d2e1640a8ef6b1c376f6",
-  "python_browser": false,
-  "python_node": false
+    "entry:toolbar-actions/desktop",
+    "entry:toolbar-actions/compact",
+    "entry:toolbar-actions/mobile-chromium",
+    "entry:toolbar-actions/mobile-webkit"
+  ]
 }

--- a/.github/test-selection.json
+++ b/.github/test-selection.json
@@ -1,8 +1,8 @@
 {
   "baseline": "c5fd66d2d42c5f33d1776eb5706073791a9a627e",
-  "change_digest": "7248df98abac20562d4d77cdc31b40f0db4ed9c34330298a392f7c7587fc86f5",
+  "change_digest": "bf3090a0ec765b80e4906cfc53d53d1afca27c3a626bcdfcd47fe9cf7c2361f4",
   "reviewed_by": "Codex toolbar review",
-  "reason": "Direct Workbench toolbar discovery, details toggle and focus entry/exit. Selected component files and four browser cases cover toolbar presentation; existing transcript stability failure is documented. Integrated current main header placement; additionally selected its eight compact-header cases to prove icon order, navigation and layout at 320/390/430 widths.",
+  "reason": "Direct Workbench toolbar discovery, details toggle and focus entry/exit. Selected component files and four browser cases cover toolbar presentation; the existing transcript stability regression is included. Integrated current main header placement; additionally selected its eight compact-header cases to prove icon order, navigation and layout at 320/390/430 widths. Stabilize view and terminal-handoff callbacks to resolve the existing transcript DOM-stability failure exposed by the selected App tests; the same selected component file proves unchanged transcript nodes and preserved draft behavior.",
   "exclusions": "No backend or native changes. Unrelated browser work remains uncommitted. No full suite. No origin-sensitive behavior changed; physical devices and manual screen-reader checks unavailable.",
   "expected_tests": {
     "python": 0,

--- a/docs/design/top-bar-actions.md
+++ b/docs/design/top-bar-actions.md
@@ -33,3 +33,11 @@ journey (4 profiles) and existing compact-header journey (8 profiles, including
 Component rerun: 37 passed, one existing transcript DOM-stability failure.
 Artifacts: /tmp/toolbar-integrated-{build,unit,browser,header}.log.
 Physical-device and manual screen-reader checks remain unavailable.
+
+CI prerequisite: keep view-navigation and terminal-handoff callbacks stable while typing. React remains the presentation authority and the URL remains navigation authority. The existing draft/transcript DOM-stability test must pass without weakening its assertions; saved content and draft persistence stay unchanged.
+
+Final verification after callback fix: 38/38 selected component tests passed,
+production build passed, and all 12 production-browser cases passed again.
+Logs: /tmp/toolbar-final-{unit,build,browser,header}.log.
+CI's initial frontend failure matched the baseline transcript assertion; its
+existing assertion now passes without modification. No tests were removed.

--- a/docs/design/top-bar-actions.md
+++ b/docs/design/top-bar-actions.md
@@ -1,0 +1,25 @@
+# Top bar actions
+Journey: open Workbench, discover assistance/details/focus directly, toggle and restore.
+Invariants: no desktop overflow step; consistently spaced 44px icons, named and
+tooltip-labelled; existing mobile navigation stays reachable.
+Authority: React owns focus and popovers; the URL drawer parameter owns inspector visibility (the existing localStorage write is retained).
+Discovery/use/refresh are applicable. Create, streaming, reconnect, retry and
+delete are unchanged: no server-owned state or API changes.
+Layers: existing App and PostToolAssistant component coverage, focused toolbar
+browser journeys and production build. No origin-sensitive changes.
+
+Verification: production build passed. Production preview at
+http://127.0.0.1:15473 passed the direct-toolbar journey in desktop Chromium
+1440x900 and 1024x700, emulated Pixel 5 Chromium, and emulated iPhone 13 WebKit.
+Details open/close, named 44px icons, keyboard focus entry on desktop, touch-profile
+focus entry/exit, and document overflow were exercised. Mobile retains More views.
+Component selection: 36/38 initially passed; focus test passed after awaiting
+mount; remaining transcript DOM-stability failure also reproduces on unchanged HEAD.
+Logs: /tmp/toolbar-unit.log, /tmp/toolbar-unit-retry.log,
+/tmp/toolbar-baseline.log, /tmp/toolbar-browser.log,
+/tmp/toolbar-browser-retry.log, /tmp/toolbar-build.log.
+Limitations: no physical device, full 320–430px boundary matrix, manual visual/AT
+review or live deployment check. Partially verified; no backend or origin-sensitive
+behavior was changed. No CI upload was made; local selection receipt reviewed.
+Product rule: expose frequent secondary actions directly when toolbar space allows,
+with consistent icon geometry rather than an unnecessary overflow step.

--- a/ui/playwright-impact.json
+++ b/ui/playwright-impact.json
@@ -19,6 +19,7 @@
     {"name": "remaining-core", "fallback": true, "patterns": ["src/nebula/v3/**"], "areas": ["core-api"]}
   ],
   "areas": {
+    "toolbar-actions": [{"area": "toolbar-actions", "project": "desktop", "test_match": "tests/interface.spec.ts", "grep": "shared actions keep sleek geometry for direct Workbench toolbar icons", "runtime": "mock", "shard": "1/1"}, {"area": "toolbar-actions", "project": "compact", "test_match": "tests/interface.spec.ts", "grep": "shared actions keep sleek geometry for direct Workbench toolbar icons", "runtime": "mock", "shard": "1/1"}, {"area": "toolbar-actions", "project": "mobile-chromium", "test_match": "tests/interface.spec.ts", "grep": "shared actions keep sleek geometry for direct Workbench toolbar icons", "runtime": "mock", "shard": "1/1"}, {"area": "toolbar-actions", "project": "mobile-webkit", "test_match": "tests/interface.spec.ts", "grep": "shared actions keep sleek geometry for direct Workbench toolbar icons", "runtime": "mock", "shard": "1/1"}],
     "assistant-reliability": [
   {
     "area": "assistant-reliability",

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -91,15 +91,15 @@ describe("Nebula workspace", () => {
   it("opens the Workbench full screen and exits with Escape", async () => {
     const user = userEvent.setup();
     renderApp();
-    await user.click(await screen.findByRole("button", { name: "More Workbench actions" }));
+    expect(screen.queryByRole("button", { name: "More Workbench actions" })).not.toBeInTheDocument();
+    await user.click(await screen.findByRole("button", { name: "Enter focus mode" }));
     const workbench = document.querySelector(".sessions-page");
-    await user.click(screen.getByRole("menuitem", { name: /Enter focus mode/ }));
     expect(workbench).toHaveClass("full-screen");
     expect(screen.getByRole("button", { name: "Exit full screen workbench" })).toBeVisible();
 
     await user.keyboard("{Escape}");
     expect(workbench).not.toHaveClass("full-screen");
-    expect(screen.getByRole("button", { name: "More Workbench actions" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Enter focus mode" })).toBeVisible();
   });
 
   it("defaults to Zero Dark and preserves all four supported preferences", () => {
@@ -345,8 +345,7 @@ describe("Nebula workspace", () => {
     expect(screen.queryByRole("textbox", { name: "Message the analyst assistant" })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Conversations")).not.toBeInTheDocument();
     expect(screen.queryByRole("complementary", { name: "Session inspector" })).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "More Workbench actions" }));
-    expect(screen.getByRole("menuitem", { name: /Show session details/ })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Show session details" })).toBeVisible();
     await user.keyboard("{Escape}");
     expect(fetchMock.mock.calls.some(([input, init]) => new URL(String(input)).pathname.endsWith("/chat/completions") && init?.method === "POST")).toBe(false);
 

--- a/ui/src/components-workbench.css
+++ b/ui/src/components-workbench.css
@@ -519,6 +519,10 @@ kbd { font-size: 11px; }
   .sessions-page.screen-fit .workspace-entry-list { min-height: 0; }
 }
 .session-toolbar-actions { display: flex; flex: 0 0 auto; align-items: center; gap: 4px; }
+.session-toolbar { column-gap: 8px; }
+.session-toolbar-actions > .icon-button,
+.session-toolbar-actions .post-tool-menu > .icon-button { width: 44px; height: 44px; min-height: 44px; padding: 0; flex: 0 0 44px; }
+
 .workbench-full-screen-toggle { color: var(--muted-strong); }
 .post-tool-toggles { display: flex; align-items: center; gap: 3px; color: var(--muted); font-size: 11px; white-space: nowrap; }
 .post-tool-toggles label { display: inline-flex; min-height: 30px; align-items: center; gap: 6px; padding: 4px 7px; border: 1px solid transparent; border-radius: 8px; cursor: pointer; transition: color .16s ease, border-color .16s ease, background .16s ease; }

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -466,7 +466,6 @@ export function SessionsPage() {
   const [conversationPanelOpen, setConversationPanelOpen] = useState(
     () => readConversationPanelOpen(localStorage),
   );
-  const [workbenchActionsOpen, setWorkbenchActionsOpen] = useState(false);
   const drawerTab = searchParams.get("drawer") === "results" ? "results" : "context";
   const sessionInspectorOpen = ["context", "results"].includes(searchParams.get("drawer") ?? "");
   const setSessionInspectorOpen = (value: boolean | ((open: boolean) => boolean)) => {
@@ -498,8 +497,6 @@ export function SessionsPage() {
   const [executionCapabilities, setExecutionCapabilities] = useState<ExecutionCapabilities>();
   const [browserScope, setBrowserScope] = useState<EngagementScopePolicy>();
   const [browserScopeLoading, setBrowserScopeLoading] = useState(false);
-  const workbenchActionsButtonRef = useRef<HTMLButtonElement>(null);
-  const workbenchActionsMenuRef = useRef<HTMLDivElement>(null);
   const conversationMenuRef = useRef<HTMLDetailsElement>(null);
   const [runCandidate, setRunCandidate] = useState<FencedRunCandidate>();
   const [terminalCommandRequest, setTerminalCommandRequest] = useState<{ id: string; source: string }>();
@@ -2928,27 +2925,6 @@ export function SessionsPage() {
       document.removeEventListener("keydown", closeOnEscape);
     };
   }, [assistantSettingsOpen]);
-  useEffect(() => {
-    if (!workbenchActionsOpen) return;
-    const closeActions = (event: PointerEvent | globalThis.KeyboardEvent) => {
-      if (event instanceof KeyboardEvent && event.key !== "Escape") return;
-      if (event instanceof PointerEvent) {
-        const target = event.target as Node;
-        if (workbenchActionsMenuRef.current?.contains(target) || workbenchActionsButtonRef.current?.contains(target)) return;
-      }
-      setWorkbenchActionsOpen(false);
-      if (event instanceof KeyboardEvent) {
-        event.preventDefault();
-        requestAnimationFrame(() => workbenchActionsButtonRef.current?.focus());
-      }
-    };
-    document.addEventListener("pointerdown", closeActions);
-    document.addEventListener("keydown", closeActions);
-    return () => {
-      document.removeEventListener("pointerdown", closeActions);
-      document.removeEventListener("keydown", closeActions);
-    };
-  }, [workbenchActionsOpen]);
   const composerBusy = sending || Boolean(authoritativeState?.busy) || pendingResponseActive;
   const canSend = Boolean(api && coreState === "online" && engagement && runtimeReady && model.trim() && (draft.trim() || pendingImages.length) && !composerBusy && !uploadingImage);
   const canSteerCurrentHarness = Boolean(
@@ -3252,32 +3228,31 @@ export function SessionsPage() {
         ] as const} />
         <div className="session-toolbar-actions">
           {view === "chat" && <button
-            className="button quiet session-conversations-toggle"
+            className="icon-button subtle session-conversations-toggle"
             type="button"
             aria-label={conversationPanelOpen ? "Hide conversations" : "Show conversations"}
+            title={conversationPanelOpen ? "Hide conversations" : "Show conversations"}
             aria-expanded={conversationPanelOpen}
             aria-controls="workbench-conversations"
             onClick={toggleConversationPanel}
           >
-            <MessageSquare size={15} aria-hidden="true" /> Conversations{sessions.length ? <span>{sessions.length}</span> : null}
+            <MessageSquare size={16} aria-hidden="true" />
           </button>}
-          {fullScreen && <button className="icon-button subtle workbench-full-screen-toggle" type="button" aria-label="Exit full screen workbench" title="Exit focus mode" onClick={() => setFullScreen(false)}><Minimize2 size={17} aria-hidden="true" /></button>}
-          <div className="workbench-actions">
-            <button ref={workbenchActionsButtonRef} className="icon-button subtle" type="button" aria-label="More Workbench actions" aria-haspopup="menu" aria-expanded={workbenchActionsOpen} aria-controls={workbenchActionsOpen ? "workbench-actions-menu" : undefined} onClick={() => setWorkbenchActionsOpen((open) => !open)}><MoreHorizontal size={18} aria-hidden="true" /></button>
-            {workbenchActionsOpen && <div ref={workbenchActionsMenuRef} className="workbench-actions-menu" id="workbench-actions-menu" role="menu" aria-label="Workbench actions">
-              {api && engagement && <PostToolAssistant api={api} engagementId={engagement.id} providers={providers} harnesses={harnesses} onRun={setRunCandidate} triggerVariant="menu" />}
-              {view === "chat" && <button className="workbench-menu-item" type="button" role="menuitem" onClick={() => {
-                setSessionInspectorOpen((open) => {
-                  localStorage.setItem("nebula.session-inspector.open", String(!open));
-                  return !open;
-                });
-                setWorkbenchActionsOpen(false);
-              }}><PanelRight size={16} aria-hidden="true" /><span><strong>{sessionInspectorOpen ? "Hide session details" : "Show session details"}</strong><small>Runtime, knowledge, and execution boundaries</small></span></button>}
-              <button className="workbench-menu-item" type="button" role="menuitem" onClick={() => { setFullScreen((value) => !value); setWorkbenchActionsOpen(false); }}>
-                {fullScreen ? <Minimize2 size={16} aria-hidden="true" /> : <Maximize2 size={16} aria-hidden="true" />}<span><strong>{fullScreen ? "Exit focus mode" : "Enter focus mode"}</strong><small>{fullScreen ? "Restore the application shell" : "Use the full viewport for this tool"}</small></span>
-              </button>
-            </div>}
-          </div>
+          {api && engagement && <PostToolAssistant api={api} engagementId={engagement.id} providers={providers} harnesses={harnesses} onRun={setRunCandidate} />}
+          {view === "chat" && <button className="icon-button subtle" type="button"
+            aria-label={sessionInspectorOpen ? "Hide session details" : "Show session details"}
+            title={sessionInspectorOpen ? "Hide session details" : "Show session details"}
+            aria-expanded={sessionInspectorOpen}
+            onClick={() => setSessionInspectorOpen((open) => {
+              localStorage.setItem("nebula.session-inspector.open", String(!open));
+              return !open;
+            })}><PanelRight size={16} aria-hidden="true" /></button>}
+          <button className="icon-button subtle workbench-full-screen-toggle" type="button"
+            aria-label={fullScreen ? "Exit full screen workbench" : "Enter focus mode"}
+            title={fullScreen ? "Exit focus mode" : "Enter focus mode"}
+            aria-pressed={fullScreen} onClick={() => setFullScreen((value) => !value)}>
+            {fullScreen ? <Minimize2 size={16} aria-hidden="true" /> : <Maximize2 size={16} aria-hidden="true" />}
+          </button>
         </div>
       </Toolbar>
 

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -19,7 +19,7 @@ import { ChatRecordedContext } from "../components/ChatRecordedContext";
 import { useChatNavigation } from "./useChatNavigation";
 import { ChatSearchPanel } from "../components/ChatSearchPanel";
 import { AssistantApprovalDetails } from "../components/AssistantApprovalDetails";
-import { lazy, Suspense, useEffect, useLayoutEffect, useMemo, useRef, useState, type ChangeEvent, type ClipboardEvent as ReactClipboardEvent, type CSSProperties, type DragEvent as ReactDragEvent, type FormEvent, type KeyboardEvent } from "react";
+import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ChangeEvent, type ClipboardEvent as ReactClipboardEvent, type CSSProperties, type DragEvent as ReactDragEvent, type FormEvent, type KeyboardEvent } from "react";
 import {useComposerAutosize} from "./useComposerAutosize";
 import { createPortal } from "react-dom";
 import {
@@ -428,12 +428,12 @@ export function SessionsPage() {
       : requestedView === "files" ? "workspace"
         : "terminal";
   const [view, setViewState] = useState<SessionView>(initialView === "chat" || initialView === "code" || initialView === "browser" || initialView === "missions" || initialView === "activity" || initialView === "workspace" || initialView === "notes" ? initialView : "terminal");
-  const setView = (next: SessionView) => {
+  const setView = useCallback((next: SessionView) => {
     setViewState(next);
     const params = new URLSearchParams(currentSearchParams.current);
     params.set("view", next);
     setSearchParams(params, { replace: true });
-  };
+  }, [setSearchParams]);
   const openUnattachedChatView = () => {
     const nextView = view === "browser" ? "browser" : "chat";
     setViewState(nextView);
@@ -3016,11 +3016,11 @@ export function SessionsPage() {
   const [browserControlsOpen, setBrowserControlsOpen] = useState(true);
   const [browserControlEnabled, setBrowserControlEnabled] = useState(false);
   const [browserActionContainer, setBrowserActionContainer] = useState<HTMLDivElement | null>(null);
-  const runInTerminal = (candidate: FencedRunCandidate) => {
+  const runInTerminal = useCallback((candidate: FencedRunCandidate) => {
     setTerminalCommandRequest({ id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`, source: candidate.source });
     setTerminalAssistantOpen(true);
     setView("terminal");
-  };
+  }, [setView]);
   const collapseBrowserAssistant = () => {
     setBrowserAssistantOpen(false);
     requestAnimationFrame(() => document.querySelector<HTMLButtonElement>('button[aria-controls="browser-assistant-panel"]')?.focus({ preventScroll: true }));

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -3017,8 +3017,7 @@ test("an idle resumed harness keeps routine telemetry quiet", async ({ page }, t
   await expect(page.locator(".chat-composer footer")).not.toContainText("0 MCP");
   await expect(page.locator(".harness-status-rail")).toHaveCount(0);
   await expect(page.locator(".chat-harness-progress")).toHaveCount(0);
-  await page.getByRole("button", { name: "More Workbench actions" }).click();
-  await page.getByRole("menuitem", { name: /Show session details/ }).click();
+  await page.getByRole("button", { name: "Show session details" }).click();
   await expect(page.locator(".session-inspector code").filter({ hasText: harnessSessionId })).toHaveText(harnessSessionId);
 
   await page.getByRole("button", { name: "New chat", exact: true }).click();
@@ -4206,8 +4205,7 @@ test("the workbench expands to the full viewport with compact chrome and complet
     await page.getByRole("button", { name: "More workbench views" }).click();
     await page.getByRole("dialog", { name: "More views" }).getByRole("button", { name: "Enter focus mode" }).click();
   } else {
-    await page.getByRole("button", { name: "More Workbench actions" }).click();
-    await page.getByRole("menuitem", { name: /Enter focus mode/ }).click();
+    await page.getByRole("button", { name: "Enter focus mode" }).click();
   }
   const workbench = page.locator(".sessions-page.full-screen");
   await expect(workbench).toBeVisible();
@@ -4268,7 +4266,7 @@ test("the workbench expands to the full viewport with compact chrome and complet
 
   await page.keyboard.press("Escape");
   if (mobile) await expect(page.getByRole("button", { name: "More workbench views" })).toBeVisible();
-  else await expect(page.getByRole("button", { name: "More Workbench actions" })).toBeVisible();
+  else await expect(page.getByRole("button", { name: "Enter focus mode" })).toBeVisible();
   await expect(page.locator(".sessions-page")).not.toHaveClass(/full-screen/);
 });
 
@@ -5161,8 +5159,7 @@ test("tool follow-up runtime lives in Settings and its Workbench toggles persist
 
   await openWorkspace(page, "/", "Workbench");
   await expect(page.getByRole("combobox", { name: "Post-tool analysis backend" })).toHaveCount(0);
-  await page.getByRole("button", { name: "More Workbench actions" }).click();
-  await page.getByRole("menuitem", { name: "Tool assistance" }).click();
+  await page.getByRole("button", { name: "Tool assistance" }).click();
   const suggestions = page.getByRole("checkbox", { name: "Suggest next steps" });
   await suggestions.click();
   await expect(suggestions).toBeChecked();
@@ -5208,8 +5205,7 @@ test("tool follow-up toggles explain missing runtime setup", async ({ page }, te
   });
 
   await openWorkspace(page, "/", "Workbench");
-  await page.getByRole("button", { name: "More Workbench actions" }).click();
-  await page.getByRole("menuitem", { name: "Tool assistance" }).click();
+  await page.getByRole("button", { name: "Tool assistance" }).click();
   const notes = page.getByRole("checkbox", { name: "Take notes" });
   await notes.click();
 
@@ -5462,8 +5458,7 @@ test("Assistant session details use reloadable drawer navigation", async ({ page
     await page.getByRole("button", { name: "More workbench views" }).click();
     await page.getByRole("dialog", { name: "More views" }).getByRole("button", { name: "Show session details" }).click();
   } else {
-    await page.getByRole("button", { name: "More Workbench actions" }).click();
-    await page.getByRole("menuitem", { name: /Show session details/ }).click();
+    await page.getByRole("button", { name: "Show session details" }).click();
   }
   const drawer = (page.viewportSize()?.width ?? 1440) <= 1100
     ? page.getByRole("dialog", {name: "Conversation details"})
@@ -6137,3 +6132,38 @@ for (const scenario of ["stale catalog", "request failure", "reconnected approva
     await expect(page.getByRole("button", { name: "Review pending actions", exact: true })).toHaveCount(0);
   });
 }
+
+test("shared actions keep sleek geometry for direct Workbench toolbar icons", async ({ page }) => {
+  await openWorkspace(page, "/?view=chat", "Workbench");
+  const mobile = (page.viewportSize()?.width ?? 1440) <= 760;
+  await expect(page.getByRole("button", { name: "More Workbench actions" })).toHaveCount(0);
+  if (mobile) {
+    await page.getByRole("button", { name: "More workbench views" }).click();
+    await page.getByRole("dialog", { name: "More views" }).getByRole("button", { name: "Enter focus mode" }).click();
+  } else {
+    const bar = page.locator(".session-toolbar-actions");
+    for (const name of ["Tool assistance", "Show session details", "Enter focus mode"]) {
+      const button = bar.getByRole("button", { name, exact: true });
+      await expect(button).toBeVisible();
+      await expect(button).toHaveAttribute("title", name);
+      const rect = await button.boundingBox();
+      expect(rect!.width).toBeGreaterThanOrEqual(44);
+      expect(rect!.height).toBeGreaterThanOrEqual(44);
+    }
+    await bar.getByRole("button", { name: "Show session details" }).click();
+    await expect(bar.getByRole("button", { name: "Hide session details" })).toHaveAttribute("aria-expanded", "true");
+    if ((page.viewportSize()?.width ?? 1440) <= 1100) await page.keyboard.press("Escape");
+    else await bar.getByRole("button", { name: "Hide session details" }).click();
+    if ((page.viewportSize()?.width ?? 1440) <= 1100) {
+      await expect(page.getByRole("dialog")).toHaveCount(0);
+      await bar.getByRole("button", { name: "Enter focus mode" }).click();
+    } else {
+      await bar.getByRole("button", { name: "Enter focus mode" }).focus();
+      await page.keyboard.press("Enter");
+    }
+  }
+  await expect(page.locator(".sessions-page")).toHaveClass(/full-screen/);
+  await page.getByRole("button", { name: "Exit full screen workbench" }).click();
+  await expect(page.locator(".sessions-page")).not.toHaveClass(/full-screen/);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+});


### PR DESCRIPTION
Workbench hid assistance, session details, and focus behind an overflow menu despite available header space. Expose these as named, tooltip-labelled icons beside conversations and New chat, with consistent 44 px targets and spacing. Preserve the current compact shell header and mobile navigation.

Validation: production build and 12 focused browser cases passed (desktop 1440/1024 plus emulated mobile Chromium/WebKit at 320–430 px). Component selection: 37 passed; the remaining transcript DOM-stability assertion also fails on the unchanged baseline. No full suite was run. Physical-device and manual screen-reader checks remain unverified.

Includes a diff-bound focused CI selection. Pre-existing browser edits are excluded.
