### PR TITLE
Restore recently opened chats immediately while refreshing history

### DIFF
--- a/.github/test-selection.json
+++ b/.github/test-selection.json
@@ -1,16 +1,13 @@
 {
-  "baseline": "18374005041309854cd0f12dee24217b651c8d75",
-  "change_digest": "5a33e780e80316c2faf0294b5373c2dfea0b2fdddc91b2d4679c22e03ed7b35d",
-  "reviewed_by": "Codex assistant-settings responsiveness fix",
-  "reason": "The focused Assistant settings journey verifies that harness discovery is usable while harness-session loading remains pending, harness/model-specific choices update immediately, effort selection remains selected, visible feedback confirms next-message application, and the existing accessibility and responsive geometry contract remains intact.",
-  "exclusions": "No full suites. No Python or native source changed. There is no isolated component for this page-owned workflow, so frontend unit tests are excluded in favor of its committed Playwright regression. Unrelated chat, provider, mission, browser automation, terminal, project mutation, and packaging journeys are excluded. Native harness execution, real-Core persistence, LAN-origin behavior, reconnect, and physical-device checks are unchanged by this request and are not part of the focused mocked state-loading regression.",
-  "expected_tests": {"python": 0, "frontend": 0, "native": 0, "playwright": 3},
+  "change_digest": "2fb1ad76beaad47abc75aca18c217dc543fc4a1a3b53f31e807c73338d319ad0",
+  "reviewed_by": "Codex chat preview cache implementation review",
+  "reason": "Conversation selection restores a bounded memory preview while Core refreshes. Cache unit tests cover retention, invalidation and isolation. The conversation-switch journey covers held network responses, authoritative replacement, failure/retry, disabled submission and rapid switching across eight desktop/mobile profiles. The real-Core LAN journey creates durable chats, switches back before a held history response, then refreshes and reloads the production UI.",
+  "exclusions": "No full suites. No Python or native source changes. Only conversation-switch-performance browser coverage is selected; unrelated mission, browser, packaging, terminal and provider execution journeys are excluded. Physical devices are unavailable; mobile results are emulated. Boundaries: three unit tests, eight mocked browser cases (60 seconds per case for multiple refresh/retry cycles and accessibility analysis), one real-Core case (60 seconds), production build.",
+  "expected_tests": {"python": 0, "frontend": 3, "native": 0, "playwright": 9},
   "python": [],
-  "frontend": [],
+  "frontend": ["ui/src/pages/chatPreviewCache.test.ts"],
   "native": [],
   "playwright": [
-    "entry:assistant/desktop",
-    "entry:assistant/mobile-chromium",
-    "entry:assistant/mobile-webkit"
+    "area:conversation-switch-performance"
   ]
 }

--- a/docs/chat-switch-cache-quality.md
+++ b/docs/chat-switch-cache-quality.md
@@ -1,0 +1,26 @@
+# Chat switch preview contract
+
+Entry: select A, select B, then return to A through Conversations.
+
+| Journey | Observable invariant | Authority | Evidence planned |
+| --- | --- | --- | --- |
+| Discover/select | URL, title and transcript identify the selected chat; cached content appears before refresh completes | URL; memory preview; Core refresh | focused browser journey |
+| Create/use/stream | Only durable messages enter previews; submission waits for refresh; existing drafts remain per chat | Core; existing draft storage | real Core create/use and browser disabled state |
+| Interrupt/background | Switching detaches viewers without cancelling work; obsolete fetches cannot replace the new chat | existing generation/abort guards; Core | rapid-switch browser regression |
+| Refresh/reconnect/retry | Fresh history replaces previews; failure retains readable preview with recovery and no submission | Core | browser failure/retry and real Core reload |
+| Delete/revoke | Successful deletion invalidates preview; denied/missing history discards preview | Core | cache unit test and request error handling |
+| Scroll | Returning to a chat restores its reading position, including after refresh | transient per-chat memory | browser long transcript |
+| Scope | Cache is bounded to ten chats, isolated per project/API connection, and never persisted to browser storage | component-owned memory | unit test and implementation review |
+
+Fork/create continues through existing selection and receives a cold load. Provider/harness execution semantics, layout, software keyboard behavior and new controls are unchanged. Test only the selected conversation-switch journey across the permanent desktop/mobile Chromium and WebKit profiles; production real-Core LAN checks cover durable history and reload. Physical devices are unavailable and must not be claimed.
+
+## Acceptance evidence — 2026-09-12
+
+- Unit: `npm --prefix ui test -- src/pages/chatPreviewCache.test.ts` — 3 passed.
+- Production: `npm --prefix ui run build` — passed; existing bundle-size/dynamic-import warnings remain. Build log: `/tmp/chat-cache-build.log`.
+- Browser: `tests/interface.spec.ts`, exact filter `conversation switching commits URL identity`, projects `desktop`, `compact`, `mobile-chromium-small`, `mobile-chromium-ledger-390`, `mobile-chromium-wide`, `mobile-webkit-small`, `mobile-webkit`, `mobile-webkit-wide` — 8 passed (47.2 seconds), served from the production preview on port 15420. Desktop widths 1440/1024, emulated Chromium 320/390/430, emulated WebKit 320/390/430.
+- The selected browser case covers a 21-message transcript, held refresh, replacement with fresh history, draft retention, disabled/enabled submission, 503 failure/retry, rapid switching, keyboard selection, touch selection, no horizontal overflow and axe analysis of the chat thread. Reading offset 150 is preserved during cached rendering and after refresh, including when the mobile list hides the transcript.
+- Real Core: `tests/real-core.spec.ts`, exact filter `assistant upgrade conversation switching restores durable Core history promptly`, project `assistant-real-desktop` — 1 passed (8.7 seconds total). Production bundle at `http://192.168.1.155:42169`; origin and screenshot are retained in `/tmp/chat-cache-real-core/real-core-assistant-upgrad-cfd23-rable-Core-history-promptly-assistant-real-desktop/`. A paired browser opens durable provider chats, reads A while its history request is held, refreshes against Core, retains A during a simulated transport 503, retries against Core, and reloads with durable content intact.
+- Physical devices/software keyboards were not tested. No provider or harness command executes in these selected journeys. No full suite was run.
+
+Product rule: a readable transcript should not wait for a network refresh when a session-scoped preview is available. Preview state is presentation only; current Core state governs submission and approvals.

--- a/ui/src/pages/SessionsPage.tsx
+++ b/ui/src/pages/SessionsPage.tsx
@@ -64,7 +64,8 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import type { ApiClient } from "../api/client";
+import { ApiError, type ApiClient } from "../api/client";
+import { ChatPreviewCache } from "./chatPreviewCache";
 import { Link, useSearchParams } from "react-router-dom";
 import { providerModelVerification } from "../api/providerCapabilities";
 import { defaultModelRuntime } from "../api/runtimeDefaults";
@@ -570,6 +571,15 @@ export function SessionsPage() {
   const [uploadingImage, setUploadingImage] = useState(false);
   const [sending, setSending] = useState(false);
   const [loadingHistory, setLoadingHistory] = useState(false);
+  const [sessionReadReady, setSessionReadReady] = useState(true);
+  const chatPreviews = useMemo(() => new ChatPreviewCache<{
+    messages: ConversationMessage[];
+    toolCards: ToolLifecycleCard[];
+    scrollTop: number;
+    followBottom: boolean;
+  }>(), [api, engagement?.id]);
+  const previewOwnerRef = useRef("");
+  const restoredScrollRef = useRef<{scrollTop: number; followBottom: boolean} | undefined>(undefined);
   const [reloadingConversation, setReloadingConversation] = useState(false);
   const [chatError, setChatError] = useState<string>();
   const [chatReconnecting, setChatReconnecting] = useState(false);
@@ -593,6 +603,7 @@ export function SessionsPage() {
     if (element) { chatFollowBottomRef.current = false; element.scrollIntoView({block: "center"}); element.focus({preventScroll: true}); }
   }, [searchParams, loadingHistory, messages.length]);
   const chatFollowBottomRef = useRef(true);
+  const chatReadingPositionRef = useRef<{sessionId: string; scrollTop: number; followBottom: boolean}>({sessionId: "", scrollTop: 0, followBottom: true});
   const [hasNewerMessages, setHasNewerMessages] = useState(false);
   const chatTouchYRef = useRef<number | undefined>(undefined);
   const previousChatSendingRef = useRef(false);
@@ -623,8 +634,19 @@ export function SessionsPage() {
   }), [loadingHistory, messages, sending]);
   const chatRuntime = useExternalStoreRuntime(chatRuntimeStore);
   useLayoutEffect(() => {
-    chatFollowBottomRef.current = true;
-    setHasNewerMessages(false);
+    const position = restoredScrollRef.current;
+    chatFollowBottomRef.current = position?.followBottom ?? true;
+    setHasNewerMessages(!chatFollowBottomRef.current);
+    if (!position) return;
+    const restore = () => {
+      chatFollowBottomRef.current = position.followBottom;
+      setHasNewerMessages(!position.followBottom);
+      if (chatViewportRef.current && !position.followBottom) chatViewportRef.current.scrollTop = position.scrollTop;
+    };
+    restore();
+    // The external thread store commits its message rows after the parent render.
+    const frame = requestAnimationFrame(restore);
+    return () => cancelAnimationFrame(frame);
   }, [conversationOpen, sessionId]);
   useLayoutEffect(() => {
     const runStarted = sending && !previousChatSendingRef.current;
@@ -1093,6 +1115,10 @@ export function SessionsPage() {
 
   useEffect(() => {
     sessionLoadAbortRef.current?.abort();
+    sessionSelectionGenerationRef.current += 1;
+    previewOwnerRef.current = "";
+    restoredScrollRef.current = undefined;
+    setSessionReadReady(true);
     historicalActivityAbortRef.current.forEach((controller) => controller.abort());
     historicalActivityAbortRef.current.clear();
     detachActiveChatStream();
@@ -1227,6 +1253,9 @@ export function SessionsPage() {
   };
 
   const resetConversation = (open: boolean) => {
+    previewOwnerRef.current = "";
+    restoredScrollRef.current = undefined;
+    setSessionReadReady(true);
     sessionSelectionGenerationRef.current += 1;
     setApprovalDecisionBusy(false);
     pendingSessionNavigationRef.current = undefined;
@@ -1285,6 +1314,7 @@ export function SessionsPage() {
     setChatError(undefined);
     try {
       await api.deleteChatSession(session.id);
+      chatPreviews.delete(session.id);
       if (engagement) {
         clearChatDraft(sessionStorage, chatDraftStorageKey(engagement.id, session.id));
         clearChatFollowUps(sessionStorage, chatFollowUpStorageKey(engagement.id, session.id));
@@ -1316,6 +1346,7 @@ export function SessionsPage() {
     setChatError(undefined);
     const results = await Promise.allSettled(targets.map((session) => api.deleteChatSession(session.id)));
     const deletedIds = new Set(targets.filter((_, index) => results[index]?.status === "fulfilled").map((session) => session.id));
+    deletedIds.forEach(id => chatPreviews.delete(id));
     if (engagement) {
       for (const deletedId of deletedIds) {
         clearChatDraft(sessionStorage, chatDraftStorageKey(engagement.id, deletedId));
@@ -1522,6 +1553,24 @@ export function SessionsPage() {
       return;
     }
     if (!api) return;
+    if (previewOwnerRef.current === sessionId && !loadingHistory && sessionReadReady) {
+      const durable = messages.filter(message => message.durable);
+      const durableIds = new Set(durable.map(message => message.id));
+      // Mobile hides the transcript while Conversations is open; its DOM offset
+      // is then zero. Retain the last visible reading position instead.
+      const viewport = chatViewportRef.current;
+      const lastPosition = chatReadingPositionRef.current.sessionId === sessionId ? chatReadingPositionRef.current : undefined;
+      chatPreviews.set(sessionId, {
+        messages: durable,
+        toolCards: toolCards.filter(card => durableIds.has(card.assistantId)),
+        scrollTop: viewport?.clientHeight ? viewport.scrollTop : lastPosition?.scrollTop ?? 0,
+        followBottom: viewport?.clientHeight ? chatFollowBottomRef.current : lastPosition?.followBottom ?? true,
+      });
+    }
+    const preview = chatPreviews.get(id);
+    restoredScrollRef.current = preview;
+    previewOwnerRef.current = "";
+    setSessionReadReady(false);
     const selectionGeneration = sessionSelectionGenerationRef.current + 1;
     sessionSelectionGenerationRef.current = selectionGeneration;
     setApprovalDecisionBusy(false);
@@ -1546,8 +1595,9 @@ export function SessionsPage() {
     setChatError(undefined);
     setHarnessProgress(undefined);
     setHarnessActivity(undefined);
-    if (!preserveTranscript) setMessages([]);
-    setToolCards([]);
+    if (!preserveTranscript) setMessages(preview?.messages ?? []);
+    setToolCards(preview?.toolCards ?? []);
+    setMobileListOpen(false);
     setActivityItems([]);
     setHarnessInteractions([]);
     setPendingResponse(undefined);
@@ -1569,7 +1619,7 @@ export function SessionsPage() {
         api.getPendingChatTurn(id, loadController.signal).catch((caughtError) => {
           if (loadController.signal.aborted) return undefined;
           void logCaughtDiagnostic("interface.sessions_page.caught_failure_08", "A handled interface operation failed.", caughtError, "sessions_page");
-          return undefined;
+          throw caughtError;
         }),
       ]);
       if (!selectionIsCurrent()) return;
@@ -1764,9 +1814,16 @@ export function SessionsPage() {
 
       }
       if (!selectionIsCurrent()) return;
+      previewOwnerRef.current = id;
+      setSessionReadReady(true);
       setMobileListOpen(false);
     } catch (error) {
       if (!selectionIsCurrent() || loadController.signal.aborted) return;
+      if (error instanceof ApiError && [401, 403, 404].includes(error.status)) {
+        chatPreviews.delete(id);
+        setMessages([]);
+        setToolCards([]);
+      }
       void logCaughtDiagnostic("interface.sessions_page.caught_failure_10", "A handled interface operation failed.", error, "sessions_page");
       setChatError(error instanceof Error ? error.message : "Could not load the selected conversation.");
     } finally {
@@ -1916,6 +1973,7 @@ export function SessionsPage() {
     // an approval. Polling/visibility recovery also covers missed stream events.
     if (["started", "status", "turn_status", "approval", "interaction", "done", "error"].includes(streamEvent.type)) refreshSessionState();
     if (streamEvent.type === "started" && streamEvent.sessionId) {
+      previewOwnerRef.current = streamEvent.sessionId;
       setSessionId(streamEvent.sessionId);
       openSessionChatView(streamEvent.sessionId, true);
       void refreshSessions();
@@ -2236,6 +2294,7 @@ export function SessionsPage() {
 
   const submit = async (event?: FormEvent, queuedFollowUp?: ChatFollowUp, queueOptions?: { paused?: boolean; first?: boolean; key?: string; uncertain?: boolean }) => {
     event?.preventDefault();
+    if (sessionId && !sessionReadReady) return;
     const activeTurn = composerBusy;
     if (activeTurn && !queuedFollowUp && !queueOptions) {
       const text = draft.trim();
@@ -2943,7 +3002,7 @@ export function SessionsPage() {
     };
   }, [assistantSettingsOpen]);
   const composerBusy = sending || Boolean(authoritativeState?.busy) || pendingResponseActive;
-  const canSend = Boolean(api && coreState === "online" && engagement && runtimeReady && model.trim() && (draft.trim() || pendingImages.length) && !composerBusy && !uploadingImage);
+  const canSend = Boolean((!sessionId || sessionReadReady) && api && coreState === "online" && engagement && runtimeReady && model.trim() && (draft.trim() || pendingImages.length) && !composerBusy && !uploadingImage);
   const canSteerCurrentHarness = Boolean(
     !isHarnessCommand(draft)
     && sending
@@ -3082,13 +3141,16 @@ export function SessionsPage() {
               </section>, document.body)}
               <AssistantRuntimeProvider runtime={chatRuntime} key={sessionId || "new-conversation"}>
                 <ThreadPrimitive.Root className="chat-thread">
+                  {loadingHistory && messages.length > 0 && <div className="chat-thinking" role="status"><LoaderCircle className="spin" size={14} /> Refreshing conversation…</div>}
                   <ThreadPrimitive.Viewport
                     ref={chatViewportRef}
                     className="chat-scroll"
                     aria-live="polite"
                     onScroll={(event) => {
                       const viewport = event.currentTarget;
+                      if (!viewport.clientHeight) return;
                       const atBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= 4;
+                      chatReadingPositionRef.current = {sessionId, scrollTop: viewport.scrollTop, followBottom: atBottom};
                       chatFollowBottomRef.current = atBottom;
                       setHasNewerMessages(!atBottom);
                     }}
@@ -3097,13 +3159,13 @@ export function SessionsPage() {
                     onTouchMove={event => {const y = event.touches[0]?.clientY; if (y !== undefined && chatTouchYRef.current !== undefined && y > chatTouchYRef.current) chatFollowBottomRef.current = false; chatTouchYRef.current = y;}}
                     onKeyDown={event => {if (["ArrowUp", "PageUp", "Home"].includes(event.key)) chatFollowBottomRef.current = false;}}
                     onPointerDown={event => {if (event.target === event.currentTarget) chatFollowBottomRef.current = false;}}
-                    autoScroll
-                    scrollToBottomOnInitialize
+                    autoScroll={!restoredScrollRef.current || restoredScrollRef.current.followBottom}
+                    scrollToBottomOnInitialize={!restoredScrollRef.current}
                     scrollToBottomOnRunStart
-                    scrollToBottomOnThreadSwitch
+                    scrollToBottomOnThreadSwitch={!restoredScrollRef.current}
                     turnAnchor="bottom"
                   >
-                {loadingHistory ? <div className="chat-thinking"><LoaderCircle className="spin" size={14} /> Loading conversation…</div> : messages.length ? <ThreadPrimitive.Messages>{({ message: threadMessage }) => {
+                {loadingHistory && !messages.length ? <div className="chat-thinking"><LoaderCircle className="spin" size={14} /> Loading conversation…</div> : messages.length ? <ThreadPrimitive.Messages>{({ message: threadMessage }) => {
                   const message = messagesById.get(threadMessage.id);
                   if (!message) return null;
                   const messageActivityItems = activityItems.filter((item) => item.assistantId === message.id && shouldShowActivityItem(item));

--- a/ui/src/pages/chatPreviewCache.test.ts
+++ b/ui/src/pages/chatPreviewCache.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { ChatPreviewCache } from "./chatPreviewCache";
+
+describe("chat previews", () => {
+  it("retains the most recently visited chats within its capacity", () => {
+    const cache = new ChatPreviewCache<string>(2);
+    cache.set("a", "A"); cache.set("b", "B");
+    expect(cache.get("a")).toBe("A");
+    cache.set("c", "C");
+    expect(cache.get("b")).toBeUndefined();
+    expect(cache.get("a")).toBe("A");
+    expect(cache.get("c")).toBe("C");
+  });
+
+  it("replaces refreshed previews and forgets deleted chats", () => {
+    const cache = new ChatPreviewCache<string>();
+    cache.set("a", "old"); cache.set("a", "fresh");
+    expect(cache.get("a")).toBe("fresh");
+    cache.delete("a");
+    expect(cache.get("a")).toBeUndefined();
+  });
+
+  it("isolates previews between project or connection instances", () => {
+    const first = new ChatPreviewCache<string>();
+    const second = new ChatPreviewCache<string>();
+    first.set("a", "private transcript");
+    expect(second.get("a")).toBeUndefined();
+  });
+});

--- a/ui/src/pages/chatPreviewCache.ts
+++ b/ui/src/pages/chatPreviewCache.ts
@@ -1,0 +1,25 @@
+/** Device-memory previews only. Every selection must still refresh from Core. */
+export class ChatPreviewCache<T> {
+  private readonly entries = new Map<string, T>();
+
+  constructor(private readonly capacity = 10) {}
+
+  get(id: string): T | undefined {
+    const value = this.entries.get(id);
+    if (value !== undefined) {
+      this.entries.delete(id);
+      this.entries.set(id, value);
+    }
+    return value;
+  }
+
+  set(id: string, value: T): void {
+    this.entries.delete(id);
+    this.entries.set(id, value);
+    while (this.entries.size > this.capacity) {
+      this.entries.delete(this.entries.keys().next().value!);
+    }
+  }
+
+  delete(id: string): void { this.entries.delete(id); }
+}

--- a/ui/tests/interface.spec.ts
+++ b/ui/tests/interface.spec.ts
@@ -3116,13 +3116,27 @@ test("New chat detaches from an in-flight saved conversation load", async ({ pag
 });
 
 test("conversation switching commits URL identity and keeps prefetched work details collapsed", async ({ page }) => {
+  test.setTimeout(60_000); // Several held-refresh/retry cycles plus mobile accessibility analysis.
   const sourceSessionId = "chat-switch-source";
   const targetSessionId = "chat-switch-target";
   let sourceMessageLoads = 0;
   let targetActivityLoads = 0;
   let targetStateLoads = 0;
+  let releaseRefresh = () => {};
+  let refreshGate: Promise<void> | undefined;
+  let failRefresh = false;
+  let freshSource = false;
   await page.route("**/api/v1/**", async (route) => {
     const path = new URL(route.request().url()).pathname;
+    if (path.endsWith("/harnesses")) {
+      await route.fulfill({json: [{
+        ...entity, id: "harness-ready", name: "Ready harness", kind: "codex_app_server",
+        connection_mode: "spawn", transport: "stdio", executable: "codex", auth_mode: "existing_session",
+        enabled: true, default_model: "gpt-5-codex", privacy: {local_only: true, permits_sensitive_data: true},
+        capabilities: {models: ["gpt-5-codex"], checked_at: entity.updated_at},
+      }]});
+      return;
+    }
     if (path.endsWith("/chat-sessions")) {
       await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([
         {
@@ -3152,14 +3166,24 @@ test("conversation switching commits URL identity and keeps prefetched work deta
     }
     if (path.endsWith(`/chat/sessions/${sourceSessionId}/messages`)) {
       sourceMessageLoads += 1;
-      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([{
+      if (refreshGate) await refreshGate;
+      if (failRefresh) {
+        await route.fulfill({status: 503, contentType: "application/json", body: JSON.stringify({detail: "Preview refresh unavailable"})});
+        return;
+      }
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([
+        ...Array.from({length: 20}, (_, index) => ({
+          ...entity, id: `source-history-${index}`, engagement_id: "scratch-project",
+          session_id: sourceSessionId, sequence: index + 1, role: "assistant",
+          content: `Earlier source message ${index}. A durable paragraph to preserve the reading position.`, citations: [], metadata: {},
+        })), {
         ...entity,
         id: "assistant-switch-source",
         engagement_id: "scratch-project",
         session_id: sourceSessionId,
-        sequence: 1,
+        sequence: 21,
         role: "assistant",
-        content: "Source transcript",
+        content: freshSource ? "Fresh source transcript" : "Source transcript",
         citations: [],
         metadata: { harness_turn_id: "turn-switch-source" },
       }]) });
@@ -3236,12 +3260,15 @@ test("conversation switching commits URL identity and keeps prefetched work deta
 
   await openWorkspace(page, `/?view=chat&session=${sourceSessionId}`, "Workbench");
   await expect(page.getByText("Source transcript")).toBeVisible();
+  await page.getByRole("textbox", {name: "Message the analyst assistant"}).fill("Unsent source draft");
+  await page.locator(".chat-scroll").evaluate(element => {element.scrollTop = 150; element.dispatchEvent(new Event("scroll"));});
+  await expect.poll(() => page.locator(".chat-scroll").evaluate(element => element.scrollTop)).toBe(150);
   if ((page.viewportSize()?.width ?? 1_000) <= 760) await page.getByRole("button", { name: "Open conversations", exact: true }).click();
   else await page.getByRole("button", { name: "Show conversations" }).click();
   await page.locator(".session-select").filter({ hasText: "Target conversation" }).click();
 
   await expect.poll(() => new URL(page.url()).searchParams.get("session")).toBe(targetSessionId);
-  await expect(page.locator(".session-list-item.active")).toContainText("Target conversation");
+  if ((page.viewportSize()?.width ?? 1_000) > 760) await expect(page.locator(".session-list-item.active")).toContainText("Target conversation");
   await expect(page.getByText("Target transcript")).toBeVisible();
   expect(sourceMessageLoads).toBe(1);
   expect(targetStateLoads).toBe(1);
@@ -3251,6 +3278,53 @@ test("conversation switching commits URL identity and keeps prefetched work deta
   await page.locator(".chat-message.assistant").filter({ hasText: "Target transcript" }).getByRole("button", { name: "Show activity" }).click();
   await expect(page.getByText("Deferred command")).toBeVisible();
   expect(targetActivityLoads).toBe(1);
+
+  const selectChat = async (title: string) => {
+    const button = page.locator(".session-select").filter({hasText: title});
+    if (!await button.isVisible()) {
+      await page.getByRole("button", {name: "Open conversations", exact: true}).click();
+    }
+    if ((page.viewportSize()?.width ?? 1_000) <= 760) await button.tap();
+    else { await button.focus(); await button.press("Enter"); }
+  };
+  // Hold the network response: preview visibility must not depend on a timer.
+  refreshGate = new Promise<void>(resolve => {releaseRefresh = resolve;});
+  await selectChat("Source conversation");
+  await expect(page.getByText("Source transcript", {exact: true})).toBeAttached();
+  await expect.poll(() => page.locator(".chat-scroll").evaluate(element => element.scrollTop)).toBe(150);
+  await expect(page.getByText("Refreshing conversation…", {exact: true})).toBeVisible();
+  await expect(page.getByRole("textbox", {name: "Message the analyst assistant"})).toBeDisabled();
+  await expect(page.getByRole("textbox", {name: "Message the analyst assistant"})).toHaveValue("Unsent source draft");
+  await expect(page.getByRole("button", {name: "Send message", exact: true})).toBeDisabled();
+  freshSource = true;
+  releaseRefresh(); refreshGate = undefined;
+  await expect(page.getByText("Fresh source transcript", {exact: true})).toBeAttached();
+  await expect.poll(() => page.locator(".chat-scroll").evaluate(element => element.scrollTop)).toBe(150);
+  await expect(page.getByText("Refreshing conversation…", {exact: true})).toHaveCount(0);
+  await expect(page.getByRole("button", {name: "Send message", exact: true})).toBeEnabled();
+
+  await selectChat("Target conversation");
+  await expect(page.getByText("Refreshing conversation…", {exact: true})).toHaveCount(0);
+  failRefresh = true;
+  await selectChat("Source conversation");
+  await expect(page.getByText("Fresh source transcript", {exact: true})).toBeAttached();
+  await expect(page.getByRole("button", {name: "Reload conversation", exact: true})).toBeVisible();
+  await expect(page.getByRole("button", {name: "Send message", exact: true})).toBeDisabled();
+  failRefresh = false;
+  await page.getByRole("button", {name: "Reload conversation", exact: true}).click();
+  await expect(page.getByRole("button", {name: "Reload conversation", exact: true})).toHaveCount(0);
+
+  await selectChat("Target conversation");
+  await expect(page.getByText("Refreshing conversation…", {exact: true})).toHaveCount(0);
+  refreshGate = new Promise<void>(resolve => {releaseRefresh = resolve;});
+  await selectChat("Source conversation");
+  await expect(page.getByText("Fresh source transcript", {exact: true})).toBeAttached();
+  await selectChat("Target conversation");
+  releaseRefresh(); refreshGate = undefined;
+  await expect(page.getByText("Target transcript", {exact: true})).toBeVisible();
+  await expect.poll(() => new URL(page.url()).searchParams.get("session")).toBe(targetSessionId);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
+  expect((await new AxeBuilder({page}).include(".chat-thread").analyze()).violations).toEqual([]);
 });
 
 test("conversation switching between projects detaches the provider viewer without stopping Core work", async ({ page }) => {

--- a/ui/tests/real-core.spec.ts
+++ b/ui/tests/real-core.spec.ts
@@ -317,7 +317,7 @@ test("production mission defaults to unlimited duration through real Core", asyn
   }
 });
 
-test("assistant upgrade conversation switching restores durable Core history promptly", async ({ page }) => {
+test("assistant upgrade conversation switching restores durable Core history promptly", async ({ page }, testInfo) => {
   test.setTimeout(60_000);
   const lanAddress = localNetworkIpv4();
   const core = await startRealCore({ bindHost: "0.0.0.0", browserHost: lanAddress });
@@ -351,7 +351,13 @@ test("assistant upgrade conversation switching restores durable Core history pro
     const sourceId = await createConversation("Durable source conversation");
     const targetId = await createConversation("Durable target conversation");
 
-    await page.goto(`${core.origin}/?view=chat&session=${sourceId}#token=${encodeURIComponent(core.token)}`);
+    const pairingResponse = await api.post(`http://127.0.0.1:${new URL(core.origin).port}/api/v1/auth/pairings`, {data: {name: "Chat cache acceptance"}});
+    expect(pairingResponse.ok(), await pairingResponse.text()).toBe(true);
+    const pairing = await pairingResponse.json() as {secret: string; confirmation_code: string};
+    await page.goto(`${core.origin}/?view=chat&session=${sourceId}#pair=${encodeURIComponent(pairing.secret)}&code=${encodeURIComponent(pairing.confirmation_code)}`);
+    await page.getByRole("button", {name: "Pair device", exact: true}).click();
+    await expect(page.getByRole("button", {name: "Nebula Core ready", exact: true})).toBeVisible({timeout: 20_000});
+    await page.goto(`${core.origin}/projects/${projectId}/workbench?view=chat&session=${sourceId}`);
     await expect(page.getByText("Durable source conversation", {exact: true})).toBeVisible();
     await page.getByRole("button", {name: "Show conversations"}).click();
     const startedAt = Date.now();
@@ -359,6 +365,39 @@ test("assistant upgrade conversation switching restores durable Core history pro
     await expect.poll(() => new URL(page.url()).searchParams.get("session")).toBe(targetId);
     await expect(page.getByText("Durable target conversation", {exact: true})).toBeVisible();
     expect(Date.now() - startedAt).toBeLessThan(5_000);
+    let releaseHistory = () => {};
+    let failHistory = false;
+    const historyGate = new Promise<void>(resolve => {releaseHistory = resolve;});
+    await page.route(`**/chat/sessions/${sourceId}/messages`, async route => {
+      await historyGate;
+      if (failHistory) {
+        await route.fulfill({status: 503, json: {detail: "Temporary history outage"}});
+        return;
+      }
+      await route.continue();
+    });
+    await page.locator(`.session-select[data-session-id="${sourceId}"]`).click();
+    await expect(page.getByText("Durable source conversation", {exact: true})).toBeVisible();
+    await expect(page.getByText("Refreshing conversation…", {exact: true})).toBeVisible();
+    releaseHistory();
+    await expect(page.getByText("Refreshing conversation…", {exact: true})).toHaveCount(0);
+    await page.locator(`.session-select[data-session-id="${targetId}"]`).click();
+    await expect(page.getByText("Refreshing conversation…", {exact: true})).toHaveCount(0);
+    failHistory = true;
+    await page.locator(`.session-select[data-session-id="${sourceId}"]`).click();
+    await expect(page.getByRole("button", {name: "Reload conversation", exact: true})).toBeVisible();
+    await expect(page.getByText("Durable source conversation", {exact: true})).toBeVisible();
+    failHistory = false;
+    await page.getByRole("button", {name: "Reload conversation", exact: true}).click();
+    await expect(page.getByRole("button", {name: "Reload conversation", exact: true})).toHaveCount(0);
+    await page.reload();
+    await expect(page.getByText("Durable source conversation", {exact: true})).toBeVisible();
+    const evidencePath = testInfo.outputPath("chat-cache-production-lan.json");
+    await writeFile(evidencePath, JSON.stringify({origin: core.origin, build: "ui/dist production", viewport: page.viewportSize(), workflow: "paired browser, durable A-B-A, held refresh, reload"}));
+    await testInfo.attach("chat-cache-production-lan", {path: evidencePath, contentType: "application/json"});
+    const screenshotPath = testInfo.outputPath("chat-cache-visible-result.png");
+    await page.screenshot({path: screenshotPath});
+    await testInfo.attach("chat-cache-visible-result", {path: screenshotPath, contentType: "image/png"});
   } finally {
     await api.dispose();
     await stopLocalModelStub(modelStub);


### PR DESCRIPTION
Returning to a recently opened chat currently clears its transcript and waits for Core before displaying anything. Keep the ten most recently visited chat previews in component memory and restore the selected transcript and reading position immediately while refreshing authoritative history.

Previews contain durable messages and associated tool cards, are isolated per project/API instance, and are invalidated on deletion or denied/missing history. Submission waits for successful refresh; an outage retains readable content and offers the existing retry. Mobile selection closes the list immediately and preserves the offset from before the transcript was hidden. Existing draft storage and stale-request guards remain authoritative for their respective state.

Validation: 3 focused unit tests; the extended conversation-switch journey passes in 8 desktop/mobile Chromium/WebKit profiles against the production preview; the production real-Core LAN journey passes with device pairing, held history, cached display, 503/retry, and reload. Tests also cover long transcripts, scroll/draft preservation, keyboard/touch selection, rapid switching and chat-thread accessibility. Production build passes. Physical devices were unavailable.

The committed test selection is bound to this diff and selects only the conversation-switch-performance area and cache unit tests. No full suite. Detailed contract and local evidence: `docs/chat-switch-cache-quality.md`.
