### PR TITLE
Fix Grok goal continuation

### DIFF
--- a/.github/test-selection.json
+++ b/.github/test-selection.json
@@ -1,25 +1,20 @@
 {
-  "baseline": "d1c7737727652f03d23c7450160f7bb1044c8705",
-  "change_digest": "b06c5fd8023d26eb109c05a441f9215dd08a2d407eaa3bec644e12bea4759e60",
-  "reviewed_by": "Codex conversation-switch performance review",
-  "reason": "Focused coverage proves unchanged session-state polling avoids SQLite write locks, revisions still advance safely, conversation selection performs one authoritative state read, and durable transcripts, URL identity, prefetched activity, responsive interaction, and real-Core relaunch persistence remain intact.",
-  "exclusions": "No full suites. Python is limited to the session projection contract plus the catalog exposure check. Frontend is limited to session-state ownership. Playwright is limited to the conversation-switch journey across permanent desktop/mobile Chromium/WebKit profiles and one real-Core desktop persistence journey. Unrelated provider generation, missions, browser automation, terminal, project mutation, and native shell tests are excluded. The real-Core journey uses a non-loopback LAN origin; physical devices are unavailable, and the responsive browser checks use permanent emulated profiles.",
-  "expected_tests": {"python": 15, "frontend": 5, "native": 0, "playwright": 9},
+  "baseline": "72d1e13ef5e9923e1125eeb8f6b8d32438161d3f",
+  "change_digest": "00a1c1f0fd7f46f3d9d5b4d6b0130a81639debd40d29a72687af325cd77fa691",
+  "reviewed_by": "Codex cross-harness goal-continuation implementation",
+  "reason": "Focused adapter coverage proves that Grok active-goal events cause same-session continuation, terminal and attention states stop continuation, intermediate ACP turn completion is not surfaced as durable goal completion, and native goal notifications remain normalized. Codex coverage proves set/resume dispatch starts execution through its native thread goal API. Both verified harness probes advertise goal monitoring.",
+  "exclusions": "No full suites. Python is limited to fifteen collected Codex and Grok goal-command and capability-probe cases. No frontend source changed, so component tests are excluded. No native source changed. Browser and real-Core Playwright are excluded from this local selection because no committed live-Grok goal fixture exists; live authenticated Grok, production bundle, LAN-origin, mobile-browser, reconnect, and physical-device evidence remain required before the operator workflow is called complete. Unrelated Claude, provider, mission, browser automation, terminal, project mutation, and packaging tests are excluded.",
+  "expected_tests": {"python": 15, "frontend": 0, "native": 0, "playwright": 0},
   "python": [
-    "tests/v3/test_session_state.py",
-    "tests/test_playwright_impact.py::test_catalog_exposes_stable_choices_for_agents_and_humans"
+    "tests/v3/test_harness_commands.py::test_grok_goal_continues_vendor_turns_until_goal_is_complete",
+    "tests/v3/test_harness_commands.py::test_grok_goal_does_not_continue_terminal_or_attention_states",
+    "tests/v3/test_harness_commands.py::test_grok_goal_prefix_precedes_but_preserves_core_context",
+    "tests/v3/test_harness_commands.py::test_grok_native_goal_notifications_are_not_lost",
+    "tests/v3/test_harness_commands.py::test_codex_goal_dispatch_and_continuation",
+    "tests/v3/test_harness_adapters.py::test_codex_probe_discovers_selectable_models",
+    "tests/v3/test_harness_adapters.py::test_grok_probe_negotiates_cached_token_without_credentials"
   ],
-  "frontend": ["ui/src/pages/useSessionState.test.tsx"],
+  "frontend": [],
   "native": [],
-  "playwright": [
-    "entry:conversation-switch-performance/desktop",
-    "entry:conversation-switch-performance/compact",
-    "entry:conversation-switch-performance/mobile-chromium-small",
-    "entry:conversation-switch-performance/mobile-chromium-ledger-390",
-    "entry:conversation-switch-performance/mobile-chromium-wide",
-    "entry:conversation-switch-performance/mobile-webkit-small",
-    "entry:conversation-switch-performance/mobile-webkit",
-    "entry:conversation-switch-performance/mobile-webkit-wide",
-    "entry:conversation-switch-performance/assistant-real-desktop"
-  ]
+  "playwright": []
 }

--- a/.github/test-selection.json
+++ b/.github/test-selection.json
@@ -1,6 +1,6 @@
 {
   "baseline": "72d1e13ef5e9923e1125eeb8f6b8d32438161d3f",
-  "change_digest": "00a1c1f0fd7f46f3d9d5b4d6b0130a81639debd40d29a72687af325cd77fa691",
+  "change_digest": "7fe971b22fa28aab29610256f6ffe6d39a31bedf5a0cded8e770c88cbc2e6de4",
   "reviewed_by": "Codex cross-harness goal-continuation implementation",
   "reason": "Focused adapter coverage proves that Grok active-goal events cause same-session continuation, terminal and attention states stop continuation, intermediate ACP turn completion is not surfaced as durable goal completion, and native goal notifications remain normalized. Codex coverage proves set/resume dispatch starts execution through its native thread goal API. Both verified harness probes advertise goal monitoring.",
   "exclusions": "No full suites. Python is limited to fifteen collected Codex and Grok goal-command and capability-probe cases. No frontend source changed, so component tests are excluded. No native source changed. Browser and real-Core Playwright are excluded from this local selection because no committed live-Grok goal fixture exists; live authenticated Grok, production bundle, LAN-origin, mobile-browser, reconnect, and physical-device evidence remain required before the operator workflow is called complete. Unrelated Claude, provider, mission, browser automation, terminal, project mutation, and packaging tests are excluded.",

--- a/docs/design/grok-goal-continuation.md
+++ b/docs/design/grok-goal-continuation.md
@@ -1,0 +1,39 @@
+# Grok goal continuation contract
+
+## Operator journey
+
+Entry point: select a healthy Grok ACP harness in Sessions, enter
+`/goal <objective>`, and observe the goal continue without repeatedly asking the
+operator to submit the next turn.
+
+Core owns the durable harness turn and connection lifecycle. The Grok session
+owns the goal objective and status. The UI renders persisted Core activity and
+does not infer completion from assistant prose or an ACP `end_turn` response.
+
+## Observable invariants
+
+- A Grok goal whose latest validated status is `running` starts another vendor
+  turn in the same session after ACP ends the current vendor turn.
+- Assistant text such as a list of next steps does not complete an active goal.
+- `complete`, `paused`, `usage_limited`, `budget_limited`, and failure states stop
+  automatic continuation.
+- A turn without a validated Grok goal update is not treated as a monitored goal.
+- Approvals remain visible and block the active continuation until decided.
+- Interrupting the durable Nebula turn cancels the active Grok turn and prevents
+  another continuation.
+- Activity from every continuation is persisted under the same Nebula turn, so
+  detach, reconnect, and refresh recover one authoritative workflow.
+
+## Lifecycle and test layers
+
+Discover/select are unchanged. Create and use occur through `/goal <objective>`.
+Streaming, approval, interruption, background ownership, reconnect, and refresh
+continue through the existing durable harness-turn path. Pause, usage limits,
+budget limits, completion, and failures are terminal for automatic continuation;
+`/goal resume` is the explicit recovery action for a paused goal. Clearing and
+deleting a goal remain vendor commands.
+
+The adapter regression layer covers repeated vendor turns and every stopping
+state. Existing selected real-Core session coverage owns persistence and
+reconnection; the production browser matrix is required before the workflow is
+claimed complete.

--- a/docs/harness-capability-matrix.json
+++ b/docs/harness-capability-matrix.json
@@ -21,7 +21,7 @@
         "streaming": true, "replay": true, "steering": false, "interruption": true,
         "interrupt_then_submit": true,
         "resumable_sessions": true, "approvals": true, "structured_user_input": false,
-        "planning_mode": true, "goal_monitoring": false, "skill_invocation": false,
+        "planning_mode": true, "goal_monitoring": true, "skill_invocation": true,
         "modes": ["default", "plan"], "reasoning_summaries": true,
         "tools": true, "live_output": true, "diffs": true, "checkpoints": false,
         "subagents": true, "hooks": false, "images": true, "citations_artifacts": true,

--- a/src/nebula/v3/harnesses.py
+++ b/src/nebula/v3/harnesses.py
@@ -4051,10 +4051,28 @@ async def _run_harness_command(
     grok = isinstance(connection, GrokAcpConnection)
     vendor = HarnessKind.GROK_ACP if grok else HarnessKind.CODEX_APP_SERVER
     if name == "/goal" and isinstance(connection, GrokAcpConnection):
-        async for event in connection.run_turn(
-            context_prompt, model=model, mode=mode, command=f"/goal {argument}".rstrip()
-        ):
-            yield event
+        command = f"/goal {argument}".rstrip()
+        monitor = argument.lower() not in {"", "status", "pause", "clear"}
+        while True:
+            latest_goal: HarnessGoalSnapshot | None = None
+            completed_event: HarnessEvent | None = None
+            async for event in connection.run_turn(
+                context_prompt, model=model, mode=mode, command=command
+            ):
+                if event.goal is not None:
+                    latest_goal = event.goal
+                if event.type == "completed":
+                    completed_event = event
+                else:
+                    yield event
+            if not monitor or latest_goal is None or latest_goal.status != "running":
+                if completed_event is not None:
+                    yield completed_event
+                return
+            # ACP's end_turn only terminates one vendor turn. The goal update is
+            # authoritative for the longer-lived workflow, so keep executing in
+            # the same session until Grok reports a terminal or paused state.
+            command = "/goal resume"
         return
     yield HarnessEvent(
         type="started",
@@ -4749,7 +4767,7 @@ class GrokAcpAdapter(HarnessAdapter):
                     reasoning_summaries=True,
                     plans=True,
                     planning_mode=True,
-                    goal_monitoring=False,
+                    goal_monitoring=True,
                     skill_invocation=True,
                     modes=["default", "plan"],
                     live_command_output=True,

--- a/src/nebula/v3/harnesses.py
+++ b/src/nebula/v3/harnesses.py
@@ -4051,13 +4051,13 @@ async def _run_harness_command(
     grok = isinstance(connection, GrokAcpConnection)
     vendor = HarnessKind.GROK_ACP if grok else HarnessKind.CODEX_APP_SERVER
     if name == "/goal" and isinstance(connection, GrokAcpConnection):
-        command = f"/goal {argument}".rstrip()
+        native_command = f"/goal {argument}".rstrip()
         monitor = argument.lower() not in {"", "status", "pause", "clear"}
         while True:
             latest_goal: HarnessGoalSnapshot | None = None
             completed_event: HarnessEvent | None = None
             async for event in connection.run_turn(
-                context_prompt, model=model, mode=mode, command=command
+                context_prompt, model=model, mode=mode, command=native_command
             ):
                 if event.goal is not None:
                     latest_goal = event.goal
@@ -4072,7 +4072,7 @@ async def _run_harness_command(
             # ACP's end_turn only terminates one vendor turn. The goal update is
             # authoritative for the longer-lived workflow, so keep executing in
             # the same session until Grok reports a terminal or paused state.
-            command = "/goal resume"
+            native_command = "/goal resume"
         return
     yield HarnessEvent(
         type="started",

--- a/tests/v3/test_harness_adapters.py
+++ b/tests/v3/test_harness_adapters.py
@@ -305,6 +305,7 @@ def test_codex_probe_discovers_selectable_models():
 
         assert health.healthy is True
         assert health.capabilities.models == ["gpt-5.4", "gpt-5.3-codex"]
+        assert health.capabilities.goal_monitoring is True
         options = health.capabilities.model_options[0]
         assert options.default_reasoning_effort == "medium"
         assert [item.id for item in options.reasoning_efforts] == ["low", "medium"]
@@ -337,6 +338,7 @@ def test_grok_probe_negotiates_cached_token_without_credentials():
         assert health.healthy is True
         assert health.harness_version == "1.0.5"
         assert health.capabilities.plans is True
+        assert health.capabilities.goal_monitoring is True
         assert health.capabilities.skill_invocation is True
         assert [method for method, _ in rpc.calls] == ["initialize", "authenticate"]
         assert rpc.calls[1][1] == {

--- a/tests/v3/test_harness_commands.py
+++ b/tests/v3/test_harness_commands.py
@@ -119,6 +119,121 @@ def test_grok_goal_prefix_precedes_but_preserves_core_context():
     asyncio.run(scenario())
 
 
+def test_grok_goal_continues_vendor_turns_until_goal_is_complete():
+    class ContinuingGoalRpc(Rpc):
+        def __init__(self):
+            super().__init__({})
+            self.turn = 0
+
+        async def request(self, method, params):
+            if method == "session/prompt":
+                self.calls.append((method, params))
+                self.turn += 1
+                await self.events.put(
+                    {
+                        "method": "session/update",
+                        "params": {
+                            "update": {
+                                "sessionUpdate": "goal_updated",
+                                "objective": "Ship the clock",
+                                "status": "active" if self.turn == 1 else "complete",
+                            }
+                        },
+                    }
+                )
+                await self.events.put(
+                    {
+                        "method": "session/update",
+                        "params": {
+                            "update": {
+                                "sessionUpdate": "agent_message_chunk",
+                                "content": {
+                                    "type": "text",
+                                    "text": "Next steps remain."
+                                    if self.turn == 1
+                                    else "Done.",
+                                },
+                            }
+                        },
+                    }
+                )
+                return {"stopReason": "end_turn"}
+            return await super().request(method, params)
+
+    async def scenario():
+        rpc = ContinuingGoalRpc()
+        connection = GrokAcpConnection(
+            rpc, external_session_id="grok", permission_handler=None
+        )
+        events = [
+            event
+            async for event in _run_harness_command(
+                connection,
+                ("/goal", "Ship the clock"),
+                model="model",
+                context_prompt="trusted context",
+            )
+        ]
+        prompts = [
+            params["prompt"]
+            for method, params in rpc.calls
+            if method == "session/prompt"
+        ]
+        assert len(prompts) == 2
+        assert prompts[0][0] == {"type": "text", "text": "/goal Ship the clock"}
+        assert prompts[1][0] == {"type": "text", "text": "/goal resume"}
+        assert [event.goal.status for event in events if event.goal] == [
+            "running",
+            "complete",
+        ]
+        assert events[-1].message == "Done."
+        assert len([event for event in events if event.type == "completed"]) == 1
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "status", ["paused", "usageLimited", "budgetLimited", "failed"]
+)
+def test_grok_goal_does_not_continue_terminal_or_attention_states(status):
+    class StoppedGoalRpc(Rpc):
+        async def request(self, method, params):
+            if method == "session/prompt":
+                self.calls.append((method, params))
+                await self.events.put(
+                    {
+                        "method": "session/update",
+                        "params": {
+                            "update": {
+                                "sessionUpdate": "goal_updated",
+                                "objective": "Clock",
+                                "status": status,
+                            }
+                        },
+                    }
+                )
+                return {"stopReason": "end_turn", "text": "Stopped."}
+            return await super().request(method, params)
+
+    async def scenario():
+        rpc = StoppedGoalRpc({})
+        connection = GrokAcpConnection(
+            rpc, external_session_id="grok", permission_handler=None
+        )
+        _ = [
+            event
+            async for event in _run_harness_command(
+                connection,
+                ("/goal", "Clock"),
+                model="model",
+                context_prompt="trusted context",
+            )
+        ]
+        assert len([call for call in rpc.calls if call[0] == "session/prompt"]) == 1
+
+    asyncio.run(scenario())
+
+
 @pytest.mark.parametrize(
     "argument,method,extra",
     [


### PR DESCRIPTION
## Summary
- keep Grok autonomous goals running across ACP `end_turn` boundaries while the normalized goal remains active
- suppress intermediate vendor completion so one Nebula goal turn stays authoritative
- preserve Codex native `thread/goal` behavior and add explicit cross-harness capability coverage
- advertise Grok goal monitoring only after the orchestration exists and correct the stale skill-invocation matrix entry

## Focused verification
- 15 selected Codex/Grok goal and capability cases passed
- Ruff lint and formatting checks passed for touched Python files
- diff-bound selection receipt validated

## Boundaries
No full suites were run. No frontend source changed. Authenticated live-Grok, production browser/LAN, mobile-browser, reconnect, and physical-device gates were not exercised, so this does not claim those acceptance layers.